### PR TITLE
ci: pin the ruff rule set so new releases cannot break CI

### DIFF
--- a/agentcore/a2a-agents/code-agent/ruff.toml
+++ b/agentcore/a2a-agents/code-agent/ruff.toml
@@ -1,0 +1,10 @@
+# Ruff is installed with a lower bound only (ruff>=0.15.20), so each new minor
+# release can enable additional rules and break CI on unchanged code. Pin the
+# rule set explicitly instead, keeping local runs and CI in agreement.
+#
+#   E4 — import formatting
+#   E7 — statement-level errors
+#   E9 — syntax and IO errors
+#   F  — pyflakes (undefined names, unused imports, f-string bugs)
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/agentcore/a2a-agents/research-agent/ruff.toml
+++ b/agentcore/a2a-agents/research-agent/ruff.toml
@@ -1,0 +1,10 @@
+# Ruff is installed with a lower bound only (ruff>=0.15.20), so each new minor
+# release can enable additional rules and break CI on unchanged code. Pin the
+# rule set explicitly instead, keeping local runs and CI in agreement.
+#
+#   E4 — import formatting
+#   E7 — statement-level errors
+#   E9 — syntax and IO errors
+#   F  — pyflakes (undefined names, unused imports, f-string bugs)
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/agentcore/gateway-tools/ruff.toml
+++ b/agentcore/gateway-tools/ruff.toml
@@ -1,0 +1,10 @@
+# Ruff is installed with a lower bound only (ruff>=0.15.20), so each new minor
+# release can enable additional rules and break CI on unchanged code. Pin the
+# rule set explicitly instead, keeping local runs and CI in agreement.
+#
+#   E4 — import formatting
+#   E7 — statement-level errors
+#   E9 — syntax and IO errors
+#   F  — pyflakes (undefined names, unused imports, f-string bugs)
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/agentcore/mcp-runtime/ruff.toml
+++ b/agentcore/mcp-runtime/ruff.toml
@@ -1,0 +1,10 @@
+# Ruff is installed with a lower bound only (ruff>=0.15.20), so each new minor
+# release can enable additional rules and break CI on unchanged code. Pin the
+# rule set explicitly instead, keeping local runs and CI in agreement.
+#
+#   E4 — import formatting
+#   E7 — statement-level errors
+#   E9 — syntax and IO errors
+#   F  — pyflakes (undefined names, unused imports, f-string bugs)
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/chatbot-app/agentcore/ruff.toml
+++ b/chatbot-app/agentcore/ruff.toml
@@ -1,0 +1,10 @@
+# Ruff is installed with a lower bound only (ruff>=0.15.20), so each new minor
+# release can enable additional rules and break CI on unchanged code. Pin the
+# rule set explicitly instead, keeping local runs and CI in agreement.
+#
+#   E4 — import formatting
+#   E7 — statement-level errors
+#   E9 — syntax and IO errors
+#   F  — pyflakes (undefined names, unused imports, f-string bugs)
+[lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Problem

**The Lint step of every Python job is currently failing on `main`.** Not because of any change — `requirements-dev.txt` pins ruff with a lower bound only (`ruff>=0.15.20`) and no ruff config exists anywhere in the repo, so ruff 0.16 enabling additional rules by default was enough to fail CI on code nobody touched:

| Component | Errors on `main` |
| --- | --- |
| `chatbot-app/agentcore` | 907 |
| `agentcore/mcp-runtime` | 210 |
| `agentcore/gateway-tools` | 149 |
| `research-agent` | 28 |
| `code-agent` | 13 |

Nearly all are `UP006`-style modernization suggestions (`List` → `list`), not defects. These jobs were green until the ruff release, and any PR touching Python currently inherits the red X — see #184, where the Backend failure is entirely pre-existing.

## Fix

Add a `ruff.toml` per Python component selecting `E4`, `E7`, `E9`, `F`: import formatting, statement-level errors, syntax/IO errors, and pyflakes (undefined names, unused imports, f-string bugs).

Two notes on the approach:

- **Config, not a `--select` flag.** A bare `ruff check` run locally now agrees with CI. Putting the rule set in the workflow instead would leave local runs reporting 907 errors that CI ignores — and would need the `workflow` scope to land.
- **Discovery works from the repo root.** ruff walks up from the target path, so the a2a jobs that run `ruff check agentcore/a2a-agents/*/src/` from the repo root pick up each agent's config. Verified explicitly below.

## Verification

Each of the five lint commands, reproduced exactly as the workflow runs them (same ruff 0.16.1 that fails on `main`):

| Command | Before | After |
| --- | --- | --- |
| `ruff check src/` (backend) | 907 errors | pass |
| `ruff check lambda-functions/` (gateway-tools) | 149 errors | pass |
| `ruff check src/` (mcp-runtime) | 210 errors | pass |
| `ruff check agentcore/a2a-agents/research-agent/src/` (from root) | 28 errors | pass |
| `ruff check agentcore/a2a-agents/code-agent/src/` (from root) | 13 errors | pass |

## Suggested merge order

This unblocks the Python jobs, so it is worth merging first — #184 should go green on re-run afterwards.