### PR TITLE
ci(frontend): add next build step to PR check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Tests
         run: npm test
 
+      - name: Build
+        run: npm run build
+
   a2a-agents:
     name: A2A Agents (Python)
     needs: changes


### PR DESCRIPTION
## What

Add `npm run build` to the frontend PR-check job.

## Why

The frontend CI currently runs only `type-check` (tsc) + `vitest`. Neither catches build-time errors that `next build` surfaces — RSC server/client boundaries, route handler collection, production bundling. This is the standard install → type-check → test → **build** pipeline for Next.js.

Validated locally that `next build` passes on `main` and on the pending Dependabot major bumps (#140, #141, #142).