### PR TITLE
feat(models): adopt the GPT-5.6 family and centralize the default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ tool execution, memory, browser automation, and agent-to-agent collaboration.
 It is intended as a realistic, extensible sample for teams exploring advanced agent architectures on AWS.
 
 > [!NOTE]
-> **New: Bedrock Mantle models.** The model picker now includes OpenAI **GPT-5.5 / GPT-5.4**, **xAI Grok 4.3**, and **Google Gemma 4** via Amazon Bedrock's OpenAI-compatible Mantle endpoints — alongside the native Bedrock models (Claude, DeepSeek, Qwen, and more).
+> **New: Bedrock Mantle models.** The model picker now includes the OpenAI **GPT-5.6 family (Sol, Terra, and Luna)**, **xAI Grok 4.3**, and **Google Gemma 4** via Amazon Bedrock's OpenAI-compatible Mantle endpoints — alongside the native Bedrock models (Claude, DeepSeek, Qwen, and more).
 
 ---
 

--- a/chatbot-app/agentcore/src/agent/config/constants.py
+++ b/chatbot-app/agentcore/src/agent/config/constants.py
@@ -37,8 +37,8 @@ A2A_PREFIX = "agentcore_"
 # Model Configuration
 # =============================================================================
 
-# Default Bedrock model ID
-DEFAULT_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+# Default text model ID
+DEFAULT_MODEL_ID = "openai.gpt-5.6-terra"
 
 # Default temperature for model inference
 DEFAULT_TEMPERATURE = 0.7

--- a/chatbot-app/agentcore/src/agents/base.py
+++ b/chatbot-app/agentcore/src/agents/base.py
@@ -13,6 +13,7 @@ import logging
 from abc import ABC
 from typing import List, Optional, Any
 
+from agent.config import DEFAULT_MODEL_ID
 from agent.tool_filter import filter_tools
 from agent.factory import create_session_manager
 
@@ -72,7 +73,7 @@ class BaseAgent(ABC):
 
     def _get_default_model_id(self) -> str:
         """Get default model ID for this agent type"""
-        return "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        return DEFAULT_MODEL_ID
 
     def _load_tools(self) -> List:
         """Load and filter tools based on enabled_tools"""

--- a/chatbot-app/agentcore/src/agents/model_factory.py
+++ b/chatbot-app/agentcore/src/agents/model_factory.py
@@ -9,8 +9,8 @@ Two execution paths coexist:
 
 Mantle models differ by region and by API path, so each is registered with its
 own spec. A Mantle stream can intermittently end with a `response.failed` event
-that the Strands SDK silently swallows (producing an empty turn); ResilientMantleModel
-retries those before any output is streamed downstream.
+that the Strands SDK silently swallows (producing an empty turn);
+BedrockMantleResponsesModel retries those before any output is streamed downstream.
 """
 
 import logging
@@ -35,7 +35,7 @@ class MantleSpec:
 
     api: "responses" -> /openai/v1 (OpenAIResponsesModel)
     region: Mantle region serving this model (independent of the app's region;
-            e.g. grok-4.3 is us-west-2 only, gpt-5.5 is not in us-west-2).
+            e.g. grok-4.3 is us-west-2 only, gpt-5.6 is served in us-east-1).
     """
     api: str
     region: str
@@ -43,12 +43,13 @@ class MantleSpec:
 
 # Mantle-only models (not callable via native Bedrock Converse). Anything not
 # listed here falls back to BedrockModel. The region is pinned per model: a
