### PR TITLE
Fix: Add missing DOCUMENT_BUCKET environment variable and align runtime configuration

### DIFF
--- a/agent-blueprint/chatbot-deployment/infrastructure/lib/chatbot-stack.ts
+++ b/agent-blueprint/chatbot-deployment/infrastructure/lib/chatbot-stack.ts
@@ -714,6 +714,7 @@ async function sendResponse(event, status, data, reason) {
       // DynamoDB Tables
       DYNAMODB_USERS_TABLE: usersTable.tableName,
       DYNAMODB_SESSIONS_TABLE: sessionsTable.tableName,
+      DOCUMENT_BUCKET: `${projectName}-docs-${this.account}-${this.region}`,
     };
 
     // Add AgentCore Memory ID from SSM Parameter Store (for conversation history)


### PR DESCRIPTION
## Description

This PR fixes a missing environment variable (`DOCUMENT_BUCKET`) in the chatbot deployment configuration.

### Problem
- `DOCUMENT_BUCKET` is required at runtime (e.g. in `route.ts`)
- It was not injected via `frontendEnvironment`
- This caused runtime fallback to SSM Parameter Store and naming mismatches

### Changes
- Added `DOCUMENT_BUCKET` to `frontendEnvironment` in `chatbot-stack.ts`
- Aligns infrastructure configuration with runtime expectations

### Impact
- Prevents undefined bucket references
- Reduces hidden dependency on SSM
- Improves deployment reliability and clarity

### Related Issue
Fixes #18 