### PR TITLE
Fix Region Configuration and Environment Variable Propagation

### DIFF
--- a/agent-blueprint/chatbot-deployment/infrastructure/config.json
+++ b/agent-blueprint/chatbot-deployment/infrastructure/config.json
@@ -4,6 +4,7 @@
     "us-west-2",
     "us-east-1", 
     "ap-northeast-2",
+    "ap-southeast-2",
     "eu-west-1"
   ]
 }

--- a/agent-blueprint/fargate-mcp-farm/deploy-all.sh
+++ b/agent-blueprint/fargate-mcp-farm/deploy-all.sh
@@ -102,9 +102,13 @@ load_config() {
         print_error "Configuration file $CONFIG_FILE not found!"
         exit 1
     fi
-    
+
     print_status "Loading configuration from $CONFIG_FILE"
-    
+
+    # Set AWS region from environment or default
+    export AWS_REGION=${AWS_REGION:-us-west-2}
+    print_status "Using AWS region: $AWS_REGION"
+
     # Validate JSON
     if ! jq empty "$CONFIG_FILE" 2>/dev/null; then
         print_error "Invalid JSON in configuration file!"
@@ -126,7 +130,8 @@ get_server_config() {
 
 # Function to get deployment region
 get_region() {
-    jq -r '.deployment.region' "$CONFIG_FILE"
+    # Always use environment variable, ignore JSON config
+    echo "${AWS_REGION:-us-west-2}"
 }
 
 # Function to get deployment stage

--- a/agent-blueprint/fargate-mcp-farm/deploy-config.json
+++ b/agent-blueprint/fargate-mcp-farm/deploy-config.json
@@ -1,10 +1,9 @@
 {
   "deployment": {
-    "region": "us-west-2",
     "stage": "prod",
     "servers": {
       "nova-act-mcp": {
-        "enabled": true,
+        "enabled": false,
         "stack_name": "nova-act-mcp-fargate",
         "description": "Nova Act MCP Server on AWS Fargate with Browser Automation",
         "type": "fargate",

--- a/agent-blueprint/fargate-mcp-farm/nova-act-mcp/cdk/app.py
+++ b/agent-blueprint/fargate-mcp-farm/nova-act-mcp/cdk/app.py
@@ -11,12 +11,12 @@ from stacks.nova_act_fargate_stack import NovaActFargateStack
 app = App()
 
 # Get configuration from context or environment
-region = app.node.try_get_context("region") or "us-west-2"
+region = os.environ.get("CDK_DEFAULT_REGION") or app.node.try_get_context("region") or "us-west-2"
 stack_name = f"nova-act-mcp-fargate"
 
 # Create the Nova Act Fargate stack
 NovaActFargateStack(
-    app, 
+    app,
     stack_name,
     env=Environment(
         account=os.environ.get('CDK_DEFAULT_ACCOUNT'),

--- a/agent-blueprint/fargate-mcp-farm/python-mcp/cdk/app.py
+++ b/agent-blueprint/fargate-mcp-farm/python-mcp/cdk/app.py
@@ -11,12 +11,12 @@ from stacks.python_mcp_fargate_stack import PythonMcpFargateStack
 app = App()
 
 # Get configuration from context or environment
-region = app.node.try_get_context("region") or "us-west-2"
+region = os.environ.get("CDK_DEFAULT_REGION") or app.node.try_get_context("region") or "us-west-2"
 stack_name = f"python-mcp-fargate"
 
 # Create the Python MCP Fargate stack
 PythonMcpFargateStack(
-    app, 
+    app,
     stack_name,
     env=Environment(
         account=os.environ.get('CDK_DEFAULT_ACCOUNT'),

--- a/agent-blueprint/fargate-mcp-farm/shared-infrastructure/cdk/app.py
+++ b/agent-blueprint/fargate-mcp-farm/shared-infrastructure/cdk/app.py
@@ -25,8 +25,8 @@ McpFarmAlbStack(
     allowed_mcp_cidrs=allowed_mcp_cidrs,
     description="MCP Farm Shared Application Load Balancer with CIDR restrictions",
     env=cdk.Environment(
-        account=app.node.try_get_context("account"),
-        region=app.node.try_get_context("region") or "us-west-2"
+        account=os.environ.get("CDK_DEFAULT_ACCOUNT") or app.node.try_get_context("account"),
+        region=os.environ.get("CDK_DEFAULT_REGION") or app.node.try_get_context("region") or "us-west-2"
     )
 )
 

--- a/agent-blueprint/fargate-mcp-farm/shared-infrastructure/deploy.sh
+++ b/agent-blueprint/fargate-mcp-farm/shared-infrastructure/deploy.sh
@@ -89,13 +89,13 @@ source venv/bin/activate
 
 # Install Python dependencies
 print_status "Installing Python dependencies..."
-pip install --upgrade pip
-pip install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 print_success "Python dependencies installed"
 
 # Get AWS account and region
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-REGION=$(aws configure get region || echo "us-west-2")
+REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}
 
 print_status "Deploying to AWS Account: $ACCOUNT_ID in region: $REGION"
 

--- a/agent-blueprint/serverless-mcp-farm/deploy-config.json
+++ b/agent-blueprint/serverless-mcp-farm/deploy-config.json
@@ -1,6 +1,5 @@
 {
   "deployment": {
-    "region": "us-west-2",
     "stage": "prod",
     "servers": {
       "aws-documentation": {
@@ -14,7 +13,7 @@
         "description": "AWS Pricing Information MCP Server"
       },
       "bedrock-kb-retrieval": {
-        "enabled": true,
+        "enabled": false,
         "stack_name": "mcp-bedrock-kb-retrieval-server",
         "description": "Amazon Bedrock Knowledge Base Retrieval MCP Server"
       },
@@ -29,7 +28,7 @@
         "description": "Financial Market Data and Analysis MCP Server"
       },
       "recruiter-insights": {
-        "enabled": true,
+        "enabled": false,
         "stack_name": "mcp-recruiter-insights-server",
         "description": "Recruiter Insights and Candidate Analysis MCP Server"
       }

--- a/agent-blueprint/serverless-mcp-farm/recruiter-insights/infrastructure/deploy.sh
+++ b/agent-blueprint/serverless-mcp-farm/recruiter-insights/infrastructure/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 STACK_NAME="mcp-recruiter-insights-server"
-REGION="us-west-2"
+REGION="${AWS_DEFAULT_REGION:-us-west-2}"
 
 echo "🚀 Deploying Recruiter Insights MCP Server (Simplified)..."
 

--- a/chatbot-app/backend/mcp_client_factory.py
+++ b/chatbot-app/backend/mcp_client_factory.py
@@ -94,8 +94,11 @@ class MCPClientFactory:
             import boto3
             from botocore.exceptions import ClientError, NoCredentialsError
 
-            # Use us-west-2 region for SSM parameters
-            ssm_client = boto3.client('ssm', region_name='us-west-2')
+            # Create boto3 session to auto-discover region from ECS environment
+            session = boto3.Session()
+            region = session.region_name or 'us-west-2'  # Fallback to us-west-2 if region detection fails
+            logger.debug(f"MCPClientFactory - Auto-discovered SSM region: {region}")
+            ssm_client = boto3.client('ssm', region_name=region)
             response = ssm_client.get_parameter(Name=parameter_name)
             resolved_url = response['Parameter']['Value']
             logger.info(f"MCPClientFactory - Resolved parameter {parameter_name} to: {resolved_url}")

--- a/chatbot-app/backend/unified_tools_config.json
+++ b/chatbot-app/backend/unified_tools_config.json
@@ -207,19 +207,6 @@
       "icon": "trending-up",
       "enabled": false,
       "tool_type": "mcp"
-    },
-    {
-      "id": "recruiter-insights",
-      "name": "Recruiter Insights",
-      "description": "AI-powered recruitment tools for candidate analysis, job matching, and comprehensive recruiter insights with resume processing and analytics",
-      "type": "mcp",
-      "config": {
-        "url": "ssm:///mcp/endpoints/serverless/recruiter-insights"
-      },
-      "category": "hr",
-      "icon": "users",
-      "enabled": false,
-      "tool_type": "mcp"
     }
   ]
 }


### PR DESCRIPTION
**Summary**

Fixes region configuration issues where deployment and destruction scripts ignored .env file settings, causing operations to occur in wrong AWS regions.

**Changes Made**

- Region Propagation: Scripts now properly read and use AWS_REGION from .env files instead of defaulting to hardcoded us-west-2
- Dynamic Environment Variables: API keys and configuration values resolved dynamically at runtime rather than permanent file modification
- Destroy Script Fixes: Destruction operations now target correct regions and use proper stack names