-# Mantle model is only served in some regions (grok-4.3 us-west-2 only, gpt-5.5
-# not in us-west-2), so the base_url region is forced independent of where the
+# Mantle model is only served in some regions (grok-4.3 in us-west-2, gpt-5.6
+# in us-east-1), so the base_url region is forced independent of where the
 # app is deployed.
 MANTLE_MODELS: dict[str, MantleSpec] = {
-    "openai.gpt-5.5": MantleSpec(api="responses", region="us-east-2"),
-    "openai.gpt-5.4": MantleSpec(api="responses", region="us-east-2"),
+    "openai.gpt-5.6-sol": MantleSpec(api="responses", region="us-east-1"),
+    "openai.gpt-5.6-terra": MantleSpec(api="responses", region="us-east-1"),
+    "openai.gpt-5.6-luna": MantleSpec(api="responses", region="us-east-1"),
     "xai.grok-4.3": MantleSpec(api="responses", region="us-west-2"),
     "google.gemma-4-31b": MantleSpec(api="responses", region="us-east-2"),
     "google.gemma-4-26b-a4b": MantleSpec(api="responses", region="us-east-2"),
@@ -99,15 +100,15 @@ def _get_bedrock_api_key() -> str:
     return _bedrock_api_key
 
 
-def _make_resilient_mantle_model(model_id: str, spec: MantleSpec, max_tokens: int):
-    """Build the resilient OpenAIResponsesModel subclass for a Mantle model."""
+def _make_bedrock_mantle_responses_model(model_id: str, spec: MantleSpec, max_tokens: int):
+    """Build the OpenAI Responses model configured for Bedrock Mantle."""
     import asyncio
     import base64
     import mimetypes
 
     from strands.models.openai_responses import OpenAIResponsesModel
 
-    class ResilientMantleModel(OpenAIResponsesModel):
+    class BedrockMantleResponsesModel(OpenAIResponsesModel):
         """Live streaming preserved. Buffers only the content-less leading events
         (messageStart). On the first content/tool block, flushes the buffer and
         streams live. If a turn produces no content block at all -- the Mantle
@@ -172,7 +173,7 @@ def _make_resilient_mantle_model(model_id: str, spec: MantleSpec, max_tokens: in
             return super()._format_request_message_content(content, role=role)
 
     base_url = f"https://bedrock-mantle.{spec.region}.api.aws/openai/v1"
-    return ResilientMantleModel(
+    return BedrockMantleResponsesModel(
         model_id=model_id,
         params={"max_output_tokens": max_tokens},
         client_args={
@@ -191,13 +192,13 @@ def build_model(
 ):
     """Build the appropriate Strands model for `model_id`.
 
-    Mantle-only models -> ResilientMantleModel (no caching, no temperature).
+    Mantle-only models -> BedrockMantleResponsesModel (no caching, no temperature).
     Everything else -> BedrockModel (caching + boto retry).
     """
     spec = MANTLE_MODELS.get(model_id)
     if spec is not None:
         logger.info("Building Mantle model %s (region=%s)", model_id, spec.region)
-        return _make_resilient_mantle_model(model_id, spec, max_tokens)
+        return _make_bedrock_mantle_responses_model(model_id, spec, max_tokens)
 
     from botocore.config import Config
 

--- a/chatbot-app/agentcore/src/agents/workflow_agent.py
+++ b/chatbot-app/agentcore/src/agents/workflow_agent.py
@@ -77,8 +77,9 @@ class WorkflowAgent(BaseAgent):
 
     def _get_default_model_id(self) -> str:
         """Get default model ID for workflow agents"""
-        # Use Sonnet for workflow orchestration (better reasoning)
-        return "us.anthropic.claude-sonnet-5"
+        from agent.config import DEFAULT_MODEL_ID
+
+        return DEFAULT_MODEL_ID
 
     def _create_session_manager(self):
         """

--- a/chatbot-app/agentcore/src/workflows/composer_workflow.py
+++ b/chatbot-app/agentcore/src/workflows/composer_workflow.py
@@ -259,7 +259,9 @@ class ComposerWorkflow:
         """
         self.session_id = session_id
         self.user_id = user_id or session_id
-        self.model_id = model_id or "us.anthropic.claude-sonnet-5"
+        from agent.config import DEFAULT_MODEL_ID
+
+        self.model_id = model_id or DEFAULT_MODEL_ID
         self.temperature = temperature if temperature is not None else 0.7
         self.region_name = os.environ.get('AWS_REGION', 'us-west-2')
         self.session_manager = session_manager

--- a/chatbot-app/agentcore/tests/unit/test_composer_workflow.py
+++ b/chatbot-app/agentcore/tests/unit/test_composer_workflow.py
@@ -112,7 +112,7 @@ class TestComposerWorkflowInit:
         agent = ComposerWorkflow(session_id="sess-123")
         assert agent.session_id == "sess-123"
         assert agent.user_id == "sess-123"  # defaults to session_id
-        assert agent.model_id == "us.anthropic.claude-sonnet-5"
+        assert agent.model_id == "openai.gpt-5.6-terra"
         assert agent.temperature == 0.7
 
     def test_init_with_custom_values(self):

--- a/chatbot-app/agentcore/tests/unit/test_model_factory.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_factory.py
@@ -31,8 +31,9 @@ class TestTemperatureGuard:
         "us.anthropic.claude-opus-4-7",
         "us.anthropic.claude-opus-4-8",
         "us.anthropic.claude-sonnet-5",
-        "openai.gpt-5.5",
-        "openai.gpt-5.4",
+        "openai.gpt-5.6-sol",
+        "openai.gpt-5.6-terra",
+        "openai.gpt-5.6-luna",
     ])
     def test_rejects(self, model_id):
         assert model_rejects_temperature(model_id) is True
@@ -84,9 +85,17 @@ class TestBedrockRouting:
 class TestMantleRouting:
     @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
     def test_mantle_model_built_with_correct_base_url(self):
-        model = build_model("openai.gpt-5.5")
-        assert "bedrock-mantle.us-east-2.api.aws/openai/v1" in model.client_args["base_url"]
+        model = build_model("openai.gpt-5.6-sol")
+        assert "bedrock-mantle.us-east-1.api.aws/openai/v1" in model.client_args["base_url"]
         assert model.client_args["api_key"] == "test-key"
+
+    def test_gpt_56_family_is_pinned_to_us_east_1(self):
+        for model_id in (
+            "openai.gpt-5.6-sol",
+            "openai.gpt-5.6-terra",
+            "openai.gpt-5.6-luna",
+        ):
+            assert MANTLE_MODELS[model_id].region == "us-east-1"
 
     @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
     def test_grok_region_is_west(self):
@@ -102,7 +111,7 @@ class TestMantleRouting:
     def test_pdf_document_uses_filename_and_file_data(self):
         # Mantle rejects the SDK default {"type":"input_file","file_url":...} with
         # "Unsupported file type: 'unknown'". The subclass must emit filename + file_data.
-        model = build_model("openai.gpt-5.5")
+        model = build_model("openai.gpt-5.6-sol")
         block = {"document": {"format": "pdf", "name": "report", "source": {"bytes": b"%PDF-1.4 x"}}}
         out = type(model)._format_request_message_content(block)
         assert out["type"] == "input_file"
@@ -112,7 +121,7 @@ class TestMantleRouting:
 
     @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
     def test_non_document_content_delegates_to_parent(self):
-        model = build_model("openai.gpt-5.5")
+        model = build_model("openai.gpt-5.6-sol")
         out = type(model)._format_request_message_content({"text": "hi"})
         assert out == {"type": "input_text", "text": "hi"}
 

--- a/chatbot-app/frontend/src/app/api/model/available-models/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/available-models/route.ts
@@ -35,17 +35,24 @@ const AVAILABLE_MODELS = [
 
   // GPT (OpenAI) - gpt-5.x via Mantle, gpt-oss via native Bedrock
   {
-    id: 'openai.gpt-5.5',
-    name: 'GPT-5.5',
+    id: 'openai.gpt-5.6-sol',
+    name: 'GPT-5.6 Sol',
     provider: 'OpenAI',
-    description: 'Frontier reasoning model (via Bedrock Mantle)',
+    description: 'Flagship frontier model (via Bedrock Mantle)',
     noTemperature: true
   },
   {
-    id: 'openai.gpt-5.4',
-    name: 'GPT-5.4',
+    id: 'openai.gpt-5.6-terra',
+    name: 'GPT-5.6 Terra',
     provider: 'OpenAI',
-    description: 'Frontier model (via Bedrock Mantle)',
+    description: 'Balanced frontier model (via Bedrock Mantle)',
+    noTemperature: true
+  },
+  {
+    id: 'openai.gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    provider: 'OpenAI',
+    description: 'Fast and cost-efficient model (via Bedrock Mantle)',
     noTemperature: true
   },
   {

--- a/chatbot-app/frontend/src/app/api/model/config/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/config/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
 
     // Default configuration
     let config = {
-      model_id: 'us.anthropic.claude-sonnet-5',
+      model_id: 'openai.gpt-5.6-terra',
       temperature: 0.5,
     }
 

--- a/chatbot-app/frontend/src/lib/dynamodb-schema.ts
+++ b/chatbot-app/frontend/src/lib/dynamodb-schema.ts
@@ -86,7 +86,7 @@ export interface UserApiKeys {
 
 export interface UserPreferences {
   // Model Configuration
-  defaultModel?: string // e.g., "us.anthropic.claude-sonnet-5"
+  defaultModel?: string // e.g., "openai.gpt-5.6-terra"
   defaultTemperature?: number // 0.0 - 1.0
   systemPrompt?: string // Custom system prompt
   customPromptName?: string // Name of custom prompt
@@ -261,7 +261,7 @@ export const EXAMPLE_USER_RECORD: UserProfileRecord = {
   createdAt: '2025-01-14T10:00:00Z',
   lastAccessAt: '2025-01-14T15:30:00Z',
   preferences: {
-    defaultModel: 'us.anthropic.claude-sonnet-5',
+    defaultModel: 'openai.gpt-5.6-terra',
     defaultTemperature: 0.5,
     systemPrompt: 'You are a helpful AI assistant.',
     enabledTools: ['calculator', 'web_search', 'code_interpreter'],
@@ -282,7 +282,7 @@ export const EXAMPLE_SESSION_RECORD: SessionRecord = {
   tags: ['aws', 'lambda', 'deployment'],
   starred: true,
   metadata: {
-    lastModel: 'us.anthropic.claude-sonnet-5',
+    lastModel: 'openai.gpt-5.6-terra',
     lastTemperature: 0.5,
     totalTokens: 8500,
     agentCoreTraceId: 'trace-abc123',

--- a/mobile-app/src/components/chat/ChatScreen.tsx
+++ b/mobile-app/src/components/chat/ChatScreen.tsx
@@ -40,7 +40,11 @@ export default function ChatScreen({
   // Load persisted model selection
   useEffect(() => {
     AsyncStorage.getItem(MODEL_STORAGE_KEY).then(saved => {
-      if (saved) setSelectedModelId(saved)
+      if (saved && AVAILABLE_MODELS.some(model => model.id === saved)) {
+        setSelectedModelId(saved)
+      } else if (saved) {
+        AsyncStorage.setItem(MODEL_STORAGE_KEY, DEFAULT_MODEL_ID)
+      }
     })
   }, [])
 

--- a/mobile-app/src/lib/constants.ts
+++ b/mobile-app/src/lib/constants.ts
@@ -2,7 +2,7 @@ export const API_BASE_URL = (
   (process.env.EXPO_PUBLIC_API_URL as string | undefined) ?? 'http://localhost:3000'
 ).replace(/\/$/, '')
 
-export const DEFAULT_MODEL_ID = 'us.anthropic.claude-sonnet-5'
+export const DEFAULT_MODEL_ID = 'openai.gpt-5.6-terra'
 export const DEFAULT_TEMPERATURE = 0.7
 export const TEXT_BUFFER_FLUSH_MS = 120
 
@@ -34,8 +34,9 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
   { id: 'us.anthropic.claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic', description: 'Most intelligent model' },
   { id: 'us.anthropic.claude-sonnet-5', name: 'Claude Sonnet 5', provider: 'Anthropic', description: 'Balanced performance' },
   { id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0', name: 'Claude Haiku 4.5', provider: 'Anthropic', description: 'Fast and efficient' },
-  { id: 'openai.gpt-5.5', name: 'GPT-5.5', provider: 'OpenAI', description: 'Frontier reasoning model' },
-  { id: 'openai.gpt-5.4', name: 'GPT-5.4', provider: 'OpenAI', description: 'Frontier model' },
+  { id: 'openai.gpt-5.6-sol', name: 'GPT-5.6 Sol', provider: 'OpenAI', description: 'Flagship frontier model' },
+  { id: 'openai.gpt-5.6-terra', name: 'GPT-5.6 Terra', provider: 'OpenAI', description: 'Balanced frontier model' },
+  { id: 'openai.gpt-5.6-luna', name: 'GPT-5.6 Luna', provider: 'OpenAI', description: 'Fast and cost-efficient model' },
   { id: 'xai.grok-4.3', name: 'Grok 4.3', provider: 'xAI', description: 'Advanced reasoning model' },
   { id: 'google.gemma-4-31b', name: 'Gemma 4 31B', provider: 'Google', description: 'Latest multimodal model' },
   { id: 'deepseek.v3.2', name: 'DeepSeek V3.2', provider: 'DeepSeek', description: 'Strong reasoning capabilities' },

--- a/telegram-app/src/message-handler.ts
+++ b/telegram-app/src/message-handler.ts
@@ -19,7 +19,9 @@ const MODELS = [
   { id: "us.anthropic.claude-sonnet-5", label: "Sonnet 5" },
   { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Haiku 4.5" },
   { id: "us.anthropic.claude-opus-4-8", label: "Opus 4.8" },
-  { id: "openai.gpt-5.5", label: "GPT-5.5" },
+  { id: "openai.gpt-5.6-sol", label: "GPT-5.6 Sol" },
+  { id: "openai.gpt-5.6-terra", label: "GPT-5.6 Terra" },
+  { id: "openai.gpt-5.6-luna", label: "GPT-5.6 Luna" },
 ] as const;
 
 export function setupMessageHandlers(bot: Bot): void {


### PR DESCRIPTION
## Summary

[GPT-5.6 Sol, Terra, and Luna became generally available on Amazon Bedrock](https://aws.amazon.com/about-aws/whats-new/2026/07/openai-gpt-sol-terra/) and supersede GPT-5.5 / GPT-5.4, which this PR removes from the model picker.

Two things get fixed along the way:

1. **Region pin.** All three GPT-5.6 tiers are served through the Responses API on the `bedrock-mantle` endpoint in `us-east-1`, so the `MantleSpec` region moves from `us-east-2`.
2. **Default model duplication.** The default was hardcoded in four places — `BaseAgent`, `WorkflowAgent`, `ComposerWorkflow`, and the frontend config route — and had already drifted between Haiku and Sonnet. They now all read `DEFAULT_MODEL_ID` from `agent.config`, set to **GPT-5.6 Terra** for its balance of reasoning and cost.

## Changes

- `model_factory.py`: replace the `gpt-5.5` / `gpt-5.4` Mantle specs with `gpt-5.6-sol` / `-terra` / `-luna` in `us-east-1`
- `constants.py`: `DEFAULT_MODEL_ID` → `openai.gpt-5.6-terra`
- `base.py` / `workflow_agent.py` / `composer_workflow.py`: read `DEFAULT_MODEL_ID` instead of hardcoding
- Frontend `available-models` + `config` routes, `dynamodb-schema.ts` doc examples
- Mobile + Telegram model lists; mobile now falls back to the default when a persisted model id is no longer offered, so clients holding a stale `gpt-5.5` selection recover on their own
- Rename `ResilientMantleModel` → `BedrockMantleResponsesModel`: the class configures the Responses API for Mantle rather than adding resilience of its own

## Verification

| Check | Result |
| --- | --- |
| `ruff check src/ --select E4,E7,E9,F` | pass |
| `pytest tests/unit/` (backend) | 424 passed |
| `npm run type-check` (frontend) | pass |
| `npm test` (frontend) | 522 passed |
| `npm run build` (frontend) | pass |
| `npx tsc --noEmit` (mobile) | pass |
| `npm run build` (telegram) | pass |

## Note

Part of a stack splitting a large local change set. Independent of #183.