### PR TITLE
fix(models): PDF attachments to Mantle models (filename + file_data)

### DIFF
--- a/chatbot-app/agentcore/src/agents/model_factory.py
+++ b/chatbot-app/agentcore/src/agents/model_factory.py
@@ -102,6 +102,8 @@ def _get_bedrock_api_key() -> str:
 def _make_resilient_mantle_model(model_id: str, spec: MantleSpec, max_tokens: int):
     """Build the resilient OpenAIResponsesModel subclass for a Mantle model."""
     import asyncio
+    import base64
+    import mimetypes
 
     from strands.models.openai_responses import OpenAIResponsesModel
 
@@ -150,6 +152,24 @@ def _make_resilient_mantle_model(model_id: str, spec: MantleSpec, max_tokens: in
                 for held in lead_buffer:
                     yield held
                 return
+
+        @classmethod
+        def _format_request_message_content(cls, content, *, role="user"):
+            # The SDK emits documents as {"type": "input_file", "file_url": <data-url>},
+            # which Mantle rejects with "Unsupported file type: 'unknown'". Mantle
+            # requires the OpenAI-standard shape with an explicit filename + file_data.
+            if "document" in content:
+                doc = content["document"]
+                fmt = doc["format"]
+                mime = mimetypes.types_map.get(f".{fmt}", "application/octet-stream")
+                data_url = f"data:{mime};base64,{base64.b64encode(doc['source']['bytes']).decode()}"
+                name = doc.get("name", "document")
+                return {
+                    "type": "input_file",
+                    "filename": f"{name}.{fmt}",
+                    "file_data": data_url,
+                }
+            return super()._format_request_message_content(content, role=role)
 
     base_url = f"https://bedrock-mantle.{spec.region}.api.aws/openai/v1"
     return ResilientMantleModel(

--- a/chatbot-app/agentcore/tests/unit/test_model_factory.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_factory.py
@@ -93,6 +93,24 @@ class TestMantleRouting:
             assert spec.api == "responses"
             assert spec.region
 
+    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
+    def test_pdf_document_uses_filename_and_file_data(self):
+        # Mantle rejects the SDK default {"type":"input_file","file_url":...} with
+        # "Unsupported file type: 'unknown'". The subclass must emit filename + file_data.
+        model = build_model("openai.gpt-5.5")
+        block = {"document": {"format": "pdf", "name": "report", "source": {"bytes": b"%PDF-1.4 x"}}}
+        out = type(model)._format_request_message_content(block)
+        assert out["type"] == "input_file"
+        assert out["filename"] == "report.pdf"
+        assert out["file_data"].startswith("data:application/pdf;base64,")
+        assert "file_url" not in out
+
+    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
+    def test_non_document_content_delegates_to_parent(self):
+        model = build_model("openai.gpt-5.5")
+        out = type(model)._format_request_message_content({"text": "hi"})
+        assert out == {"type": "input_text", "text": "hi"}
+
 
 class TestApiKeyResolution:
     @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "env-key"})


### PR DESCRIPTION
## Problem
Attaching a PDF to a Mantle model (gpt-5.x / grok / gemma-4) failed with:
\`\`\`
Error code: 400 - Unsupported file type: 'unknown'. Only PDF files are supported.
\`\`\`

## Root cause
The Strands SDK (\`openai_responses.py\`) formats a document content block as:
\`\`\`python
{"type": "input_file", "file_url": "data:application/pdf;base64,..."}
\`\`\`
Mantle's OpenAI-compatible endpoint cannot infer the file type from a bare \`file_url\` data URL and reports it as \`'unknown'\`. Verified by reproducing both the failure (\`file_url\`) and the fix (\`filename\` + \`file_data\`) via raw curl against the Mantle Responses API.

## Fix
Override \`_format_request_message_content\` in \`ResilientMantleModel\` to emit the OpenAI-standard shape for documents:
\`\`\`python
{"type": "input_file", "filename": "<name>.<format>", "file_data": "data:..."}
\`\`\`
All non-document content types delegate to the parent (\`super()\`), so images/text/citations are unchanged. This is an app-level workaround (same approach as the existing \`response.failed\` retry) — the SDK is not modified.

## Verification
- Unit tests: 21 pass (added \`test_pdf_document_uses_filename_and_file_data\`, \`test_non_document_content_delegates_to_parent\`)
- ruff clean
- End-to-end: gpt-5.5 reads an attached PDF and returns its text content