### PR TITLE
feat(terraform)!: S3 native state locking (requires TF >= 1.11)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,7 +8,7 @@ Complete deployment instructions for the AgentCore-based chatbot platform.
 - **AWS CLI** configured with credentials
 - **Docker** installed and running
 - **Node.js** and **Python** installed
-- **Terraform** >= 1.5
+- **Terraform** >= 1.11.0 (required for S3 native state locking via `use_lockfile`)
 - **AgentCore** enabled in your AWS account region
 
 ## Architecture Overview
@@ -267,6 +267,51 @@ cd infra/environments/dev
 terraform force-unlock LOCK-ID
 ```
 
+### Migrating from DynamoDB-based locking
+
+Older deployments used a DynamoDB `${project}-tflock` table for state locking. This repo now uses S3 native locking (`use_lockfile = true`), which requires Terraform >= 1.11. Existing deployments should cut over in two phases.
+
+**Phase 1 — dual-lock (all operators upgrade to TF >= 1.11):**
+
+Temporarily edit `infra/environments/dev/backend.tf` locally to keep both locks active while the team upgrades:
+
+```hcl
+backend "s3" {
+  key            = "dev/terraform.tfstate"
+  encrypt        = true
+  use_lockfile   = true
+  dynamodb_table = "strands-agent-chatbot-tflock"  # temporary, keep during rollout
+}
+```
+
+Run `terraform init -reconfigure` in `infra/environments/dev/`. Confirm `plan`/`apply` works. Leave this in place until every operator is on TF >= 1.11.
+
+**Phase 2 — cutover (drop DynamoDB):**
+
+1. Pull the new shipped `backend.tf` (S3-only, no `dynamodb_table`).
+2. `./infra/scripts/deploy.sh init` — runs `terraform init -reconfigure` against the existing state.
+3. `cd infra/bootstrap && terraform init && terraform apply` — this destroys `aws_dynamodb_table.tflock`. No manual `aws dynamodb delete-table` call is required.
+
+### Rolling back state
+
+The bootstrap bucket has versioning enabled, so any prior `terraform.tfstate` object version can be restored in place:
+
+```bash
+# List prior versions of the state object
+aws s3api list-object-versions \
+  --bucket "${PROJECT_NAME}-tfstate-${ACCOUNT_ID}-us-east-1" \
+  --prefix dev/terraform.tfstate
+
+# Restore a specific versionId as the current object
+aws s3api copy-object \
+  --bucket "${PROJECT_NAME}-tfstate-${ACCOUNT_ID}-us-east-1" \
+  --key dev/terraform.tfstate \
+  --copy-source "${PROJECT_NAME}-tfstate-${ACCOUNT_ID}-us-east-1/dev/terraform.tfstate?versionId=VERSION_ID"
+
+# Confirm drift against live infra
+cd infra/environments/dev && terraform plan
+```
+
 ### Local Development Issues
 
 ```bash
