### PR TITLE
feat(models): add Bedrock Mantle OpenAI models, curate model list, Opus 4.8

### DIFF
--- a/chatbot-app/agentcore/requirements.txt
+++ b/chatbot-app/agentcore/requirements.txt
@@ -9,6 +9,9 @@ uvicorn[standard]==0.35.0
 strands-agents[a2a,otel]>=1.30.0
 strands-agents-tools[a2a_client]>=0.2.20
 
+# OpenAI SDK - required for Bedrock Mantle OpenAI-compatible models (gpt-5.x, grok, gemma-4)
+openai>=2.0.0
+
 # Voice Chat (BidiAgent)
 aws-sdk-bedrock-runtime  # Required by strands BidiNovaSonicModel
 

--- a/chatbot-app/agentcore/src/agents/chat_agent.py
+++ b/chatbot-app/agentcore/src/agents/chat_agent.py
@@ -8,9 +8,9 @@ import logging
 import os
 from typing import Dict, Any, List, Optional
 from strands import Agent
-from strands.models import BedrockModel, CacheConfig
 from strands.tools.executors import SequentialToolExecutor
 from agents.base import BaseAgent
+from agents.model_factory import build_model
 from agent.hooks import ResearchApprovalHook, EmailApprovalHook, GitHubApprovalHook
 from agent.config.prompt_builder import (
     build_text_system_prompt,
@@ -110,37 +110,16 @@ class ChatAgent(BaseAgent):
     def create_agent(self):
         """Create Strands agent with filtered tools and session management"""
         try:
-            from botocore.config import Config
-
             config = self.get_model_config()
 
-            # Configure retry for transient Bedrock errors (serviceUnavailableException)
-            retry_config = Config(
-                retries={
-                    'max_attempts': 10,
-                    'mode': 'adaptive'  # Adaptive retry with exponential backoff
-                },
-                connect_timeout=30,
-                read_timeout=300  # Increased to 5 minutes for complex Code Interpreter operations
+            # Routes to BedrockModel (caching) or a Mantle OpenAI provider based
+            # on model_id. Mantle models ignore caching/temperature internally.
+            model = build_model(
+                config["model_id"],
+                temperature=config.get("temperature"),
+                max_tokens=32000,
+                caching_enabled=bool(self.caching_enabled),
             )
-
-            # Create model configuration
-            model_config = {
-                "model_id": config["model_id"],
-                "boto_client_config": retry_config,
-                "max_tokens": 32000,
-            }
-            # Extended thinking models (Opus 4.7) don't support temperature
-            if "opus-4-7" not in config["model_id"]:
-                model_config["temperature"] = config.get("temperature", 0.7)
-
-            # Add CacheConfig if caching is enabled (strands-agents 1.24.0+)
-            if self.caching_enabled:
-                model_config["cache_config"] = CacheConfig(strategy="auto")
-                logger.info("Prompt caching enabled via CacheConfig(strategy='auto')")
-
-            logger.debug("Bedrock retry config: max_attempts=10, mode=adaptive")
-            model = BedrockModel(**model_config)
 
             # Create hooks
             hooks = []

--- a/chatbot-app/agentcore/src/agents/model_factory.py
+++ b/chatbot-app/agentcore/src/agents/model_factory.py
@@ -1,0 +1,206 @@
+"""Model factory - builds the right Strands model provider for a given model_id.
+
+Two execution paths coexist:
+- Native Bedrock (`BedrockModel`): supports prompt caching. Default for any
+  model_id not registered as Mantle-only.
+- Bedrock Mantle OpenAI-compatible (`OpenAIResponsesModel`): for frontier/extra
+  models not available on native Bedrock Converse (gpt-5.x, grok, gemma-4).
+  No prompt caching. Authenticated with a Bedrock API key from Secrets Manager.
+
+Mantle models differ by region and by API path, so each is registered with its
+own spec. A Mantle stream can intermittently end with a `response.failed` event
+that the Strands SDK silently swallows (producing an empty turn); ResilientMantleModel
+retries those before any output is streamed downstream.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import boto3
+from strands.models import BedrockModel, CacheConfig
+
+logger = logging.getLogger(__name__)
+
+
+# Model IDs (substring match) that reject the `temperature` inference param:
+# Anthropic extended-thinking Opus, and OpenAI gpt-5.x reasoning models.
+NO_TEMPERATURE_MODELS = ("opus-4-7", "opus-4-8", "gpt-5")
+
+
+@dataclass(frozen=True)
+class MantleSpec:
+    """How to reach a Mantle-only model.
+
+    api: "responses" -> /openai/v1 (OpenAIResponsesModel)
+    region: Mantle region serving this model (independent of the app's region;
+            e.g. grok-4.3 is us-west-2 only, gpt-5.5 is not in us-west-2).
+    """
+    api: str
+    region: str
+
+
+# Mantle-only models (not callable via native Bedrock Converse). Anything not
+# listed here falls back to BedrockModel. The region is pinned per model: a
+# Mantle model is only served in some regions (grok-4.3 us-west-2 only, gpt-5.5
+# not in us-west-2), so the base_url region is forced independent of where the
+# app is deployed.
+MANTLE_MODELS: dict[str, MantleSpec] = {
+    "openai.gpt-5.5": MantleSpec(api="responses", region="us-east-2"),
+    "openai.gpt-5.4": MantleSpec(api="responses", region="us-east-2"),
+    "xai.grok-4.3": MantleSpec(api="responses", region="us-west-2"),
+    "google.gemma-4-31b": MantleSpec(api="responses", region="us-east-2"),
+    "google.gemma-4-26b-a4b": MantleSpec(api="responses", region="us-east-2"),
+    "google.gemma-4-e2b": MantleSpec(api="responses", region="us-east-2"),
+}
+
+
+# Native Bedrock models that are NOT available in every region. Selecting one of
+# these forces the BedrockModel client to the listed region, overriding the
+# app's deployment region (AWS_REGION). Models available everywhere are omitted
+# and use the default region. Keep in sync with regional Converse availability.
+NATIVE_MODEL_REGION_OVERRIDES: dict[str, str] = {
+    # qwen3-235b is absent in us-east-1; pin to us-west-2 which serves it.
+    "qwen.qwen3-235b-a22b-2507-v1:0": "us-west-2",
+}
+
+
+def model_rejects_temperature(model_id: str) -> bool:
+    return any(tag in model_id for tag in NO_TEMPERATURE_MODELS)
+
+
+_bedrock_api_key: Optional[str] = None
+
+
+def _get_bedrock_api_key() -> str:
+    """Fetch the Bedrock API key from Secrets Manager (cached process-wide).
+
+    Falls back to the AWS_BEARER_TOKEN_BEDROCK env var for local development.
+    """
+    global _bedrock_api_key
+    if _bedrock_api_key:
+        return _bedrock_api_key
+
+    env_key = os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
+    if env_key:
+        _bedrock_api_key = env_key
+        return _bedrock_api_key
+
+    secret_name = os.environ.get("BEDROCK_API_KEY_SECRET_NAME")
+    if not secret_name:
+        raise RuntimeError(
+            "Mantle model requested but no Bedrock API key available "
+            "(set BEDROCK_API_KEY_SECRET_NAME or AWS_BEARER_TOKEN_BEDROCK)"
+        )
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    client = boto3.client("secretsmanager", region_name=region)
+    _bedrock_api_key = client.get_secret_value(SecretId=secret_name)["SecretString"]
+    return _bedrock_api_key
+
+
+def _make_resilient_mantle_model(model_id: str, spec: MantleSpec, max_tokens: int):
+    """Build the resilient OpenAIResponsesModel subclass for a Mantle model."""
+    import asyncio
+
+    from strands.models.openai_responses import OpenAIResponsesModel
+
+    class ResilientMantleModel(OpenAIResponsesModel):
+        """Live streaming preserved. Buffers only the content-less leading events
+        (messageStart). On the first content/tool block, flushes the buffer and
+        streams live. If a turn produces no content block at all -- the Mantle
+        `response.failed` event that the SDK swallows into an empty turn -- the
+        buffer is discarded and the call retried. Safe because nothing was yielded
+        downstream before the first content block.
+        """
+
+        MAX_RETRIES = 6
+        RETRY_BASE_S = 1.0
+        _CONTENT_KEYS = ("contentBlockStart", "contentBlockDelta")
+
+        async def stream(self, *args, **kwargs):
+            attempt = 0
+            while True:
+                lead_buffer = []
+                produced = False
+                async for event in super().stream(*args, **kwargs):
+                    if produced:
+                        yield event
+                        continue
+                    key = next(iter(event.keys())) if isinstance(event, dict) else None
+                    if key in self._CONTENT_KEYS:
+                        produced = True
+                        for held in lead_buffer:
+                            yield held
+                        lead_buffer = []
+                        yield event
+                    else:
+                        lead_buffer.append(event)
+                if produced:
+                    return
+                if attempt < self.MAX_RETRIES:
+                    attempt += 1
+                    logger.warning(
+                        "Mantle empty turn (response.failed) for %s; retry %d/%d",
+                        model_id, attempt, self.MAX_RETRIES,
+                    )
+                    await asyncio.sleep(self.RETRY_BASE_S * attempt)
+                    continue
+                logger.error("Mantle model %s exhausted retries on empty turn", model_id)
+                for held in lead_buffer:
+                    yield held
+                return
+
+    base_url = f"https://bedrock-mantle.{spec.region}.api.aws/openai/v1"
+    return ResilientMantleModel(
+        model_id=model_id,
+        params={"max_output_tokens": max_tokens},
+        client_args={
+            "api_key": _get_bedrock_api_key(),
+            "base_url": base_url,
+        },
+    )
+
+
+def build_model(
+    model_id: str,
+    *,
+    temperature: Optional[float] = None,
+    max_tokens: int = 32000,
+    caching_enabled: bool = False,
+):
+    """Build the appropriate Strands model for `model_id`.
+
+    Mantle-only models -> ResilientMantleModel (no caching, no temperature).
+    Everything else -> BedrockModel (caching + boto retry).
+    """
+    spec = MANTLE_MODELS.get(model_id)
+    if spec is not None:
+        logger.info("Building Mantle model %s (region=%s)", model_id, spec.region)
+        return _make_resilient_mantle_model(model_id, spec, max_tokens)
+
+    from botocore.config import Config
+
+    retry_config = Config(
+        retries={"max_attempts": 10, "mode": "adaptive"},
+        connect_timeout=30,
+        read_timeout=300,
+    )
+    model_config = {
+        "model_id": model_id,
+        "boto_client_config": retry_config,
+        "max_tokens": max_tokens,
+    }
+    # Force the region for native models that aren't available everywhere;
+    # otherwise BedrockModel defaults to the app's AWS_REGION.
+    region_override = NATIVE_MODEL_REGION_OVERRIDES.get(model_id)
+    if region_override:
+        model_config["region_name"] = region_override
+        logger.info("Region override for %s -> %s", model_id, region_override)
+    if not model_rejects_temperature(model_id):
+        model_config["temperature"] = temperature if temperature is not None else 0.7
+    if caching_enabled:
+        model_config["cache_config"] = CacheConfig(strategy="auto")
+        logger.info("Prompt caching enabled via CacheConfig(strategy='auto')")
+
+    return BedrockModel(**model_config)

--- a/chatbot-app/agentcore/src/workflows/composer_workflow.py
+++ b/chatbot-app/agentcore/src/workflows/composer_workflow.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from typing import AsyncGenerator, Optional, Dict, Any
 
 from strands import Agent
-from strands.models import BedrockModel
+from agents.model_factory import build_model
 
 from models.composer_schemas import (
     WritingTaskStatus,
@@ -1155,7 +1155,6 @@ Please address this feedback in the revised outline.
         """Invoke LLM with prompt and return response text"""
         import sys
         import io
-        from botocore.config import Config
 
         # Log the full prompt for debugging
         logger.info("=" * 80)
@@ -1164,20 +1163,11 @@ Please address this feedback in the revised outline.
         logger.info(prompt)
         logger.info("=" * 80)
 
-        retry_config = Config(
-            retries={
-                'max_attempts': 5,
-                'mode': 'adaptive'
-            },
-            connect_timeout=30,
-            read_timeout=120
-        )
-
-        model = BedrockModel(
-            model_id=self.model_id,
+        # Routes to BedrockModel or a Mantle OpenAI provider based on model_id.
+        model = build_model(
+            self.model_id,
             temperature=self.temperature,
             max_tokens=8096,
-            boto_client_config=retry_config
         )
 
         # Create a simple agent for LLM invocation (stateless)

--- a/chatbot-app/agentcore/tests/unit/test_model_factory.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_factory.py
@@ -1,0 +1,114 @@
+"""
+Tests for agents.model_factory
+
+Covers:
+- build_model routing: Bedrock vs Mantle by model_id
+- temperature guard (extended-thinking / reasoning models)
+- Mantle base_url / region selection
+- Bedrock API key resolution (env var and Secrets Manager)
+"""
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+import agents.model_factory as mf
+from agents.model_factory import (
+    build_model,
+    model_rejects_temperature,
+    MANTLE_MODELS,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_key_cache():
+    mf._bedrock_api_key = None
+    yield
+    mf._bedrock_api_key = None
+
+
+class TestTemperatureGuard:
+    @pytest.mark.parametrize("model_id", [
+        "us.anthropic.claude-opus-4-7",
+        "us.anthropic.claude-opus-4-8",
+        "openai.gpt-5.5",
+        "openai.gpt-5.4",
+    ])
+    def test_rejects(self, model_id):
+        assert model_rejects_temperature(model_id) is True
+
+    @pytest.mark.parametrize("model_id", [
+        "us.anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "xai.grok-4.3",
+        "google.gemma-4-31b",
+    ])
+    def test_allows(self, model_id):
+        assert model_rejects_temperature(model_id) is False
+
+
+class TestBedrockRouting:
+    def test_bedrock_model_for_native_id(self):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model("us.anthropic.claude-sonnet-4-6", temperature=0.5, caching_enabled=True)
+            kwargs = MockBedrock.call_args.kwargs
+            assert kwargs["model_id"] == "us.anthropic.claude-sonnet-4-6"
+            assert kwargs["temperature"] == 0.5
+            assert "cache_config" in kwargs
+
+    def test_no_temperature_for_opus(self):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model("us.anthropic.claude-opus-4-8", temperature=0.7)
+            assert "temperature" not in MockBedrock.call_args.kwargs
+
+    def test_no_cache_when_disabled(self):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model("us.anthropic.claude-sonnet-4-6", caching_enabled=False)
+            assert "cache_config" not in MockBedrock.call_args.kwargs
+
+    def test_region_override_for_restricted_native_model(self):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model("qwen.qwen3-235b-a22b-2507-v1:0")
+            assert MockBedrock.call_args.kwargs["region_name"] == "us-west-2"
+
+    def test_no_region_override_for_global_model(self):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model("us.anthropic.claude-sonnet-4-6")
+            assert "region_name" not in MockBedrock.call_args.kwargs
+
+
+class TestMantleRouting:
+    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
+    def test_mantle_model_built_with_correct_base_url(self):
+        model = build_model("openai.gpt-5.5")
+        assert "bedrock-mantle.us-east-2.api.aws/openai/v1" in model.client_args["base_url"]
+        assert model.client_args["api_key"] == "test-key"
+
+    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
+    def test_grok_region_is_west(self):
+        model = build_model("xai.grok-4.3")
+        assert "us-west-2" in model.client_args["base_url"]
+
+    def test_all_mantle_models_have_responses_api(self):
+        for spec in MANTLE_MODELS.values():
+            assert spec.api == "responses"
+            assert spec.region
+
+
+class TestApiKeyResolution:
+    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "env-key"})
+    def test_env_var_takes_precedence(self):
+        assert mf._get_bedrock_api_key() == "env-key"
+
+    @patch.dict(os.environ, {"BEDROCK_API_KEY_SECRET_NAME": "my/secret", "AWS_REGION": "us-east-2"}, clear=True)
+    def test_secrets_manager_fallback(self):
+        fake_client = MagicMock()
+        fake_client.get_secret_value.return_value = {"SecretString": "sm-key"}
+        with patch.object(mf.boto3, "client", return_value=fake_client) as mock_client:
+            assert mf._get_bedrock_api_key() == "sm-key"
+            mock_client.assert_called_once_with("secretsmanager", region_name="us-east-2")
+            fake_client.get_secret_value.assert_called_once_with(SecretId="my/secret")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_raises_when_no_key(self):
+        with pytest.raises(RuntimeError, match="no Bedrock API key"):
+            mf._get_bedrock_api_key()

--- a/chatbot-app/frontend/src/app/api/model/available-models/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/available-models/route.ts
@@ -1,16 +1,20 @@
 /**
  * Available Models endpoint - returns list of supported AI models
+ *
+ * Two backend execution paths (decided server-side by model_id):
+ * - Native Bedrock (BedrockModel): prompt caching supported.
+ * - Bedrock Mantle (OpenAIResponsesModel): frontier/extra models not on native
+ *   Bedrock Converse (gpt-5.x, grok, gemma-4). No prompt caching.
  */
 import { NextResponse } from 'next/server'
 
 export const runtime = 'nodejs'
 
-// Available Bedrock models
 const AVAILABLE_MODELS = [
-  // Claude (Anthropic)
+  // Claude (Anthropic) - native Bedrock, prompt caching
   {
-    id: 'us.anthropic.claude-opus-4-7',
-    name: 'Claude Opus 4.7',
+    id: 'us.anthropic.claude-opus-4-8',
+    name: 'Claude Opus 4.8',
     provider: 'Anthropic',
     description: 'Most intelligent model, best for complex tasks',
     noTemperature: true
@@ -28,7 +32,37 @@ const AVAILABLE_MODELS = [
     description: 'Fast and efficient, cost-effective'
   },
 
-  // DeepSeek
+  // GPT (OpenAI) - gpt-5.x via Mantle, gpt-oss via native Bedrock
+  {
+    id: 'openai.gpt-5.5',
+    name: 'GPT-5.5',
+    provider: 'OpenAI',
+    description: 'Frontier reasoning model (via Bedrock Mantle)',
+    noTemperature: true
+  },
+  {
+    id: 'openai.gpt-5.4',
+    name: 'GPT-5.4',
+    provider: 'OpenAI',
+    description: 'Frontier model (via Bedrock Mantle)',
+    noTemperature: true
+  },
+  {
+    id: 'openai.gpt-oss-120b-1:0',
+    name: 'GPT OSS 120B',
+    provider: 'OpenAI',
+    description: 'Open-source GPT model with 120B parameters'
+  },
+
+  // Grok (xAI) - via Mantle
+  {
+    id: 'xai.grok-4.3',
+    name: 'Grok 4.3',
+    provider: 'xAI',
+    description: 'Advanced reasoning model (via Bedrock Mantle)'
+  },
+
+  // DeepSeek - native Bedrock
   {
     id: 'deepseek.v3.2',
     name: 'DeepSeek V3.2',
@@ -36,132 +70,72 @@ const AVAILABLE_MODELS = [
     description: 'Advanced language model with strong reasoning capabilities'
   },
 
-  // Nova (Amazon)
+  // Gemma (Google) - gemma-4 via Mantle
   {
-    id: 'us.amazon.nova-2-omni-v1:0',
-    name: 'Nova 2 Omni',
-    provider: 'Amazon',
-    description: 'Preview multimodal model with advanced capabilities'
+    id: 'google.gemma-4-31b',
+    name: 'Gemma 4 31B',
+    provider: 'Google',
+    description: 'Latest multimodal model (via Bedrock Mantle)'
   },
   {
-    id: 'us.amazon.nova-2-pro-preview-20251202-v1:0',
-    name: 'Nova 2 Pro',
-    provider: 'Amazon',
-    description: 'High-performance multimodal model'
-  },
-  {
-    id: 'us.amazon.nova-2-lite-v1:0',
-    name: 'Nova 2 Lite',
-    provider: 'Amazon',
-    description: 'Lightweight and efficient model'
+    id: 'google.gemma-4-26b-a4b',
+    name: 'Gemma 4 26B',
+    provider: 'Google',
+    description: 'Efficient MoE multimodal model (via Bedrock Mantle)'
   },
 
-  // GPT (OpenAI)
+  // Z.AI GLM - native Bedrock
   {
-    id: 'openai.gpt-oss-120b-1:0',
-    name: 'GPT OSS 120B',
-    provider: 'OpenAI',
-    description: 'Open-source GPT model with 120B parameters'
+    id: 'zai.glm-5',
+    name: 'GLM-5',
+    provider: 'Z.AI',
+    description: 'Latest flagship reasoning and agentic model'
   },
   {
-    id: 'openai.gpt-oss-safeguard-20b',
-    name: 'GPT OSS Safeguard 20B',
-    provider: 'OpenAI',
-    description: 'Content safety model for custom policy enforcement'
-  },
-  {
-    id: 'openai.gpt-oss-safeguard-120b',
-    name: 'GPT OSS Safeguard 120B',
-    provider: 'OpenAI',
-    description: 'Larger content safety model for complex moderation'
+    id: 'zai.glm-4.7',
+    name: 'GLM-4.7',
+    provider: 'Z.AI',
+    description: 'Strong general-purpose model'
   },
 
-  // Qwen
+  // Moonshot - native Bedrock
   {
-    id: 'qwen.qwen3-vl-235b-a22b',
-    name: 'Qwen3 VL 235B',
-    provider: 'Qwen',
-    description: 'Multimodal model for image, video, and code understanding'
+    id: 'moonshotai.kimi-k2.5',
+    name: 'Kimi K2.5',
+    provider: 'Moonshot AI',
+    description: 'Deep reasoning model for complex workflows'
   },
+
+  // MiniMax - native Bedrock
+  {
+    id: 'minimax.minimax-m2.5',
+    name: 'MiniMax M2.5',
+    provider: 'MiniMax AI',
+    description: 'Built for coding agents and automation'
+  },
+
+  // Qwen - native Bedrock
   {
     id: 'qwen.qwen3-235b-a22b-2507-v1:0',
     name: 'Qwen 235B',
     provider: 'Qwen',
     description: 'Large-scale language model with 235B parameters'
   },
-  {
-    id: 'qwen.qwen3-next-80b-a3b',
-    name: 'Qwen3 Next 80B',
-    provider: 'Qwen',
-    description: 'Fast inference for ultra-long documents and RAG'
-  },
-  {
-    id: 'qwen.qwen3-32b-v1:0',
-    name: 'Qwen 32B',
-    provider: 'Qwen',
-    description: 'Efficient language model with 32B parameters'
-  },
 
-  // Gemma (Google)
+  // Mistral - native Bedrock
   {
-    id: 'google.gemma-3-27b-it',
-    name: 'Gemma 3 27B',
-    provider: 'Google',
-    description: 'Powerful text and image model for enterprise'
-  },
-  {
-    id: 'google.gemma-3-12b-it',
-    name: 'Gemma 3 12B',
-    provider: 'Google',
-    description: 'Balanced text and image model for workstations'
-  },
-  {
-    id: 'google.gemma-3-4b-it',
-    name: 'Gemma 3 4B',
-    provider: 'Google',
-    description: 'Efficient text and image model for on-device AI'
-  },
-
-  // NVIDIA
-  {
-    id: 'nvidia.nemotron-nano-12b-v2',
-    name: 'Nemotron Nano 12B v2 VL',
-    provider: 'NVIDIA',
-    description: 'Advanced multimodal reasoning for video understanding'
-  },
-  {
-    id: 'nvidia.nemotron-nano-9b-v2',
-    name: 'Nemotron Nano 9B v2',
-    provider: 'NVIDIA',
-    description: 'High efficiency for reasoning and agentic tasks'
-  },
-
-  // Mistral
-  {
-    id: 'mistral.voxtral-small-24b-2507',
-    name: 'Voxtral Small 24B',
+    id: 'mistral.mistral-large-3-675b-instruct',
+    name: 'Mistral Large 3',
     provider: 'Mistral AI',
-    description: 'State-of-the-art audio input with text performance'
-  },
-  {
-    id: 'mistral.voxtral-mini-3b-2507',
-    name: 'Voxtral Mini 3B',
-    provider: 'Mistral AI',
-    description: 'Advanced audio understanding with transcription'
+    description: 'Flagship instruction model with 675B parameters'
   },
 
-  // Others
+  // NVIDIA - native Bedrock
   {
-    id: 'moonshot.kimi-k2-thinking',
-    name: 'Kimi K2 Thinking',
-    provider: 'Moonshot AI',
-    description: 'Deep reasoning model for complex workflows'
-  },
-  {
-    id: 'minimax.minimax-m2',
-    name: 'MiniMax M2',
-    provider: 'MiniMax AI',
-    description: 'Built for coding agents and automation'
+    id: 'nvidia.nemotron-super-3-120b',
+    name: 'Nemotron Super 3 120B',
+    provider: 'NVIDIA',
+    description: 'High-performance reasoning and agentic model'
   }
 ]
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -67,6 +67,11 @@ data "aws_secretsmanager_secret" "google_maps_creds" {
   name  = "${var.project_name}/mcp/google-maps-credentials"
 }
 
+data "aws_secretsmanager_secret" "bedrock_api_key" {
+  count = var.enable_mantle_models ? 1 : 0
+  name  = "${var.project_name}/bedrock/api-key"
+}
+
 locals {
   lambda_tools_root = "${local.root_dir}/agentcore/gateway-tools/lambda-functions"
 
@@ -291,24 +296,29 @@ module "runtime_orchestrator" {
   artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
   artifact_bucket_name = aws_s3_bucket.artifacts.id
 
-  extra_env_vars = {
-    DYNAMODB_USERS_TABLE                  = module.data.users_table_name
-    DYNAMODB_SESSIONS_TABLE               = module.data.sessions_table_name
-    MEMORY_ARN                            = module.memory.memory_arn
-    CODE_AGENT_RUNTIME_ARN                = module.runtime_code_agent.runtime_arn
-    RESEARCH_AGENT_RUNTIME_ARN            = module.runtime_research_agent.runtime_arn
-    MCP_3LO_RUNTIME_ARN                   = module.runtime_mcp_3lo.runtime_arn
-    CODE_INTERPRETER_ID                   = module.agentcore_shared.code_interpreter_id
-    BROWSER_ID                            = module.agentcore_shared.browser_id
-    BROWSER_NAME                          = module.agentcore_shared.browser_name
-    NOVA_ACT_WORKFLOW_DEFINITION_NAME     = module.agentcore_shared.nova_act_workflow_name
-    NOVA_ACT_REGION                       = "us-east-1"
-    AGENT_OBSERVABILITY_ENABLED           = "true"
-    OTEL_PYTHON_DISTRO                    = "aws_distro"
-    OTEL_PYTHON_CONFIGURATOR              = "aws_configurator"
-    OTEL_LOGS_EXPORTER                    = "otlp"
-    OTEL_PYTHON_DISABLED_INSTRUMENTATIONS = "urllib3,urllib"
-  }
+  extra_env_vars = merge(
+    {
+      DYNAMODB_USERS_TABLE                  = module.data.users_table_name
+      DYNAMODB_SESSIONS_TABLE               = module.data.sessions_table_name
+      MEMORY_ARN                            = module.memory.memory_arn
+      CODE_AGENT_RUNTIME_ARN                = module.runtime_code_agent.runtime_arn
+      RESEARCH_AGENT_RUNTIME_ARN            = module.runtime_research_agent.runtime_arn
+      MCP_3LO_RUNTIME_ARN                   = module.runtime_mcp_3lo.runtime_arn
+      CODE_INTERPRETER_ID                   = module.agentcore_shared.code_interpreter_id
+      BROWSER_ID                            = module.agentcore_shared.browser_id
+      BROWSER_NAME                          = module.agentcore_shared.browser_name
+      NOVA_ACT_WORKFLOW_DEFINITION_NAME     = module.agentcore_shared.nova_act_workflow_name
+      NOVA_ACT_REGION                       = "us-east-1"
+      AGENT_OBSERVABILITY_ENABLED           = "true"
+      OTEL_PYTHON_DISTRO                    = "aws_distro"
+      OTEL_PYTHON_CONFIGURATOR              = "aws_configurator"
+      OTEL_LOGS_EXPORTER                    = "otlp"
+      OTEL_PYTHON_DISABLED_INSTRUMENTATIONS = "urllib3,urllib"
+    },
+    var.enable_mantle_models ? {
+      BEDROCK_API_KEY_SECRET_NAME = data.aws_secretsmanager_secret.bedrock_api_key[0].name
+    } : {},
+  )
 
   depends_on = [
     module.auth,

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -31,6 +31,12 @@ variable "enable_google_maps" {
   default     = true
 }
 
+variable "enable_mantle_models" {
+  description = "Wire the Bedrock API key secret into the orchestrator so Mantle OpenAI-compatible models (gpt-5.x, grok, gemma-4) can be selected. Requires a Secrets Manager secret at <project_name>/bedrock/api-key."
+  type        = bool
+  default     = false
+}
+
 variable "google_oauth_client_id" {
   description = "Google OAuth Client ID for Gmail/Calendar MCP 3LO. Empty disables the provider."
   type        = string

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -105,6 +105,7 @@ STATE_BUCKET="${PROJECT_NAME}-tfstate-${ACCOUNT_ID}-${STATE_REGION}"
 SKIP_TAVILY=false
 SKIP_GOOGLE_SEARCH=false
 SKIP_GOOGLE_MAPS=false
+ENABLE_MANTLE_MODELS=false
 
 _secret_exists() {
   aws secretsmanager describe-secret --secret-id "$1" --region "$AWS_REGION" >/dev/null 2>&1
@@ -190,6 +191,26 @@ prompt_api_keys() {
     fi
   fi
 
+  # Bedrock API key (for Mantle OpenAI-compatible models: gpt-5.x, grok, gemma-4)
+  local mantle_secret="${PROJECT_NAME}/bedrock/api-key"
+  if _secret_exists "$mantle_secret"; then
+    ENABLE_MANTLE_MODELS=true
+    echo ""
+    echo "Bedrock Mantle  : already configured (gpt-5.x, grok, gemma-4 enabled)"
+  else
+    echo ""
+    echo "Bedrock API Key (enables Mantle models: GPT-5.5, Grok-4.3, Gemma-4)"
+    echo "  Generate at: https://console.aws.amazon.com/bedrock/home#/api-keys"
+    read -rp "  Bedrock API Key (Enter to skip): " key
+    if [ -n "${key:-}" ]; then
+      _ensure_secret "$mantle_secret" "Bedrock API key for Mantle OpenAI-compatible models" "$key"
+      ENABLE_MANTLE_MODELS=true
+      echo "  -> stored"
+    else
+      echo "  (skipped — GPT-5.5, Grok, Gemma-4 will not be available)"
+    fi
+  fi
+
   # Google Maps Embed (frontend key — separate from server-side credentials).
   # The Embed API requires the key in the browser, so it MUST be a distinct key
   # restricted to Maps Embed API + your CloudFront domain in Google Cloud Console.
@@ -215,6 +236,7 @@ prompt_api_keys() {
 }
 
 prompt_api_keys
+export TF_VAR_enable_mantle_models="$ENABLE_MANTLE_MODELS"
 
 # ------------------------------------------------------------
 # OAuth credential prompts (Google / GitHub / Notion)

--- a/mobile-app/src/lib/constants.ts
+++ b/mobile-app/src/lib/constants.ts
@@ -31,16 +31,16 @@ export interface ModelInfo {
 }
 
 export const AVAILABLE_MODELS: ModelInfo[] = [
-  { id: 'us.anthropic.claude-opus-4-7', name: 'Claude Opus 4.7', provider: 'Anthropic', description: 'Most intelligent model' },
+  { id: 'us.anthropic.claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic', description: 'Most intelligent model' },
   { id: 'us.anthropic.claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'Anthropic', description: 'Balanced performance' },
   { id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0', name: 'Claude Haiku 4.5', provider: 'Anthropic', description: 'Fast and efficient' },
-  { id: 'us.amazon.nova-2-pro-preview-20251202-v1:0', name: 'Nova 2 Pro', provider: 'Amazon', description: 'High-performance multimodal' },
-  { id: 'us.amazon.nova-2-lite-v1:0', name: 'Nova 2 Lite', provider: 'Amazon', description: 'Lightweight and efficient' },
+  { id: 'openai.gpt-5.5', name: 'GPT-5.5', provider: 'OpenAI', description: 'Frontier reasoning model' },
+  { id: 'openai.gpt-5.4', name: 'GPT-5.4', provider: 'OpenAI', description: 'Frontier model' },
+  { id: 'xai.grok-4.3', name: 'Grok 4.3', provider: 'xAI', description: 'Advanced reasoning model' },
+  { id: 'google.gemma-4-31b', name: 'Gemma 4 31B', provider: 'Google', description: 'Latest multimodal model' },
   { id: 'deepseek.v3.2', name: 'DeepSeek V3.2', provider: 'DeepSeek', description: 'Strong reasoning capabilities' },
-  { id: 'qwen.qwen3-235b-a22b-2507-v1:0', name: 'Qwen 235B', provider: 'Qwen', description: 'Large-scale language model' },
-  { id: 'qwen.qwen3-32b-v1:0', name: 'Qwen 32B', provider: 'Qwen', description: 'Efficient language model' },
-  { id: 'google.gemma-3-27b-it', name: 'Gemma 3 27B', provider: 'Google', description: 'Text and image model' },
-  { id: 'moonshot.kimi-k2-thinking', name: 'Kimi K2 Thinking', provider: 'Moonshot AI', description: 'Deep reasoning model' },
+  { id: 'zai.glm-5', name: 'GLM-5', provider: 'Z.AI', description: 'Flagship reasoning model' },
+  { id: 'moonshotai.kimi-k2.5', name: 'Kimi K2.5', provider: 'Moonshot AI', description: 'Deep reasoning model' },
 ]
 
 export const MODEL_STORAGE_KEY = 'selected_model_id'

--- a/telegram-app/src/message-handler.ts
+++ b/telegram-app/src/message-handler.ts
@@ -17,7 +17,8 @@ import { bufferMessage, setFlushHandler, clearBusy } from "./inbound-buffer.js";
 const MODELS = [
   { id: "us.anthropic.claude-sonnet-4-6", label: "Sonnet 4.6" },
   { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Haiku 4.5" },
-  { id: "us.anthropic.claude-opus-4-7", label: "Opus 4.7" },
+  { id: "us.anthropic.claude-opus-4-8", label: "Opus 4.8" },
+  { id: "openai.gpt-5.5", label: "GPT-5.5" },
 ] as const;
 
 export function setupMessageHandlers(bot: Bot): void {


### PR DESCRIPTION
## Summary

Adds AWS Bedrock Mantle OpenAI-compatible models to the model picker, curates the existing list, and migrates Claude Opus 4.7 → 4.8.

## How it works

`model_factory.build_model()` routes by `model_id`:
- **Native Bedrock** (`BedrockModel`) — prompt caching kept. Default for anything not registered as Mantle-only. Includes Opus 4.8, glm-5, kimi-k2.5, etc.
- **Bedrock Mantle** (`ResilientMantleModel`, subclass of `OpenAIResponsesModel`) — for models not on native Converse: `gpt-5.5`, `gpt-5.4`, `grok-4.3`, `gemma-4`. Authenticated with a Bedrock API key from Secrets Manager. No caching.

### Two issues handled
1. **SDK swallows `response.failed`** — the Strands `openai_responses.py` parser (incl. latest 1.43.0) ignores Mantle `response.failed` stream events, ending the turn empty (the "announce-then-stall" symptom). `ResilientMantleModel` detects an empty turn and retries, **preserving live streaming** (only the leading `messageStart` is held; once a content block starts it streams live and never retries).
2. **Region restrictions** — Mantle models differ by region (`grok-4.3` us-west-2 only, `gpt-5.5` not in us-west-2). Each model pins its region in the base_url, independent of the app's deploy region. A `NATIVE_MODEL_REGION_OVERRIDES` map does the same for region-restricted native models (e.g. `qwen3-235b`).

## Changes
- `agents/model_factory.py` (new) + `test_model_factory.py` (new, 19 tests)
- `chat_agent.py`, `composer_workflow.py` route through `build_model()`; temperature guard now data-driven (opus-4-7/4-8, gpt-5.x)
- `deploy.sh` prompts for the Bedrock API key → Secrets Manager, wires `enable_mantle_models`; Terraform injects `BEDROCK_API_KEY_SECRET_NAME` into the orchestrator
- Model lists (frontend/mobile/telegram): drop Nova + dead IDs + gemma-3; add gpt-5.5/5.4, grok-4.3, gemma-4, glm-5, kimi-k2.5, minimax-m2.5, mistral-large-3, nemotron-super-3; Opus 4.7 → 4.8
- `requirements.txt`: add `openai>=2.0.0`

## Verification
- Backend 417 + new 19 factory tests pass; frontend 522 pass
- E2E multi-step tool calling verified through `build_model()` for gpt-5.5, grok-4.3, gemma-4 (live streaming intact)
- Deployed to dev; CloudWatch orchestrator logs show **0 ERROR/Traceback**. `response.failed` retries fire (retry 1-2/6) and all recover — no empty turns reach users.

## Known constraints
- **gpt-5.x intermittent availability**: Mantle returns `response.failed` ("Engine not found") sporadically. Retry mitigates (recovered in 1-2 attempts in prod), but a sustained outage can still surface. grok/gemma are stable.
- **Prompt caching does not apply to Mantle models** — by design; native-capable models stay on BedrockModel to keep caching.
- Mantle requires `enable_mantle_models=true` + a Bedrock API key secret; absent, those models simply aren't selectable end-to-end.