### PR TITLE
fix(frontend): recover sharp libvips bundling and warmup auth race

### DIFF
--- a/chatbot-app/frontend/Dockerfile
+++ b/chatbot-app/frontend/Dockerfile
@@ -59,6 +59,11 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
+# sharp's native libvips (.so) is dlopen'd at runtime and isn't picked up by
+# Next's standalone file tracer, so copy the full @img tree explicitly. On alpine
+# only the linuxmusl/wasm variants are installed, so this stays small.
+COPY --from=builder /app/node_modules/@img ./node_modules/@img
+
 # Set the correct permission for prerender cache
 RUN mkdir -p .next
 RUN chown nextjs:nodejs .next

--- a/chatbot-app/frontend/src/config/session.ts
+++ b/chatbot-app/frontend/src/config/session.ts
@@ -103,6 +103,13 @@ export async function triggerWarmup(sessionId?: string, authHeaders?: Record<str
     return
   }
 
+  // AgentCore Runtime requires a JWT; an unauthenticated warmup just 401s.
+  // Caller is responsible for passing a populated Authorization header.
+  if (!authHeaders?.Authorization) {
+    console.error('[Warmup] Aborted: missing Authorization header (caller race?)')
+    return
+  }
+
   const lastWarmup = parseInt(sessionStorage.getItem(WARMUP_KEY) || '0', 10)
   const lastWarmupSession = sessionStorage.getItem(WARMUP_SESSION_KEY)
 

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -238,9 +238,16 @@ export const useChatAPI = ({
       setSessionId(currentSessionId)
       sessionIdRef.current = currentSessionId
 
-      // 3. Trigger warmup with auth
-      const authHeaders = await getAuthHeaders()
-      triggerWarmup(currentSessionId, authHeaders)
+      // 3. Trigger warmup with auth.
+      // Amplify's fetchAuthSession() can return an empty token immediately after
+      // a page load while getCurrentUser() already succeeds, so wait for the
+      // token to hydrate before warming. The runtime requires JWT auth.
+      const authHeaders = await waitForAuthHeaders()
+      if (authHeaders.Authorization) {
+        triggerWarmup(currentSessionId, authHeaders)
+      } else if (userId !== 'anonymous') {
+        logger.error('[Session] Authed user but token never hydrated; skipping warmup')
+      }
     }
 
     initSession()
@@ -267,6 +274,21 @@ export const useChatAPI = ({
       }
     } catch (error) {
       logger.debug('No auth session available (local dev or not authenticated)')
+    }
+    return {}
+  }
+
+  // Poll fetchAuthSession briefly until the access token is hydrated. Needed
+  // right after page load: getCurrentUser() can resolve before the token is
+  // available in memory, so a one-shot getAuthHeaders() may return empty.
+  const waitForAuthHeaders = async (
+    maxAttempts = 5,
+    delayMs = 200,
+  ): Promise<Record<string, string>> => {
+    for (let i = 0; i < maxAttempts; i++) {
+      const headers = await getAuthHeaders()
+      if (headers.Authorization) return headers
+      await new Promise((r) => setTimeout(r, delayMs))
     }
     return {}
   }


### PR DESCRIPTION
## Summary
- **sharp 0.35.1 → libvips dlopen failure**: dependabot PR #123 bumped sharp 0.34.5→0.35.1, which split libvips into `@img/sharp-libvips-linuxmusl-x64@1.3.0` (`libvips-cpp.so.8.18.3`). Next's standalone tracer doesn't follow runtime dlopen, so the runner image was missing the `.so`. Result: every `import sharp` (incl. `app/api/stream/chat/route.ts`) failed with `ERR_DLOPEN_FAILED`, returning 500 to the client. Fix: copy `node_modules/@img` into the runner stage explicitly.
- **Warmup 401 on page load**: `getCurrentUser()` resolves before `fetchAuthSession()` has the JWT hydrated, so warmup was firing without an Authorization header and AgentCore Runtime returned 401. Fix: poll `fetchAuthSession()` (5×200ms) and only warm once the token is available; abort warmup if it isn't.

## Test plan
- [ ] Deploy via `./infra/scripts/deploy.sh apply -target=module.chat`
- [ ] `/api/stream/chat` returns SSE 200 (no `Could not load "sharp"` in ECS logs)
- [ ] ECS frontend logs no longer show `[AgentCore Warmup] Failed: 401`
- [ ] Orchestrator logs show real chat invocations (not just warmup)