### PR TITLE
fix: respect existing Cognito configuration during redeploy

### DIFF
--- a/agent-blueprint/chatbot-deployment/infrastructure/scripts/deploy.sh
+++ b/agent-blueprint/chatbot-deployment/infrastructure/scripts/deploy.sh
@@ -104,23 +104,30 @@ if [ "$ENABLE_COGNITO" = "true" ]; then
 
     # Check if Cognito User Pool already exists but stack does not
     # (stack exists = CDK manages the pool normally; stack gone + pool retained = import mode)
-    echo " Checking for existing Cognito User Pool..."
-    COGNITO_STACK_EXISTS=$(aws cloudformation describe-stacks --stack-name CognitoAuthStack \
-        --region $AWS_REGION 2>/dev/null && echo "true" || echo "false")
-    if [ "$COGNITO_STACK_EXISTS" = "false" ]; then
-        EXISTING_POOL_ID=$(aws cognito-idp list-user-pools --max-results 60 --region $AWS_REGION \
-            --query "UserPools[?Name=='chatbot-users'].Id" --output text 2>/dev/null || echo "")
-        if [ -n "$EXISTING_POOL_ID" ] && [ "$EXISTING_POOL_ID" != "None" ]; then
-            echo " Retained Cognito User Pool found: $EXISTING_POOL_ID - will import"
-            export USE_EXISTING_COGNITO=true
-            export EXISTING_COGNITO_USER_POOL_ID="$EXISTING_POOL_ID"
+    if [ "$USE_EXISTING_COGNITO" = "true" ] && [ -n "$EXISTING_COGNITO_USER_POOL_ID" ]; then
+        echo "Using existing Cognito User Pool from configuration: $EXISTING_COGNITO_USER_POOL_ID"
+    else
+        echo "Checking for existing Cognito User Pool..."
+
+        COGNITO_STACK_EXISTS=$(aws cloudformation describe-stacks --stack-name CognitoAuthStack \
+            --region $AWS_REGION 2>/dev/null && echo "true" || echo "false")
+
+        if [ "$COGNITO_STACK_EXISTS" = "false" ]; then
+            EXISTING_POOL_ID=$(aws cognito-idp list-user-pools --max-results 60 --region $AWS_REGION \
+                --query "UserPools[?Name=='chatbot-users'].Id" --output text 2>/dev/null || echo "")
+
+            if [ -n "$EXISTING_POOL_ID" ] && [ "$EXISTING_POOL_ID" != "None" ]; then
+                echo "Retained Cognito User Pool found: $EXISTING_POOL_ID - will import"
+                export USE_EXISTING_COGNITO=true
+                export EXISTING_COGNITO_USER_POOL_ID="$EXISTING_POOL_ID"
+            else
+                echo "No existing Cognito User Pool found - will create new one"
+                export USE_EXISTING_COGNITO=false
+            fi
         else
-            echo " No existing Cognito User Pool found - will create new one"
+            echo "CognitoAuthStack already exists - CDK will manage the existing pool"
             export USE_EXISTING_COGNITO=false
         fi
-    else
-        echo " CognitoAuthStack already exists - CDK will manage the existing pool"
-        export USE_EXISTING_COGNITO=false
     fi
 
     npx cdk deploy CognitoAuthStack --require-approval never


### PR DESCRIPTION
## Summary

This PR fixes an issue where user-provided Cognito configuration is ignored during redeployments, causing a new User Pool to be created instead of reusing an existing one.

## Problem

On initial deployment, a new Cognito User Pool is created as expected when no environment variables are provided.

However, on subsequent deployments, even when explicitly setting:

- USE_EXISTING_COGNITO=true
- EXISTING_COGNITO_USER_POOL_ID=<existing-pool-id>

the script overrides this configuration based on stack detection logic and sets USE_EXISTING_COGNITO=false. As a result, a new Cognito User Pool is created on every run.

## Root Cause

The deployment script prioritizes auto-detection logic over user-provided environment variables, leading to unintended overrides.

## Changes

- Updated logic to check for user-provided configuration first
- Use existing Cognito User Pool when both:
  - USE_EXISTING_COGNITO=true
  - EXISTING_COGNITO_USER_POOL_ID is provided
- Fallback to existing auto-detection logic when configuration is not provided
- Preserved existing behavior for first-time deployments

## Behavior After Fix

- First deployment (no env variables): creates a new User Pool
- Subsequent deployment with env variables: reuses existing User Pool
- Default auto-detection flow remains unchanged

## Impact

- Prevents unnecessary creation of multiple Cognito User Pools
- Ensures idempotent deployments
- Improves predictability and user control

## Testing

- Verified initial deployment creates a new Cognito User Pool
- Verified redeployment with env variables reuses the existing pool
- Verified fallback behavior when env variables are not provided

## Related Issue

Fixes #41 