@@ -367,7 +412,7 @@ The Terraform infrastructure is organized as:
 
 ```
 infra/
-+-- bootstrap/             # S3 state bucket + DynamoDB lock (one-time)
++-- bootstrap/             # S3 state bucket (one-time)
 +-- environments/dev/      # Root module wiring all components
 +-- modules/
 |   +-- auth               # Cognito (pool, clients, resource server)

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.11.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -34,7 +34,6 @@ data "aws_caller_identity" "current" {}
 
 locals {
   state_bucket = "${var.project_name}-tfstate-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
-  lock_table   = "${var.project_name}-tflock"
 }
 
 resource "aws_s3_bucket" "tfstate" {
@@ -66,31 +65,16 @@ resource "aws_s3_bucket_public_access_block" "tfstate" {
   restrict_public_buckets = true
 }
 
-resource "aws_dynamodb_table" "tflock" {
-  name         = local.lock_table
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "LockID"
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-}
-
 output "state_bucket" {
   value = aws_s3_bucket.tfstate.bucket
-}
-
-output "lock_table" {
-  value = aws_dynamodb_table.tflock.name
 }
 
 output "backend_hcl" {
   description = "Paste into environments/*/backend.tf"
   value       = <<-EOT
-    bucket         = "${aws_s3_bucket.tfstate.bucket}"
-    dynamodb_table = "${aws_dynamodb_table.tflock.name}"
-    region         = "${var.aws_region}"
-    encrypt        = true
+    bucket       = "${aws_s3_bucket.tfstate.bucket}"
+    region       = "${var.aws_region}"
+    encrypt      = true
+    use_lockfile = true
   EOT
 }

--- a/infra/environments/dev/backend.tf
+++ b/infra/environments/dev/backend.tf
@@ -1,11 +1,12 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.11.0"
 
-  # Backend config (bucket, dynamodb_table, region) is injected by
+  # Backend config (bucket, region) is injected by
   # infra/scripts/deploy.sh via -backend-config flags.
   backend "s3" {
-    key     = "dev/terraform.tfstate"
-    encrypt = true
+    key          = "dev/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 
   required_providers {

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   ./infra/scripts/deploy.sh [plan|apply|destroy|init] [-target=...]
 #
-# - Auto-bootstraps the S3 state bucket + DynamoDB lock table on first run.
+# - Auto-bootstraps the S3 state bucket on first run (S3 native locking).
 # - Derives backend config from PROJECT_NAME/AWS_REGION/AWS account id.
 # - Re-inits terraform if backend config changed.
 
@@ -79,7 +79,6 @@ STATE_REGION="us-east-1"
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 STATE_BUCKET="${PROJECT_NAME}-tfstate-${ACCOUNT_ID}-${STATE_REGION}"
-LOCK_TABLE="${PROJECT_NAME}-tflock"
 
 # ------------------------------------------------------------
 # API key prompts (only for apply; skipped if secret already exists)
@@ -422,7 +421,7 @@ ensure_backend() {
     return 0
   fi
 
-  echo ">>> Bootstrapping Terraform state backend (bucket + lock table in $STATE_REGION)..."
+  echo ">>> Bootstrapping Terraform state backend (bucket only; S3 native locking) in $STATE_REGION..."
   (
     cd "$BOOTSTRAP_DIR"
     terraform init -input=false
@@ -439,7 +438,6 @@ tf_init() {
   cd "$ENV_DIR"
   terraform init -input=false -reconfigure \
     -backend-config="bucket=${STATE_BUCKET}" \
-    -backend-config="dynamodb_table=${LOCK_TABLE}" \
     -backend-config="region=${STATE_REGION}"
 }
 


### PR DESCRIPTION
## Summary

Replace DynamoDB-based Terraform state locking with Terraform 1.11's native S3 locking (`use_lockfile = true`). Removes the `${project}-tflock` DynamoDB table, its IAM surface, the bootstrap output, and the `dynamodb_table` `-backend-config` flag from `deploy.sh`.

**Breaking change:** requires Terraform >= 1.11.

## Why S3 Native Locking

- **Consistency** — the lock object (`<key>.tflock`) lives in the same S3 bucket as the state it guards, so locking and state writes share one consistency domain. Eliminates the "state updated but DynamoDB lock entry diverged" failure mode inherent to the two-service setup.
- **Simplification** — one backing service (S3) instead of two (S3 + DynamoDB). One fewer Terraform resource, IAM surface, bootstrap output, and backend-config flag to maintain or document.
- **Cost reduction** — the PAY_PER_REQUEST DynamoDB lock table goes away entirely. Small per-deployment savings but recurring and meaningful at fleet scale (sandbox / PR-preview accounts).

## Migration (existing deployments)

**Phase 1 — dual-lock (everyone upgrades to TF >= 1.11):**

Temporarily edit `infra/environments/dev/backend.tf` locally to keep both locks active during the rollout:

```hcl
backend "s3" {
  key            = "dev/terraform.tfstate"
  encrypt        = true
  use_lockfile   = true
  dynamodb_table = "strands-agent-chatbot-tflock"  # temporary
}
```

Run `terraform init -reconfigure`. Confirm `plan`/`apply` works. Leave in place until every operator is on TF >= 1.11.

**Phase 2 — cutover (drop DynamoDB):**

1. Pull the new shipped `backend.tf` (S3-only, no `dynamodb_table`).
2. `./infra/scripts/deploy.sh init` — runs `terraform init -reconfigure` against the existing state.
3. `cd infra/bootstrap && terraform init && terraform apply` — destroys `aws_dynamodb_table.tflock`. No manual `aws dynamodb delete-table` call needed.

Full migration + rollback procedures are in `DEPLOYMENT.md`.

## Test plan

- [x] `terraform fmt -check` clean on edited files
- [x] `terraform init -backend=false && terraform validate` succeeds in `infra/bootstrap/` and `infra/environments/dev/`
- [ ] Fresh-bootstrap smoke test in a sandbox account (no pre-existing state bucket): `./infra/scripts/deploy.sh apply` creates bucket only, end-to-end apply completes
- [ ] Migration drill on an existing dev deployment: dual-lock phase, then cutover, then bootstrap apply destroys the lock table cleanly
- [ ] Rollback drill: restore a prior `terraform.tfstate` versionId via `aws s3api copy-object` and confirm `terraform plan` reports expected drift
- [ ] Version gate: `terraform -version` < 1.11 fails fast with a clear `required_version` error in both `bootstrap/` and `environments/dev/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)