### PR TITLE
fix(frontend): verify Cognito JWT signatures instead of decoding them

### DIFF
--- a/chatbot-app/frontend/__tests__/api/documents.test.ts
+++ b/chatbot-app/frontend/__tests__/api/documents.test.ts
@@ -24,14 +24,14 @@ vi.mock('@/lib/auth-utils', () => ({
 
 import { extractUserFromRequest } from '@/lib/auth-utils'
 
-describe('Documents Download API', () => {
+describe('Documents Download API', async () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubEnv('DOCUMENT_BUCKET', 'test-document-bucket')
   })
 
-  describe('Request Validation', () => {
-    it('should require sessionId', () => {
+  describe('Request Validation', async () => {
+    it('should require sessionId', async () => {
       const body: { filename: string; toolType: string; sessionId?: string } = {
         filename: 'report.docx',
         toolType: 'word_document'
@@ -42,7 +42,7 @@ describe('Documents Download API', () => {
       expect(isValid).toBeFalsy()
     })
 
-    it('should require filename', () => {
+    it('should require filename', async () => {
       const body: { sessionId: string; toolType: string; filename?: string } = {
         sessionId: 'session-123',
         toolType: 'word_document'
@@ -53,7 +53,7 @@ describe('Documents Download API', () => {
       expect(isValid).toBeFalsy()
     })
 
-    it('should require toolType', () => {
+    it('should require toolType', async () => {
       const body: { sessionId: string; filename: string; toolType?: string } = {
         sessionId: 'session-123',
         filename: 'report.docx'
@@ -64,7 +64,7 @@ describe('Documents Download API', () => {
       expect(isValid).toBeFalsy()
     })
 
-    it('should accept valid request body (no userId needed)', () => {
+    it('should accept valid request body (no userId needed)', async () => {
       const body = {
         sessionId: 'user123_abc_session456',
         filename: 'report.docx',
@@ -77,13 +77,13 @@ describe('Documents Download API', () => {
     })
   })
 
-  describe('User ID Extraction from Authorization Header', () => {
+  describe('User ID Extraction from Authorization Header', async () => {
     /**
      * The route uses extractUserFromRequest() to get userId from JWT.
      * This is the same pattern used by /api/workspace/files.
      */
 
-    it('should extract userId from authenticated request', () => {
+    it('should extract userId from authenticated request', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: '18c1e380-1234-5678-9abc-def012345678' })
 
@@ -93,13 +93,13 @@ describe('Documents Download API', () => {
         }
       }
 
-      const user = extractUserFromRequest(mockRequest as any)
+      const user = await extractUserFromRequest(mockRequest as any)
 
       expect(user.userId).toBe('18c1e380-1234-5678-9abc-def012345678')
       expect(mockExtract).toHaveBeenCalledWith(mockRequest)
     })
 
-    it('should return anonymous for unauthenticated request', () => {
+    it('should return anonymous for unauthenticated request', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: 'anonymous' })
 
@@ -109,12 +109,12 @@ describe('Documents Download API', () => {
         }
       }
 
-      const user = extractUserFromRequest(mockRequest as any)
+      const user = await extractUserFromRequest(mockRequest as any)
 
       expect(user.userId).toBe('anonymous')
     })
 
-    it('should use full UUID from JWT (not truncated sessionId prefix)', () => {
+    it('should use full UUID from JWT (not truncated sessionId prefix)', async () => {
       /**
        * This test verifies the fix for the NoSuchKey bug:
        * - S3 files are stored with full UUID: documents/18c1e380-xxxx-xxxx-xxxx-xxxxxxxxxxxx/...
@@ -131,7 +131,7 @@ describe('Documents Download API', () => {
         }
       }
 
-      const user = extractUserFromRequest(mockRequest as any)
+      const user = await extractUserFromRequest(mockRequest as any)
 
       // Full UUID (36 chars), not truncated prefix (8 chars)
       expect(user.userId).toBe(fullUUID)
@@ -140,26 +140,26 @@ describe('Documents Download API', () => {
     })
   })
 
-  describe('Tool Type to Document Type Mapping', () => {
+  describe('Tool Type to Document Type Mapping', async () => {
     const toolTypeToDocType: Record<string, string> = {
       'word_document': 'word',
       'excel_spreadsheet': 'excel',
       'powerpoint_presentation': 'powerpoint'
     }
 
-    it('should map word_document to word', () => {
+    it('should map word_document to word', async () => {
       expect(toolTypeToDocType['word_document']).toBe('word')
     })
 
-    it('should map excel_spreadsheet to excel', () => {
+    it('should map excel_spreadsheet to excel', async () => {
       expect(toolTypeToDocType['excel_spreadsheet']).toBe('excel')
     })
 
-    it('should map powerpoint_presentation to powerpoint', () => {
+    it('should map powerpoint_presentation to powerpoint', async () => {
       expect(toolTypeToDocType['powerpoint_presentation']).toBe('powerpoint')
     })
 
-    it('should use toolType as-is for unknown types', () => {
+    it('should use toolType as-is for unknown types', async () => {
       const unknownType = 'custom_document'
       const documentType = toolTypeToDocType[unknownType] || unknownType
 
@@ -167,8 +167,8 @@ describe('Documents Download API', () => {
     })
   })
 
-  describe('S3 Key Construction', () => {
-    it('should construct correct S3 key for word document', () => {
+  describe('S3 Key Construction', async () => {
+    it('should construct correct S3 key for word document', async () => {
       const bucket = 'test-document-bucket'
       const userId = '18c1e380-1234-5678-9abc-def012345678'  // Full UUID from JWT
       const sessionId = '18c1e380_timestamp_uuid'
@@ -180,7 +180,7 @@ describe('Documents Download API', () => {
       expect(s3Key).toBe('s3://test-document-bucket/documents/18c1e380-1234-5678-9abc-def012345678/18c1e380_timestamp_uuid/word/report.docx')
     })
 
-    it('should construct correct S3 key for excel document', () => {
+    it('should construct correct S3 key for excel document', async () => {
       const bucket = 'test-document-bucket'
       const userId = 'user-456-full-uuid-here'
       const sessionId = 'user456_xyz_session789'
@@ -192,7 +192,7 @@ describe('Documents Download API', () => {
       expect(s3Key).toBe('s3://test-document-bucket/documents/user-456-full-uuid-here/user456_xyz_session789/excel/data.xlsx')
     })
 
-    it('should construct correct S3 key for anonymous user', () => {
+    it('should construct correct S3 key for anonymous user', async () => {
       const bucket = 'test-document-bucket'
       const userId = 'anonymous'  // From extractUserFromRequest when no auth
       const sessionId = 'anon0000_abc_session123'
@@ -204,7 +204,7 @@ describe('Documents Download API', () => {
       expect(s3Key).toBe('s3://test-document-bucket/documents/anonymous/anon0000_abc_session123/word/anonymous-doc.docx')
     })
 
-    it('should handle filenames with spaces', () => {
+    it('should handle filenames with spaces', async () => {
       const bucket = 'test-document-bucket'
       const userId = 'user-123-full-uuid'
       const sessionId = 'session-456'
@@ -216,7 +216,7 @@ describe('Documents Download API', () => {
       expect(s3Key).toBe('s3://test-document-bucket/documents/user-123-full-uuid/session-456/word/My Report 2024.docx')
     })
 
-    it('should handle filenames with special characters', () => {
+    it('should handle filenames with special characters', async () => {
       const bucket = 'test-document-bucket'
       const userId = 'user-123-full-uuid'
       const sessionId = 'session-456'
@@ -229,8 +229,8 @@ describe('Documents Download API', () => {
     })
   })
 
-  describe('End-to-End Flow (with extractUserFromRequest)', () => {
-    it('should correctly process authenticated user download request', () => {
+  describe('End-to-End Flow (with extractUserFromRequest)', async () => {
+    it('should correctly process authenticated user download request', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: '18c1e380-1234-5678-9abc-def012345678' })
 
@@ -249,7 +249,7 @@ describe('Documents Download API', () => {
       }
 
       // Simulate route logic
-      const user = extractUserFromRequest({} as any)
+      const user = await extractUserFromRequest({} as any)
       const userId = user.userId
       const documentType = toolTypeToDocType[request.toolType] || request.toolType
       const s3Key = `s3://${bucket}/documents/${userId}/${request.sessionId}/${documentType}/${request.filename}`
@@ -259,7 +259,7 @@ describe('Documents Download API', () => {
       expect(s3Key).toBe('s3://test-document-bucket/documents/18c1e380-1234-5678-9abc-def012345678/18c1e380_timestamp_uuid/word/quarterly-report.docx')
     })
 
-    it('should correctly process anonymous user download request', () => {
+    it('should correctly process anonymous user download request', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: 'anonymous' })
 
@@ -277,7 +277,7 @@ describe('Documents Download API', () => {
       }
 
       // Simulate route logic
-      const user = extractUserFromRequest({} as any)
+      const user = await extractUserFromRequest({} as any)
       const userId = user.userId
       const documentType = toolTypeToDocType[request.toolType] || request.toolType
       const s3Key = `s3://${bucket}/documents/${userId}/${request.sessionId}/${documentType}/${request.filename}`
@@ -288,7 +288,7 @@ describe('Documents Download API', () => {
     })
   })
 
-  describe('Frontend Integration (Authorization Header)', () => {
+  describe('Frontend Integration (Authorization Header)', async () => {
     /**
      * Tests verifying that frontend sends proper Authorization header
      * so BFF can extract userId correctly.
@@ -322,8 +322,8 @@ describe('Documents Download API', () => {
     })
   })
 
-  describe('Error Handling', () => {
-    it('should handle missing DOCUMENT_BUCKET gracefully', () => {
+  describe('Error Handling', async () => {
+    it('should handle missing DOCUMENT_BUCKET gracefully', async () => {
       vi.stubEnv('DOCUMENT_BUCKET', '')
 
       const bucket = process.env.DOCUMENT_BUCKET

--- a/chatbot-app/frontend/__tests__/api/memory.test.ts
+++ b/chatbot-app/frontend/__tests__/api/memory.test.ts
@@ -55,7 +55,7 @@ function createMockNextRequest(options: {
   }
 }
 
-describe('Memory Reset API', () => {
+describe('Memory Reset API', async () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset environment
@@ -64,30 +64,30 @@ describe('Memory Reset API', () => {
     vi.stubEnv('AWS_REGION', 'us-west-2')
   })
 
-  describe('Authentication', () => {
-    it('should extract user from request', () => {
+  describe('Authentication', async () => {
+    it('should extract user from request', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: 'test-user-123', email: 'test@example.com' })
 
       const request = createMockNextRequest()
-      const user = extractUserFromRequest(request as any)
+      const user = await extractUserFromRequest(request as any)
 
       expect(user.userId).toBe('test-user-123')
       expect(mockExtract).toHaveBeenCalledWith(request)
     })
 
-    it('should reject anonymous users', () => {
+    it('should reject anonymous users', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: 'anonymous' })
 
       const request = createMockNextRequest()
-      const user = extractUserFromRequest(request as any)
+      const user = await extractUserFromRequest(request as any)
 
       expect(user.userId).toBe('anonymous')
       // API should return 401 for anonymous users
     })
 
-    it('should handle authenticated users with Cognito token', () => {
+    it('should handle authenticated users with Cognito token', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({
         userId: '18c1e380-6021-700d-3572-40d05568f4ce',
@@ -100,56 +100,56 @@ describe('Memory Reset API', () => {
           authorization: 'Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...',
         },
       })
-      const user = extractUserFromRequest(request as any)
+      const user = await extractUserFromRequest(request as any)
 
       expect(user.userId).toBe('18c1e380-6021-700d-3572-40d05568f4ce')
     })
   })
 
-  describe('Namespace Filtering', () => {
-    it('should accept valid namespace: preferences', () => {
+  describe('Namespace Filtering', async () => {
+    it('should accept valid namespace: preferences', async () => {
       const validNamespaces = ['preferences', 'facts', 'summaries', 'all']
       const namespace = 'preferences'
 
       expect(validNamespaces).toContain(namespace)
     })
 
-    it('should accept valid namespace: facts', () => {
+    it('should accept valid namespace: facts', async () => {
       const validNamespaces = ['preferences', 'facts', 'summaries', 'all']
       const namespace = 'facts'
 
       expect(validNamespaces).toContain(namespace)
     })
 
-    it('should accept valid namespace: summaries', () => {
+    it('should accept valid namespace: summaries', async () => {
       const validNamespaces = ['preferences', 'facts', 'summaries', 'all']
       const namespace = 'summaries'
 
       expect(validNamespaces).toContain(namespace)
     })
 
-    it('should accept valid namespace: all', () => {
+    it('should accept valid namespace: all', async () => {
       const validNamespaces = ['preferences', 'facts', 'summaries', 'all']
       const namespace = 'all'
 
       expect(validNamespaces).toContain(namespace)
     })
 
-    it('should reject invalid namespace', () => {
+    it('should reject invalid namespace', async () => {
       const validNamespaces = ['preferences', 'facts', 'summaries', 'all']
       const invalidNamespace = 'invalid-namespace'
 
       expect(validNamespaces).not.toContain(invalidNamespace)
     })
 
-    it('should default to all when no namespace specified', () => {
+    it('should default to all when no namespace specified', async () => {
       const request = createMockNextRequest()
       const namespace = request.nextUrl.searchParams.get('namespace') || 'all'
 
       expect(namespace).toBe('all')
     })
 
-    it('should use specified namespace from query params', () => {
+    it('should use specified namespace from query params', async () => {
       const request = createMockNextRequest({
         searchParams: { namespace: 'preferences' },
       })
@@ -159,28 +159,28 @@ describe('Memory Reset API', () => {
     })
   })
 
-  describe('Namespace to Strategy Type Mapping', () => {
+  describe('Namespace to Strategy Type Mapping', async () => {
     const namespaceToType: Record<string, string> = {
       preferences: 'USER_PREFERENCE',
       facts: 'SEMANTIC',
       summaries: 'SUMMARIZATION',
     }
 
-    it('should map preferences to USER_PREFERENCE', () => {
+    it('should map preferences to USER_PREFERENCE', async () => {
       expect(namespaceToType['preferences']).toBe('USER_PREFERENCE')
     })
 
-    it('should map facts to SEMANTIC', () => {
+    it('should map facts to SEMANTIC', async () => {
       expect(namespaceToType['facts']).toBe('SEMANTIC')
     })
 
-    it('should map summaries to SUMMARIZATION', () => {
+    it('should map summaries to SUMMARIZATION', async () => {
       expect(namespaceToType['summaries']).toBe('SUMMARIZATION')
     })
   })
 
-  describe('Namespace Path Generation', () => {
-    it('should generate correct namespace path for user preferences', () => {
+  describe('Namespace Path Generation', async () => {
+    it('should generate correct namespace path for user preferences', async () => {
       const strategyId = 'user_preference_extraction-abc123'
       const userId = 'test-user-123'
       const namespace = `/strategies/${strategyId}/actors/${userId}`
@@ -188,7 +188,7 @@ describe('Memory Reset API', () => {
       expect(namespace).toBe('/strategies/user_preference_extraction-abc123/actors/test-user-123')
     })
 
-    it('should generate correct namespace path for semantic facts', () => {
+    it('should generate correct namespace path for semantic facts', async () => {
       const strategyId = 'semantic_fact_extraction-def456'
       const userId = 'test-user-123'
       const namespace = `/strategies/${strategyId}/actors/${userId}`
@@ -196,7 +196,7 @@ describe('Memory Reset API', () => {
       expect(namespace).toBe('/strategies/semantic_fact_extraction-def456/actors/test-user-123')
     })
 
-    it('should generate correct namespace path for summaries', () => {
+    it('should generate correct namespace path for summaries', async () => {
       const strategyId = 'conversation_summary-ghi789'
       const userId = 'test-user-123'
       const namespace = `/strategies/${strategyId}/actors/${userId}`
@@ -205,8 +205,8 @@ describe('Memory Reset API', () => {
     })
   })
 
-  describe('Local Mode Handling', () => {
-    it('should reject memory operations in local mode', () => {
+  describe('Local Mode Handling', async () => {
+    it('should reject memory operations in local mode', async () => {
       vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'true')
 
       const isLocal = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
@@ -215,7 +215,7 @@ describe('Memory Reset API', () => {
       // API should return 400 for local mode
     })
 
-    it('should allow memory operations in cloud mode', () => {
+    it('should allow memory operations in cloud mode', async () => {
       vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
 
       const isLocal = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
@@ -224,8 +224,8 @@ describe('Memory Reset API', () => {
     })
   })
 
-  describe('Memory ID Configuration', () => {
-    it('should use MEMORY_ID from environment', () => {
+  describe('Memory ID Configuration', async () => {
+    it('should use MEMORY_ID from environment', async () => {
       vi.stubEnv('MEMORY_ID', 'test-memory-id-123')
 
       const memoryId = process.env.MEMORY_ID
@@ -233,7 +233,7 @@ describe('Memory Reset API', () => {
       expect(memoryId).toBe('test-memory-id-123')
     })
 
-    it('should handle missing MEMORY_ID', () => {
+    it('should handle missing MEMORY_ID', async () => {
       vi.stubEnv('MEMORY_ID', '')
 
       const memoryId = process.env.MEMORY_ID
@@ -243,8 +243,8 @@ describe('Memory Reset API', () => {
     })
   })
 
-  describe('Response Format - GET (Stats)', () => {
-    it('should format stats response correctly', () => {
+  describe('Response Format - GET (Stats)', async () => {
+    it('should format stats response correctly', async () => {
       const mockStats = {
         USER_PREFERENCE: { count: 67, namespace: '/strategies/user_pref-xxx/actors/user-123' },
         SEMANTIC: { count: 142, namespace: '/strategies/semantic-xxx/actors/user-123' },
@@ -269,8 +269,8 @@ describe('Memory Reset API', () => {
     })
   })
 
-  describe('Response Format - DELETE (Reset)', () => {
-    it('should format delete response correctly', () => {
+  describe('Response Format - DELETE (Reset)', async () => {
+    it('should format delete response correctly', async () => {
       const deleteResults = {
         USER_PREFERENCE: 67,
         SEMANTIC: 142,
@@ -295,7 +295,7 @@ describe('Memory Reset API', () => {
       expect(response.message).toBe('Deleted 224 memory records')
     })
 
-    it('should format partial delete response for single namespace', () => {
+    it('should format partial delete response for single namespace', async () => {
       const deleteResults = {
         USER_PREFERENCE: 67,
       }
@@ -319,18 +319,18 @@ describe('Memory Reset API', () => {
     })
   })
 
-  describe('Error Handling', () => {
-    it('should handle missing authentication', () => {
+  describe('Error Handling', async () => {
+    it('should handle missing authentication', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: 'anonymous' })
 
-      const user = extractUserFromRequest({} as any)
+      const user = await extractUserFromRequest({} as any)
 
       expect(user.userId).toBe('anonymous')
       // Should return 401 Unauthorized
     })
 
-    it('should handle invalid namespace parameter', () => {
+    it('should handle invalid namespace parameter', async () => {
       const request = createMockNextRequest({
         searchParams: { namespace: 'invalid' },
       })
@@ -373,8 +373,8 @@ describe('Memory Reset API', () => {
     })
   })
 
-  describe('Strategy Info Caching', () => {
-    it('should cache strategy info with TTL', () => {
+  describe('Strategy Info Caching', async () => {
+    it('should cache strategy info with TTL', async () => {
       const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
       const cache = {
@@ -394,7 +394,7 @@ describe('Memory Reset API', () => {
       expect(cache.strategies).toHaveLength(3)
     })
 
-    it('should invalidate expired cache', () => {
+    it('should invalidate expired cache', async () => {
       const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
       const cache = {
@@ -408,7 +408,7 @@ describe('Memory Reset API', () => {
       expect(isCacheValid).toBe(false)
     })
 
-    it('should invalidate cache on memory ID change', () => {
+    it('should invalidate cache on memory ID change', async () => {
       const cache = {
         memoryId: 'old-memory-id',
         strategies: [],
@@ -423,9 +423,9 @@ describe('Memory Reset API', () => {
   })
 })
 
-describe('Memory Record Operations', () => {
-  describe('List Records', () => {
-    it('should paginate through all records', () => {
+describe('Memory Record Operations', async () => {
+  describe('List Records', async () => {
+    it('should paginate through all records', async () => {
       // Simulate pagination logic
       const pages = [
         { records: Array(100).fill({ memoryRecordId: 'rec' }), nextToken: 'token1' },
@@ -442,8 +442,8 @@ describe('Memory Record Operations', () => {
     })
   })
 
-  describe('Delete Records', () => {
-    it('should delete each record individually', () => {
+  describe('Delete Records', async () => {
+    it('should delete each record individually', async () => {
       const records = [
         { memoryRecordId: 'rec-1' },
         { memoryRecordId: 'rec-2' },
@@ -460,7 +460,7 @@ describe('Memory Record Operations', () => {
       expect(deletedCount).toBe(3)
     })
 
-    it('should handle deletion failures gracefully', () => {
+    it('should handle deletion failures gracefully', async () => {
       const records = [
         { memoryRecordId: 'rec-1', deleteSuccess: true },
         { memoryRecordId: 'rec-2', deleteSuccess: false }, // Simulated failure

--- a/chatbot-app/frontend/__tests__/api/session.test.ts
+++ b/chatbot-app/frontend/__tests__/api/session.test.ts
@@ -57,14 +57,14 @@ function createMockNextRequest(options: {
   }
 }
 
-describe('Session List API', () => {
+describe('Session List API', async () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset environment
     vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
   })
 
-  describe('Authentication', () => {
+  describe('Authentication', async () => {
     it('should extract user from request', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: 'test-user-123' })
@@ -74,7 +74,7 @@ describe('Session List API', () => {
 
       // Simulate what the route handler does
       const request = createMockNextRequest()
-      const user = extractUserFromRequest(request as any)
+      const user = await extractUserFromRequest(request as any)
 
       expect(user.userId).toBe('test-user-123')
       expect(mockExtract).toHaveBeenCalledWith(request)
@@ -85,13 +85,13 @@ describe('Session List API', () => {
       mockExtract.mockReturnValue({ userId: 'anonymous' })
 
       const request = createMockNextRequest()
-      const user = extractUserFromRequest(request as any)
+      const user = await extractUserFromRequest(request as any)
 
       expect(user.userId).toBe('anonymous')
     })
   })
 
-  describe('Session Retrieval', () => {
+  describe('Session Retrieval', async () => {
     it('should call DynamoDB for authenticated users in AWS mode', async () => {
       vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
 
@@ -159,8 +159,8 @@ describe('Session List API', () => {
     })
   })
 
-  describe('Response Formatting', () => {
-    it('should format session response correctly', () => {
+  describe('Response Formatting', async () => {
+    it('should format session response correctly', async () => {
       const rawSession = {
         sessionId: 'sess-123',
         title: 'My Chat Session',
@@ -201,7 +201,7 @@ describe('Session List API', () => {
       expect(formattedSession).not.toHaveProperty('internalData')
     })
 
-    it('should handle missing optional fields', () => {
+    it('should handle missing optional fields', async () => {
       const rawSession = {
         sessionId: 'sess-456',
         title: 'Minimal Session',
@@ -227,7 +227,7 @@ describe('Session List API', () => {
     })
   })
 
-  describe('Error Handling', () => {
+  describe('Error Handling', async () => {
     it('should handle DynamoDB errors gracefully', async () => {
       const mockGetSessions = getDynamoSessions as ReturnType<typeof vi.fn>
       mockGetSessions.mockRejectedValue(new Error('DynamoDB connection failed'))
@@ -235,7 +235,7 @@ describe('Session List API', () => {
       await expect(getDynamoSessions('user-123', 20, undefined)).rejects.toThrow('DynamoDB connection failed')
     })
 
-    it('should return empty array for anonymous users in AWS mode', () => {
+    it('should return empty array for anonymous users in AWS mode', async () => {
       vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
 
       const userId = 'anonymous'
@@ -252,13 +252,13 @@ describe('Session List API', () => {
   })
 })
 
-describe('Session Delete API', () => {
+describe('Session Delete API', async () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  describe('Delete Operation', () => {
-    it('should require session ID', () => {
+  describe('Delete Operation', async () => {
+    it('should require session ID', async () => {
       // Simulate validation
       const sessionId = undefined
 

--- a/chatbot-app/frontend/__tests__/api/workspace.test.ts
+++ b/chatbot-app/frontend/__tests__/api/workspace.test.ts
@@ -55,30 +55,30 @@ function createMockNextRequest(options: {
   }
 }
 
-describe('Workspace Files API', () => {
+describe('Workspace Files API', async () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubEnv('DOCUMENT_BUCKET', 'test-bucket')
   })
 
-  describe('Tool to Document Type Mapping', () => {
+  describe('Tool to Document Type Mapping', async () => {
     // Uses centralized TOOL_TO_DOC_TYPE from @/config/document-tools
 
-    it('should map Word tool names to word document type', () => {
+    it('should map Word tool names to word document type', async () => {
       expect(TOOL_TO_DOC_TYPE['create_word_document']).toBe('word')
       expect(TOOL_TO_DOC_TYPE['modify_word_document']).toBe('word')
       expect(TOOL_TO_DOC_TYPE['read_word_document']).toBe('word')
       expect(TOOL_TO_DOC_TYPE['list_my_word_documents']).toBe('word')
     })
 
-    it('should map Excel tool names to excel document type', () => {
+    it('should map Excel tool names to excel document type', async () => {
       expect(TOOL_TO_DOC_TYPE['create_excel_spreadsheet']).toBe('excel')
       expect(TOOL_TO_DOC_TYPE['modify_excel_spreadsheet']).toBe('excel')
       expect(TOOL_TO_DOC_TYPE['read_excel_spreadsheet']).toBe('excel')
       expect(TOOL_TO_DOC_TYPE['list_my_excel_spreadsheets']).toBe('excel')
     })
 
-    it('should map PowerPoint tool names to powerpoint document type', () => {
+    it('should map PowerPoint tool names to powerpoint document type', async () => {
       expect(TOOL_TO_DOC_TYPE['create_presentation']).toBe('powerpoint')
       expect(TOOL_TO_DOC_TYPE['update_slide_content']).toBe('powerpoint')
       expect(TOOL_TO_DOC_TYPE['add_slide']).toBe('powerpoint')
@@ -86,14 +86,14 @@ describe('Workspace Files API', () => {
       expect(TOOL_TO_DOC_TYPE['move_slide']).toBe('powerpoint')
     })
 
-    it('should return undefined for unknown tools', () => {
+    it('should return undefined for unknown tools', async () => {
       expect(TOOL_TO_DOC_TYPE['unknown_tool']).toBeUndefined()
       expect(TOOL_TO_DOC_TYPE['send_email']).toBeUndefined()
     })
   })
 
-  describe('Request Validation', () => {
-    it('should extract document type from toolName parameter', () => {
+  describe('Request Validation', async () => {
+    it('should extract document type from toolName parameter', async () => {
       const request = createMockNextRequest({
         searchParams: { toolName: 'create_word_document' }
       })
@@ -102,7 +102,7 @@ describe('Workspace Files API', () => {
       expect(toolName).toBe('create_word_document')
     })
 
-    it('should extract document type from docType parameter', () => {
+    it('should extract document type from docType parameter', async () => {
       const request = createMockNextRequest({
         searchParams: { docType: 'word' }
       })
@@ -111,7 +111,7 @@ describe('Workspace Files API', () => {
       expect(docType).toBe('word')
     })
 
-    it('should prefer docType over toolName when both provided', () => {
+    it('should prefer docType over toolName when both provided', async () => {
       const request = createMockNextRequest({
         searchParams: {
           toolName: 'create_excel_spreadsheet',
@@ -127,7 +127,7 @@ describe('Workspace Files API', () => {
       expect(finalDocType).toBe('word')
     })
 
-    it('should require either toolName or docType', () => {
+    it('should require either toolName or docType', async () => {
       const request = createMockNextRequest({
         searchParams: {} // No params
       })
@@ -144,19 +144,19 @@ describe('Workspace Files API', () => {
     })
   })
 
-  describe('Authentication', () => {
-    it('should extract user from request', () => {
+  describe('Authentication', async () => {
+    it('should extract user from request', async () => {
       const mockExtract = extractUserFromRequest as ReturnType<typeof vi.fn>
       mockExtract.mockReturnValue({ userId: 'user-123' })
 
       const request = createMockNextRequest({ searchParams: { docType: 'word' } })
-      const user = extractUserFromRequest(request as any)
+      const user = await extractUserFromRequest(request as any)
 
       expect(user.userId).toBe('user-123')
       expect(mockExtract).toHaveBeenCalledWith(request)
     })
 
-    it('should extract session ID from request', () => {
+    it('should extract session ID from request', async () => {
       const mockGetSession = getSessionId as ReturnType<typeof vi.fn>
       mockGetSession.mockReturnValue({ sessionId: 'session-456' })
 
@@ -166,7 +166,7 @@ describe('Workspace Files API', () => {
       expect(sessionId).toBe('session-456')
     })
 
-    it('should require session ID', () => {
+    it('should require session ID', async () => {
       const mockGetSession = getSessionId as ReturnType<typeof vi.fn>
       mockGetSession.mockReturnValue({ sessionId: null })
 
@@ -177,8 +177,8 @@ describe('Workspace Files API', () => {
     })
   })
 
-  describe('S3 Path Construction', () => {
-    it('should construct correct S3 prefix for word documents', () => {
+  describe('S3 Path Construction', async () => {
+    it('should construct correct S3 prefix for word documents', async () => {
       const userId = 'user-123'
       const sessionId = 'session-456'
       const docType = 'word'
@@ -188,7 +188,7 @@ describe('Workspace Files API', () => {
       expect(s3Prefix).toBe('documents/user-123/session-456/word/')
     })
 
-    it('should construct correct S3 prefix for excel documents', () => {
+    it('should construct correct S3 prefix for excel documents', async () => {
       const userId = 'user-abc'
       const sessionId = 'session-xyz'
       const docType = 'excel'
@@ -198,7 +198,7 @@ describe('Workspace Files API', () => {
       expect(s3Prefix).toBe('documents/user-abc/session-xyz/excel/')
     })
 
-    it('should construct correct S3 prefix for powerpoint documents', () => {
+    it('should construct correct S3 prefix for powerpoint documents', async () => {
       const userId = 'test-user'
       const sessionId = 'test-session'
       const docType = 'powerpoint'
@@ -209,8 +209,8 @@ describe('Workspace Files API', () => {
     })
   })
 
-  describe('Response Formatting', () => {
-    it('should format file response correctly', () => {
+  describe('Response Formatting', async () => {
+    it('should format file response correctly', async () => {
       // Mock S3 object
       const s3Object = {
         Key: 'documents/user-123/session-456/word/report.docx',
@@ -239,14 +239,14 @@ describe('Workspace Files API', () => {
       })
     })
 
-    it('should map doc type to correct tool_type format using DOC_TYPE_TO_TOOL_TYPE', () => {
+    it('should map doc type to correct tool_type format using DOC_TYPE_TO_TOOL_TYPE', async () => {
       // Uses centralized DOC_TYPE_TO_TOOL_TYPE from @/config/document-tools
       expect(DOC_TYPE_TO_TOOL_TYPE['word']).toBe('word_document')
       expect(DOC_TYPE_TO_TOOL_TYPE['excel']).toBe('excel_spreadsheet')
       expect(DOC_TYPE_TO_TOOL_TYPE['powerpoint']).toBe('powerpoint_presentation')
     })
 
-    it('should filter out hidden files', () => {
+    it('should filter out hidden files', async () => {
       const files = [
         { filename: 'report.docx', Key: 'path/report.docx' },
         { filename: '.template_metadata', Key: 'path/.template_metadata' },
@@ -260,7 +260,7 @@ describe('Workspace Files API', () => {
       expect(filteredFiles.map(f => f.filename)).toEqual(['report.docx', 'data.xlsx'])
     })
 
-    it('should sort files by last_modified descending (most recent first)', () => {
+    it('should sort files by last_modified descending (most recent first)', async () => {
       const files = [
         { filename: 'old.docx', last_modified: '2024-01-10T10:00:00Z' },
         { filename: 'newest.docx', last_modified: '2024-01-15T15:00:00Z' },
@@ -279,8 +279,8 @@ describe('Workspace Files API', () => {
     })
   })
 
-  describe('Error Handling', () => {
-    it('should handle missing DOCUMENT_BUCKET', () => {
+  describe('Error Handling', async () => {
+    it('should handle missing DOCUMENT_BUCKET', async () => {
       vi.stubEnv('DOCUMENT_BUCKET', '')
 
       const bucket = process.env.DOCUMENT_BUCKET
@@ -289,7 +289,7 @@ describe('Workspace Files API', () => {
       expect(bucket).toBe('')
     })
 
-    it('should handle S3 list errors gracefully', () => {
+    it('should handle S3 list errors gracefully', async () => {
       // Simulate S3 error scenario
       const s3Error = new Error('Access Denied')
 
@@ -297,7 +297,7 @@ describe('Workspace Files API', () => {
       expect(s3Error.message).toBe('Access Denied')
     })
 
-    it('should handle empty S3 response', () => {
+    it('should handle empty S3 response', async () => {
       const s3Response = {
         Contents: undefined
       }
@@ -310,40 +310,40 @@ describe('Workspace Files API', () => {
   })
 })
 
-describe('Workspace Download API', () => {
-  describe('Path to S3 key mapping (toS3Key)', () => {
+describe('Workspace Download API', async () => {
+  describe('Path to S3 key mapping (toS3Key)', async () => {
     const userId = 'user-123'
     const sessionId = 'session-456'
 
-    it('should map code-agent paths to code-agent-workspace prefix', () => {
+    it('should map code-agent paths to code-agent-workspace prefix', async () => {
       const path = 'code-agent/output.csv'
       const expected = `code-agent-workspace/${userId}/${sessionId}/output.csv`
       const result = toS3Key(userId, sessionId, path)
       expect(result).toBe(expected)
     })
 
-    it('should map code-interpreter paths', () => {
+    it('should map code-interpreter paths', async () => {
       const path = 'code-interpreter/chart.png'
       const expected = `code-interpreter-workspace/${userId}/${sessionId}/chart.png`
       const result = toS3Key(userId, sessionId, path)
       expect(result).toBe(expected)
     })
 
-    it('should map documents paths', () => {
+    it('should map documents paths', async () => {
       const path = 'documents/word/report.docx'
       const expected = `documents/${userId}/${sessionId}/word/report.docx`
       const result = toS3Key(userId, sessionId, path)
       expect(result).toBe(expected)
     })
 
-    it('should default to documents namespace for unrecognized paths', () => {
+    it('should default to documents namespace for unrecognized paths', async () => {
       const path = 'random/file.txt'
       const expected = `documents/${userId}/${sessionId}/random/file.txt`
       const result = toS3Key(userId, sessionId, path)
       expect(result).toBe(expected)
     })
 
-    it('should strip leading slash', () => {
+    it('should strip leading slash', async () => {
       const path = '/code-agent/file.json'
       const expected = `code-agent-workspace/${userId}/${sessionId}/file.json`
       const result = toS3Key(userId, sessionId, path)
@@ -351,34 +351,34 @@ describe('Workspace Download API', () => {
     })
   })
 
-  describe('Request validation', () => {
-    it('should require path and sessionId in body', () => {
+  describe('Request validation', async () => {
+    it('should require path and sessionId in body', async () => {
       const body = { path: 'code-agent/file.csv', sessionId: 'sess-123' }
       expect(body.path).toBeTruthy()
       expect(body.sessionId).toBeTruthy()
     })
 
-    it('should reject missing path', () => {
+    it('should reject missing path', async () => {
       const body = { sessionId: 'sess-123' } as any
       const isValid = !!(body.path && body.sessionId)
       expect(isValid).toBe(false)
     })
 
-    it('should reject missing sessionId', () => {
+    it('should reject missing sessionId', async () => {
       const body = { path: 'code-agent/file.csv' } as any
       const isValid = !!(body.path && body.sessionId)
       expect(isValid).toBe(false)
     })
   })
 
-  describe('Filename extraction', () => {
-    it('should extract filename from path', () => {
+  describe('Filename extraction', async () => {
+    it('should extract filename from path', async () => {
       const path = 'code-agent/subdir/output.csv'
       const filename = path.split('/').pop() || 'download'
       expect(filename).toBe('output.csv')
     })
 
-    it('should fallback to download when path ends with slash', () => {
+    it('should fallback to download when path ends with slash', async () => {
       const path = 'code-agent/'
       const filename = path.split('/').pop() || 'download'
       expect(filename).toBe('download')
@@ -403,12 +403,12 @@ function toS3Key(userId: string, sessionId: string, path: string): string {
   return `documents/${userId}/${sessionId}/${cleanPath}`
 }
 
-describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
+describe('Frontend Workspace File Fetching (useStreamEvents)', async () => {
   // Tests for the frontend logic that fetches workspace files
   // Uses centralized TOOL_TO_DOC_TYPE from @/config/document-tools
 
-  describe('TOOL_TO_DOC_TYPE mapping', () => {
-    it('should detect word tools', () => {
+  describe('TOOL_TO_DOC_TYPE mapping', async () => {
+    it('should detect word tools', async () => {
       const toolNames = ['create_word_document', 'modify_word_document']
       const usedDocTypes = new Set<string>()
 
@@ -421,7 +421,7 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
       expect(usedDocTypes.size).toBe(1)
     })
 
-    it('should detect multiple doc types from different tools', () => {
+    it('should detect multiple doc types from different tools', async () => {
       const toolNames = ['create_word_document', 'create_excel_spreadsheet', 'create_presentation']
       const usedDocTypes = new Set<string>()
 
@@ -436,7 +436,7 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
       expect(usedDocTypes.has('powerpoint')).toBe(true)
     })
 
-    it('should ignore non-document tools', () => {
+    it('should ignore non-document tools', async () => {
       const toolNames = ['web_search', 'calculator', 'create_word_document']
       const usedDocTypes = new Set<string>()
 
@@ -449,24 +449,24 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
     })
   })
 
-  describe('DOC_TYPE_TO_TOOL_TYPE mapping', () => {
+  describe('DOC_TYPE_TO_TOOL_TYPE mapping', async () => {
     // Uses centralized DOC_TYPE_TO_TOOL_TYPE from @/config/document-tools
 
-    it('should map word to word_document', () => {
+    it('should map word to word_document', async () => {
       expect(DOC_TYPE_TO_TOOL_TYPE['word']).toBe('word_document')
     })
 
-    it('should map excel to excel_spreadsheet', () => {
+    it('should map excel to excel_spreadsheet', async () => {
       expect(DOC_TYPE_TO_TOOL_TYPE['excel']).toBe('excel_spreadsheet')
     })
 
-    it('should map powerpoint to powerpoint_presentation', () => {
+    it('should map powerpoint to powerpoint_presentation', async () => {
       expect(DOC_TYPE_TO_TOOL_TYPE['powerpoint']).toBe('powerpoint_presentation')
     })
   })
 
-  describe('Workspace file integration', () => {
-    it('should transform API response for DynamoDB storage with user_id', () => {
+  describe('Workspace file integration', async () => {
+    it('should transform API response for DynamoDB storage with user_id', async () => {
       // Simulate API response - BFF returns userId which is needed for S3 path
       const apiResponse = {
         files: [
@@ -489,7 +489,7 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
       ])
     })
 
-    it('should handle empty API response', () => {
+    it('should handle empty API response', async () => {
       const apiResponse = { files: [] }
 
       const documents = apiResponse.files || []
@@ -497,7 +497,7 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
       expect(documents).toEqual([])
     })
 
-    it('should handle API error gracefully', () => {
+    it('should handle API error gracefully', async () => {
       // Simulate error scenario
       let workspaceDocuments: Array<{ filename: string; tool_type: string }> = []
 
@@ -512,7 +512,7 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
     })
   })
 
-  describe('Workspace API fetch headers (Integration)', () => {
+  describe('Workspace API fetch headers (Integration)', async () => {
     /**
      * These tests verify that the frontend correctly includes authentication
      * headers when calling /api/workspace/files. Without proper headers:
@@ -650,7 +650,7 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
       expect(data.sessionId).toBe(sessionId)
     })
 
-    it('should construct correct headers object for workspace fetch', () => {
+    it('should construct correct headers object for workspace fetch', async () => {
       /**
        * Test the header construction logic that should be used in useStreamEvents.
        * This verifies the fix pattern.
@@ -674,7 +674,7 @@ describe('Frontend Workspace File Fetching (useStreamEvents)', () => {
       })
     })
 
-    it('should handle missing auth token gracefully (still include session ID)', () => {
+    it('should handle missing auth token gracefully (still include session ID)', async () => {
       /**
        * For anonymous users, auth token may not be available.
        * Session ID should still be included.

--- a/chatbot-app/frontend/__tests__/lib/auth-utils.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/auth-utils.test.ts
@@ -8,6 +8,14 @@
  * - Error handling for invalid tokens
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const verifyJwt = vi.hoisted(() => vi.fn())
+vi.mock('aws-jwt-verify', () => ({
+  CognitoJwtVerifier: {
+    create: () => ({ verify: verifyJwt }),
+  },
+}))
+
 import { extractUserFromRequest, getSessionId } from '@/lib/auth-utils'
 
 // Helper to create a mock JWT token
@@ -27,47 +35,87 @@ function createMockRequest(headers: Record<string, string> = {}): Request {
   } as unknown as Request
 }
 
-describe('extractUserFromRequest', () => {
+describe('extractUserFromRequest', async () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubEnv('NEXT_PUBLIC_COGNITO_USER_POOL_ID', 'us-east-1_test')
+    vi.stubEnv('NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID', 'test-client')
+    verifyJwt.mockImplementation(async (token: string) => {
+      const parts = token.split('.')
+      if (parts.length !== 3) throw new Error('Invalid JWT')
+      return JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'))
+    })
   })
 
-  describe('Authorization Header Handling', () => {
-    it('should return anonymous when no Authorization header', () => {
+  describe('Authorization Header Handling', async () => {
+    it('should return anonymous when no Authorization header', async () => {
       const request = createMockRequest({})
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('anonymous')
     })
 
-    it('should return anonymous when Authorization header is empty', () => {
+    it('should return anonymous when Authorization header is empty', async () => {
       const request = createMockRequest({ authorization: '' })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('anonymous')
     })
 
-    it('should return anonymous when Authorization header does not start with Bearer', () => {
+    it('should return anonymous when Authorization header does not start with Bearer', async () => {
       const request = createMockRequest({ authorization: 'Basic abc123' })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('anonymous')
     })
 
-    it('should return anonymous for malformed Bearer token', () => {
+    it('should return anonymous for malformed Bearer token', async () => {
       const request = createMockRequest({ authorization: 'Bearer ' })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('anonymous')
     })
   })
 
-  describe('JWT Token Parsing', () => {
-    it('should extract userId from Cognito sub claim', () => {
+  describe('Signature Verification', async () => {
+    it('should return anonymous when the verifier rejects the signature', async () => {
+      verifyJwt.mockRejectedValueOnce(new Error('Invalid signature'))
+      const token = createMockJWT({ sub: 'attacker-forged-sub' })
+      const request = createMockRequest({ authorization: `Bearer ${token}` })
+
+      const result = await extractUserFromRequest(request)
+
+      expect(result.userId).toBe('anonymous')
+    })
+
+    it('should verify the token rather than trusting its payload', async () => {
+      const token = createMockJWT({ sub: 'user-123-uuid' })
+      const request = createMockRequest({ authorization: `Bearer ${token}` })
+
+      await extractUserFromRequest(request)
+
+      expect(verifyJwt).toHaveBeenCalledWith(token)
+    })
+
+    it('should return anonymous when Cognito env vars are missing', async () => {
+      vi.stubEnv('NEXT_PUBLIC_COGNITO_USER_POOL_ID', '')
+      vi.stubEnv('NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID', '')
+      const token = createMockJWT({ sub: 'user-123-uuid' })
+      const request = createMockRequest({ authorization: `Bearer ${token}` })
+
+      const result = await extractUserFromRequest(request)
+
+      expect(result.userId).toBe('anonymous')
+      expect(verifyJwt).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('JWT Token Parsing', async () => {
+    it('should extract userId from Cognito sub claim', async () => {
       const token = createMockJWT({
         sub: 'user-123-uuid',
         email: 'test@example.com',
@@ -75,46 +123,46 @@ describe('extractUserFromRequest', () => {
       })
       const request = createMockRequest({ authorization: `Bearer ${token}` })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('user-123-uuid')
       expect(result.email).toBe('test@example.com')
       expect(result.username).toBe('testuser')
     })
 
-    it('should fallback to cognito:username when sub is missing', () => {
+    it('should fallback to cognito:username when sub is missing', async () => {
       const token = createMockJWT({
         'cognito:username': 'fallback-user',
         email: 'fallback@example.com'
       })
       const request = createMockRequest({ authorization: `Bearer ${token}` })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('fallback-user')
     })
 
-    it('should return anonymous for invalid JWT format (not 3 parts)', () => {
+    it('should return anonymous for invalid JWT format (not 3 parts)', async () => {
       const request = createMockRequest({ authorization: 'Bearer invalid.token' })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('anonymous')
     })
 
-    it('should return anonymous for invalid base64 payload', () => {
+    it('should return anonymous for invalid base64 payload', async () => {
       const request = createMockRequest({ authorization: 'Bearer header.!!!invalid!!!.signature' })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('anonymous')
     })
 
-    it('should handle token with only sub claim', () => {
+    it('should handle token with only sub claim', async () => {
       const token = createMockJWT({ sub: 'sub-only-user' })
       const request = createMockRequest({ authorization: `Bearer ${token}` })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('sub-only-user')
       expect(result.email).toBeUndefined()
@@ -122,24 +170,24 @@ describe('extractUserFromRequest', () => {
     })
   })
 
-  describe('Edge Cases', () => {
-    it('should handle empty payload', () => {
+  describe('Edge Cases', async () => {
+    it('should handle empty payload', async () => {
       const token = createMockJWT({})
       const request = createMockRequest({ authorization: `Bearer ${token}` })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('anonymous')
     })
 
-    it('should handle token with special characters in claims', () => {
+    it('should handle token with special characters in claims', async () => {
       const token = createMockJWT({
         sub: 'user-with-special-chars-äöü',
         email: 'test+special@example.com'
       })
       const request = createMockRequest({ authorization: `Bearer ${token}` })
 
-      const result = extractUserFromRequest(request)
+      const result = await extractUserFromRequest(request)
 
       expect(result.userId).toBe('user-with-special-chars-äöü')
       expect(result.email).toBe('test+special@example.com')
@@ -147,7 +195,7 @@ describe('extractUserFromRequest', () => {
   })
 })
 
-describe('getSessionId', () => {
+describe('getSessionId', async () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Mock crypto.randomUUID
@@ -156,8 +204,8 @@ describe('getSessionId', () => {
     })
   })
 
-  describe('Existing Session ID', () => {
-    it('should return existing session ID from header', () => {
+  describe('Existing Session ID', async () => {
+    it('should return existing session ID from header', async () => {
       const existingSessionId = 'existing-session-id-12345678901234567890'
       const request = createMockRequest({ 'x-session-id': existingSessionId })
 
@@ -167,7 +215,7 @@ describe('getSessionId', () => {
       // Note: isNew is determined by ensureSessionExists, not getSessionId
     })
 
-    it('should not generate new ID when header exists', () => {
+    it('should not generate new ID when header exists', async () => {
       const request = createMockRequest({ 'x-session-id': 'existing-id' })
 
       const result = getSessionId(request, 'user-123')
@@ -176,8 +224,8 @@ describe('getSessionId', () => {
     })
   })
 
-  describe('New Session ID Generation', () => {
-    it('should generate new session ID when header is missing', () => {
+  describe('New Session ID Generation', async () => {
+    it('should generate new session ID when header is missing', async () => {
       const request = createMockRequest({})
 
       const result = getSessionId(request, 'user-123')
@@ -186,7 +234,7 @@ describe('getSessionId', () => {
       expect(result.sessionId).toBeTruthy()
     })
 
-    it('should generate session ID >= 33 characters', () => {
+    it('should generate session ID >= 33 characters', async () => {
       const request = createMockRequest({})
 
       const result = getSessionId(request, 'user-123')
@@ -194,7 +242,7 @@ describe('getSessionId', () => {
       expect(result.sessionId.length).toBeGreaterThanOrEqual(33)
     })
 
-    it('should include user prefix for authenticated users', () => {
+    it('should include user prefix for authenticated users', async () => {
       const request = createMockRequest({})
 
       const result = getSessionId(request, 'user-123-full-id')
@@ -203,7 +251,7 @@ describe('getSessionId', () => {
       expect(result.sessionId.startsWith('user-123')).toBe(true)
     })
 
-    it('should use anon0000 prefix for anonymous users', () => {
+    it('should use anon0000 prefix for anonymous users', async () => {
       const request = createMockRequest({})
 
       const result = getSessionId(request, 'anonymous')
@@ -211,7 +259,7 @@ describe('getSessionId', () => {
       expect(result.sessionId.startsWith('anon0000')).toBe(true)
     })
 
-    it('should include timestamp in session ID', () => {
+    it('should include timestamp in session ID', async () => {
       const request = createMockRequest({})
       const beforeTime = Date.now()
 
@@ -226,7 +274,7 @@ describe('getSessionId', () => {
       expect(timestamp).toBeGreaterThanOrEqual(beforeTime - 1000)
     })
 
-    it('should include random UUID in session ID', () => {
+    it('should include random UUID in session ID', async () => {
       const request = createMockRequest({})
 
       const result = getSessionId(request, 'user-123')
@@ -236,8 +284,8 @@ describe('getSessionId', () => {
     })
   })
 
-  describe('Session ID Format Validation', () => {
-    it('should generate consistent format', () => {
+  describe('Session ID Format Validation', async () => {
+    it('should generate consistent format', async () => {
       const request = createMockRequest({})
 
       const result = getSessionId(request, 'testuser')

--- a/chatbot-app/frontend/next-env.d.ts
+++ b/chatbot-app/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/chatbot-app/frontend/package-lock.json
+++ b/chatbot-app/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "@smithy/signature-v4": "^4.0.0",
         "@tailwindcss/typography": "^0.5.20",
         "aws-amplify": "^6.18.0",
+        "aws-jwt-verify": "^5.2.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "cmdk": "^1.1.1",
@@ -289,7 +290,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.4.tgz",
       "integrity": "sha512-RjJABL3lVByNcqeCeBuGWecfCtRS0paFdVyQ0nbA6XSJNYaoHT5J57WyGY8cUWmaKx2YNY0poFtuKaGXfRxjKg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "^3.973.6",
@@ -680,7 +680,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1076.0.tgz",
       "integrity": "sha512-3qj40tOjHIjOP3EYgP2yM5Hi/ZKZfDhPbtay2QEpAe3ffgSaHWPedzj41B6WH/dopn5D6vhdzzU/YNh6D3hiSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1346,7 +1345,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1802,7 +1800,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1851,7 +1848,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -6993,6 +6989,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7013,6 +7010,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -7088,7 +7086,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.162",
@@ -7295,7 +7294,6 @@
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -7325,7 +7323,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7336,7 +7333,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7412,7 +7408,6 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -8075,7 +8070,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8397,7 +8391,6 @@
       "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.18.0.tgz",
       "integrity": "sha512-a+dRKC+OBI94BBGfKVLK7e9hAqbG1mfkpRYDXh45HUs1CUwxDOBjzglXOfOvnzL0zL+mUfbvYpmYzsumGflk0g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/analytics": "7.0.94",
         "@aws-amplify/api": "6.3.27",
@@ -8439,6 +8432,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-5.2.1.tgz",
+      "integrity": "sha512-J+buA4M+qvQDk58WXFBLkDodkEX3DDL1ac5XFQPW3opxAsaLXYu5hYnlSHsaBRDBUXBAn695kE/cw/mdyJKwJg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/axe-core": {
@@ -8601,7 +8603,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -8857,7 +8858,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -9168,7 +9168,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9551,7 +9550,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9918,7 +9916,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.11",
@@ -10278,7 +10277,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10448,7 +10446,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11685,7 +11682,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -12336,7 +12332,6 @@
       "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.11.0.tgz",
       "integrity": "sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -13054,6 +13049,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15754,7 +15750,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15780,6 +15775,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15795,6 +15791,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15807,7 +15804,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prism-react-renderer": {
       "version": "2.4.1",
@@ -15921,7 +15919,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15931,7 +15928,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15968,8 +15964,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -16003,7 +15998,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -16182,8 +16176,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -17312,8 +17305,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
       "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -17416,7 +17408,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17702,7 +17693,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18110,7 +18100,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18227,7 +18216,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18688,7 +18676,6 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"

--- a/chatbot-app/frontend/package.json
+++ b/chatbot-app/frontend/package.json
@@ -44,6 +44,7 @@
     "@smithy/signature-v4": "^4.0.0",
     "@tailwindcss/typography": "^0.5.20",
     "aws-amplify": "^6.18.0",
+    "aws-jwt-verify": "^5.2.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "cmdk": "^1.1.1",

--- a/chatbot-app/frontend/src/app/api/code-agent/workspace-download/route.ts
+++ b/chatbot-app/frontend/src/app/api/code-agent/workspace-download/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'sessionId is required' }, { status: 400 })
     }
 
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const bucket = await getDocumentBucket()

--- a/chatbot-app/frontend/src/app/api/conversation/history/route.ts
+++ b/chatbot-app/frontend/src/app/api/conversation/history/route.ts
@@ -74,7 +74,7 @@ async function initializeAwsClients() {
 export async function GET(request: NextRequest) {
   try {
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Get query parameters

--- a/chatbot-app/frontend/src/app/api/documents/download/route.ts
+++ b/chatbot-app/frontend/src/app/api/documents/download/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Extract userId from Authorization header (JWT token)
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Get document bucket from environment or Parameter Store

--- a/chatbot-app/frontend/src/app/api/memory/reset/route.ts
+++ b/chatbot-app/frontend/src/app/api/memory/reset/route.ts
@@ -219,7 +219,7 @@ export async function DELETE(request: NextRequest) {
     }
 
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     if (userId === 'anonymous') {
@@ -338,7 +338,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     if (userId === 'anonymous') {

--- a/chatbot-app/frontend/src/app/api/model/config/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/config/route.ts
@@ -14,7 +14,7 @@ export const runtime = 'nodejs'
 export async function GET(request: NextRequest) {
   try {
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Default configuration

--- a/chatbot-app/frontend/src/app/api/model/config/update/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/config/update/route.ts
@@ -14,7 +14,7 @@ const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 export async function POST(request: NextRequest) {
   try {
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const body = await request.json()

--- a/chatbot-app/frontend/src/app/api/session/[sessionId]/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/[sessionId]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
 ) {
   try {
     const { sessionId } = await params
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     console.log(`[API] Getting session ${sessionId} for user ${userId}`)
@@ -78,7 +78,7 @@ export async function PUT(
 ) {
   try {
     const { sessionId } = await params
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const body = await request.json()
@@ -163,7 +163,7 @@ export async function POST(
 ) {
   try {
     const { sessionId } = await params
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const body = await request.json()
@@ -235,7 +235,7 @@ export async function DELETE(
 ) {
   try {
     const { sessionId } = await params
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     console.log(`[API] Deleting session ${sessionId} for user ${userId}`)

--- a/chatbot-app/frontend/src/app/api/session/compact/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/compact/route.ts
@@ -36,7 +36,7 @@ async function getMemoryId(): Promise<string | null> {
 /** List all eventIds for the session (used to capture snapshot before sending summary) */
 export async function GET(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const { searchParams } = new URL(request.url)
@@ -91,7 +91,7 @@ export async function GET(request: NextRequest) {
 /** Delete the specified eventIds (or all events if eventIds not provided) */
 export async function POST(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const { sessionId, eventIds } = await request.json()

--- a/chatbot-app/frontend/src/app/api/session/delete/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/delete/route.ts
@@ -12,7 +12,7 @@ export const runtime = 'nodejs'
 export async function DELETE(request: NextRequest) {
   try {
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Get session ID from query parameter

--- a/chatbot-app/frontend/src/app/api/session/list/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/list/route.ts
@@ -13,7 +13,7 @@ export const runtime = 'nodejs'
 export async function GET(request: NextRequest) {
   try {
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Get query parameters

--- a/chatbot-app/frontend/src/app/api/session/new/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/new/route.ts
@@ -13,7 +13,7 @@ export const runtime = 'nodejs'
 export async function POST(request: NextRequest) {
   try {
     // Extract user from Cognito JWT token
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Generate new session ID

--- a/chatbot-app/frontend/src/app/api/session/truncate/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/truncate/route.ts
@@ -38,7 +38,7 @@ async function getMemoryId(): Promise<string | null> {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const { sessionId, fromEventId, fromTimestamp } = await request.json()

--- a/chatbot-app/frontend/src/app/api/session/update-browser-session/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/update-browser-session/route.ts
@@ -10,7 +10,7 @@ export const runtime = 'nodejs'
 
 export async function POST(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const { sessionId, browserSession } = await request.json()

--- a/chatbot-app/frontend/src/app/api/session/update-metadata/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/update-metadata/route.ts
@@ -11,7 +11,7 @@ export const runtime = 'nodejs'
 
 export async function POST(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     const { sessionId, messageId, metadata } = await request.json()

--- a/chatbot-app/frontend/src/app/api/skills/disabled/route.ts
+++ b/chatbot-app/frontend/src/app/api/skills/disabled/route.ts
@@ -8,7 +8,7 @@ const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 
 export async function GET(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
 
     if (IS_LOCAL) {
       return NextResponse.json({ disabledSkills: [] })
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const body = await request.json()
     const disabledSkills: string[] = Array.isArray(body.disabledSkills) ? body.disabledSkills : []
 

--- a/chatbot-app/frontend/src/app/api/stream/chat/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/chat/route.ts
@@ -182,7 +182,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Extract user from Cognito JWT token in Authorization header
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Extract raw JWT token for forwarding to MCP Runtime (3LO OAuth user identity)

--- a/chatbot-app/frontend/src/app/api/stream/execution-status/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/execution-status/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'executionId is required' }, { status: 400 })
   }
 
-  const user = extractUserFromRequest(request)
+  const user = await extractUserFromRequest(request)
   const authToken = request.headers.get('authorization') || ''
 
   const result = await getExecutionStatus(executionId, user.userId, authToken)

--- a/chatbot-app/frontend/src/app/api/stream/resume/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/resume/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  const user = extractUserFromRequest(request)
+  const user = await extractUserFromRequest(request)
   const authToken = request.headers.get('authorization') || ''
 
   console.log(`[Resume] Proxying to backend: execution=${executionId}, cursor=${cursor}`)

--- a/chatbot-app/frontend/src/app/api/stream/stop/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/stop/route.ts
@@ -20,7 +20,7 @@ const AGENTCORE_URL = process.env.NEXT_PUBLIC_AGENTCORE_URL || 'http://localhost
 export async function POST(request: NextRequest) {
   try {
     // Extract user from request
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // Get session ID from request body or header

--- a/chatbot-app/frontend/src/app/api/voice/end/route.ts
+++ b/chatbot-app/frontend/src/app/api/voice/end/route.ts
@@ -14,7 +14,7 @@ export const runtime = 'nodejs'
 export async function POST(request: NextRequest) {
   try {
     // 1. Authentication
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     // 2. Get session info from request body

--- a/chatbot-app/frontend/src/app/api/voice/start/route.ts
+++ b/chatbot-app/frontend/src/app/api/voice/start/route.ts
@@ -58,21 +58,18 @@ export const runtime = 'nodejs'
 
 export async function POST(request: NextRequest) {
   try {
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
     const { sessionId } = getSessionId(request, userId)
     const body = await request.json().catch(() => ({}))
     const enabledTools: string[] = body.enabledTools || []
-
-    const authHeader = request.headers.get('authorization')
-    const authToken = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null
 
     const { isNew } = await ensureSessionExists(userId, sessionId, {
       title: 'Voice Chat',
       metadata: { isVoiceSession: true },
     })
 
-    console.log(`[Voice Start] User: ${userId}, Session: ${sessionId}, New: ${isNew}, Tools: ${enabledTools.length}, AuthToken: ${authToken ? 'present' : 'missing'}`)
+    console.log(`[Voice Start] User: ${userId}, Session: ${sessionId}, New: ${isNew}, Tools: ${enabledTools.length}`)
 
     let wsUrl: string
 
@@ -91,7 +88,7 @@ export async function POST(request: NextRequest) {
       }
 
       const queryParams: Record<string, string> = {
-        'X-Amzn-Bedrock-AgentCore-Runtime-Custom-Session-Id': sessionId,
+        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
       }
       if (userId) {
         queryParams['X-Amzn-Bedrock-AgentCore-Runtime-Custom-User-Id'] = userId
@@ -99,10 +96,6 @@ export async function POST(request: NextRequest) {
       if (enabledTools.length > 0) {
         queryParams['X-Amzn-Bedrock-AgentCore-Runtime-Custom-Enabled-Tools'] = JSON.stringify(enabledTools)
       }
-      if (authToken) {
-        queryParams['access_token'] = authToken
-      }
-
       wsUrl = buildWsUrl(runtimeArn, AWS_REGION, queryParams)
     }
 
@@ -115,7 +108,7 @@ export async function POST(request: NextRequest) {
       wsUrl,
       awsRegion: AWS_REGION,
       isNewSession: isNew,
-      authToken,
+      isLocal: IS_LOCAL,
     })
   } catch (error) {
     console.error('[Voice Start] Error:', error)

--- a/chatbot-app/frontend/src/app/api/warmup/route.ts
+++ b/chatbot-app/frontend/src/app/api/warmup/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json().catch(() => ({}))
-    const { userId } = extractUserFromRequest(request)
+    const { userId } = await extractUserFromRequest(request)
     const sessionId = body.sessionId
 
     const authHeader = request.headers.get('authorization') || ''

--- a/chatbot-app/frontend/src/app/api/workspace/download/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/download/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
 
     let bucket = process.env.ARTIFACT_BUCKET

--- a/chatbot-app/frontend/src/app/api/workspace/files/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/files/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Extract user and session
-    const user = extractUserFromRequest(request)
+    const user = await extractUserFromRequest(request)
     const userId = user.userId
     const { sessionId } = getSessionId(request, userId)
 

--- a/chatbot-app/frontend/src/lib/auth-utils.ts
+++ b/chatbot-app/frontend/src/lib/auth-utils.ts
@@ -1,6 +1,7 @@
 /**
  * Authentication utilities for extracting user info from Cognito JWT tokens
  */
+import { CognitoJwtVerifier } from 'aws-jwt-verify'
 
 interface CognitoUser {
   userId: string
@@ -8,34 +9,50 @@ interface CognitoUser {
   username?: string
 }
 
+let verifier: ReturnType<typeof CognitoJwtVerifier.create> | null = null
+let verifierConfig = ''
+
+function getVerifier() {
+  const userPoolId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID
+  const clientId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID
+  if (!userPoolId || !clientId) return null
+
+  const config = `${userPoolId}:${clientId}`
+  if (!verifier || verifierConfig !== config) {
+    verifier = CognitoJwtVerifier.create({
+      userPoolId,
+      tokenUse: 'access',
+      clientId,
+    })
+    verifierConfig = config
+  }
+  return verifier
+}
+
 /**
  * Extract user information from Cognito JWT token in Authorization header
  */
-export function extractUserFromRequest(request: Request): CognitoUser {
+export async function extractUserFromRequest(request: Request): Promise<CognitoUser> {
   try {
-    // Get Authorization header
     const authHeader = request.headers.get('authorization')
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return { userId: 'anonymous' }
     }
 
-    // Extract JWT token
-    const token = authHeader.substring(7)
-
-    // Decode JWT payload (base64)
-    const parts = token.split('.')
-    if (parts.length !== 3) {
-      console.warn('[Auth] Invalid JWT format')
+    const cognitoVerifier = getVerifier()
+    if (!cognitoVerifier) {
+      console.warn('[Auth] Cognito verifier is not configured')
       return { userId: 'anonymous' }
     }
 
-    const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'))
+    const payload = await cognitoVerifier.verify(authHeader.substring(7))
 
     // Cognito access tokens: sub, username, client_id
-    // Cognito ID tokens: sub, email, cognito:username
-    const userId = payload.sub || payload['cognito:username'] || payload.username || 'anonymous'
-    const email = payload.email
-    const username = payload['cognito:username'] || payload.username
+    const userIdClaim = payload.sub || payload['cognito:username'] || payload.username
+    const userId = typeof userIdClaim === 'string' ? userIdClaim : 'anonymous'
+    const email = typeof payload.email === 'string' ? payload.email : undefined
+    const usernameClaim = payload['cognito:username'] || payload.username
+    const username = typeof usernameClaim === 'string' ? usernameClaim : undefined
 
     console.log(`[Auth] Authenticated user: ${userId} (${email || username || 'no email'})`)
 
@@ -45,7 +62,7 @@ export function extractUserFromRequest(request: Request): CognitoUser {
       username
     }
   } catch (error) {
-    console.error('[Auth] Error extracting user from token:', error)
+    console.warn('[Auth] JWT verification failed:', error instanceof Error ? error.message : error)
     return { userId: 'anonymous' }
   }
 }


### PR DESCRIPTION
## Problem

`extractUserFromRequest` split the bearer token on `.` and base64-decoded the payload **without checking the signature**:

```ts
const parts = token.split('.')
if (parts.length !== 3) { ... }
const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'))
const userId = payload.sub || ...
```

Every API route derives `userId` from that value. Because nothing was verified, a caller could hand-craft a token with an arbitrary `sub` and read or mutate **another user's** sessions, conversation history, memory, documents, and workspace files — all of which key off `userId`. No valid credential was needed; the token only had to have three dot-separated parts.

## Fix

Verification now goes through `aws-jwt-verify`'s `CognitoJwtVerifier`, which checks the signature against the user pool JWKS along with issuer, audience, `token_use`, and expiry. The verifier is cached per user-pool/client pair, so the JWKS is fetched once per configuration rather than per request.

Consequences:

- `extractUserFromRequest` becomes `async`; its 25 call sites are awaited.
- Claims are narrowed to strings before use — a verified payload can still carry non-string values.
- Requests fall back to `userId: 'anonymous'` when the token is absent, fails verification, or Cognito is unconfigured, matching the previous fail-closed behavior for malformed input.

## Tests

Three tests were added for the property this PR exists to guarantee, since the existing suite mocks the verifier and would pass either way:

- rejected signature → `anonymous`
- the verifier is actually called with the token (not bypassed)
- missing Cognito env vars → `anonymous`, verifier never invoked

**Mutation-checked:** restoring the old `auth-utils.ts` makes exactly those 3 fail (`3 failed | 20 passed`), so they do catch a regression back to accepting forged tokens.

## Verification

| Check | Result |
| --- | --- |
| `npm run type-check` | pass |
| `npm test` | 525 passed (23 files) |
| `npm run build` | pass |
| `npm ci --dry-run` (lockfile ↔ package.json) | pass |

## Note

Part of a stack splitting a large local change set. Adds the `aws-jwt-verify@^5.2.1` dependency. Independent of #183 and #184.