### PR TITLE
feat(compaction): summarize sessions with GPT-5.6 Luna via Bedrock Mantle

### DIFF
--- a/chatbot-app/frontend/package-lock.json
+++ b/chatbot-app/frontend/package-lock.json
@@ -13,7 +13,6 @@
         "@aws-amplify/ui-react": "^6.15.4",
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/client-bedrock-agentcore": "^3.1076.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1076.0",
         "@aws-sdk/client-dynamodb": "^3.1076.0",
         "@aws-sdk/client-s3": "^3.1076.0",
         "@aws-sdk/client-ssm": "^3.1076.0",
@@ -629,31 +628,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1076.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1076.0.tgz",
-      "integrity": "sha512-BmGgoX5iix1ZcMA6qOyM4NY9JZQ7TaNbP3bM4cAN/yl7SkodCE7D6CU72QTp/AQ1DphhEjfbiKM6rvkbYKyNrQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/credential-provider-node": "^3.972.59",
-        "@aws-sdk/eventstream-handler-node": "^3.972.23",
-        "@aws-sdk/middleware-eventstream": "^3.972.19",
-        "@aws-sdk/middleware-websocket": "^3.972.32",
-        "@aws-sdk/token-providers": "3.1076.0",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.1076.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1076.0.tgz",
@@ -1060,21 +1034,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.23.tgz",
-      "integrity": "sha512-palwWdW4JouKu2IFI6biJ9r6FlWLqr2pvVe/tNU1TkVEOjtPElD2aYF6Cox8TickL5OiOFkPDThixYPQ8LAr1g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.972.20",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.20.tgz",
@@ -1082,21 +1041,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.19.tgz",
-      "integrity": "sha512-r3CGU8gnLe+ugV2rcR8IPUE8AKg7znWkzrKR+pvnjFr8eXrTo1TU0O31CD3eCjNH5jUY4+r4d35MDFzazYWFkQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "@aws-sdk/types": "^3.973.14",
         "@smithy/core": "^3.27.0",
         "@smithy/types": "^4.15.0",
@@ -1134,38 +1078,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.32.tgz",
-      "integrity": "sha512-Qkg0Na1Xr4tSL1o/01Z6YhxWqvmJE0wTNFLNwDx9h3m/uVvgav4FPalqq7uh9qRRvwaPBwIfEvurXFi9Td57mg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/signature-v4": "^5.5.3",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/signature-v4": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.0.tgz",
-      "integrity": "sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {

--- a/chatbot-app/frontend/package.json
+++ b/chatbot-app/frontend/package.json
@@ -19,7 +19,6 @@
     "@aws-amplify/ui-react": "^6.15.4",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-bedrock-agentcore": "^3.1076.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.1076.0",
     "@aws-sdk/client-dynamodb": "^3.1076.0",
     "@aws-sdk/client-s3": "^3.1076.0",
     "@aws-sdk/client-ssm": "^3.1076.0",

--- a/chatbot-app/frontend/src/app/api/session/compact/summarize/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/compact/summarize/route.ts
@@ -3,15 +3,12 @@
  *
  * Receives the current messages directly from the frontend (no need to
  * re-load from AgentCore Memory, which avoids actorId / payload format issues).
- * Generates a summary via Bedrock Converse.
+ * Generates a summary with GPT-5.6 Luna via Bedrock Mantle.
  */
 import { NextRequest, NextResponse } from 'next/server'
-import {
-  BedrockRuntimeClient,
-  ConverseStreamCommand,
-} from '@aws-sdk/client-bedrock-runtime'
 
-const AWS_REGION = process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
+const COMPACTION_MODEL_ID = 'openai.gpt-5.6-luna'
+const MANTLE_RESPONSES_URL = 'https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses'
 
 export const runtime = 'nodejs'
 
@@ -102,27 +99,56 @@ ${transcript}
 Now produce the summary following the instructions above.`
 }
 
-async function streamConverse(client: BedrockRuntimeClient, modelId: string, prompt: string): Promise<ReadableStream<Uint8Array>> {
-  const response = await client.send(new ConverseStreamCommand({
-    modelId,
-    messages: [{ role: 'user', content: [{ text: prompt }] }],
-    inferenceConfig: { maxTokens: 4096 },
-  }))
+type MantleContent = {
+  type?: string
+  text?: string
+}
 
-  const encoder = new TextEncoder()
-  return new ReadableStream({
-    async start(controller) {
-      try {
-        for await (const event of response.stream ?? []) {
-          const text = event.contentBlockDelta?.delta?.text
-          if (text) controller.enqueue(encoder.encode(text))
-        }
-        controller.close()
-      } catch (err) {
-        controller.error(err)
-      }
+type MantleOutput = {
+  type?: string
+  content?: MantleContent[]
+}
+
+type MantleResponse = {
+  output?: MantleOutput[]
+  error?: { message?: string }
+}
+
+async function generateSummary(prompt: string): Promise<string> {
+  const apiKey = process.env.AWS_BEARER_TOKEN_BEDROCK
+  if (!apiKey) {
+    throw new Error('AWS_BEARER_TOKEN_BEDROCK is not configured')
+  }
+
+  const response = await fetch(MANTLE_RESPONSES_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
     },
+    body: JSON.stringify({
+      model: COMPACTION_MODEL_ID,
+      input: prompt,
+      max_output_tokens: 4096,
+    }),
   })
+
+  const payload = await response.json() as MantleResponse
+  if (!response.ok) {
+    throw new Error(payload.error?.message || `Mantle Responses API returned ${response.status}`)
+  }
+
+  const text = payload.output
+    ?.filter(item => item.type === 'message')
+    .flatMap(item => item.content ?? [])
+    .filter(item => item.type === 'output_text' && item.text)
+    .map(item => item.text)
+    .join('') ?? ''
+
+  if (!text) {
+    throw new Error('Mantle Responses API returned no summary text')
+  }
+  return text
 }
 
 function isContextWindowError(error: unknown): boolean {
@@ -139,11 +165,11 @@ function isContextWindowError(error: unknown): boolean {
 
 export async function POST(request: NextRequest) {
   try {
-    const { messages, modelId } = await request.json()
+    const { messages } = await request.json()
 
-    if (!messages || !Array.isArray(messages) || !modelId) {
+    if (!messages || !Array.isArray(messages)) {
       return NextResponse.json(
-        { success: false, error: 'messages (array) and modelId are required' },
+        { success: false, error: 'messages array is required' },
         { status: 400 }
       )
     }
@@ -179,20 +205,18 @@ export async function POST(request: NextRequest) {
       console.warn(`[compact/summarize] Transcript truncated to ${transcript.length} chars`)
     }
 
-    const client = new BedrockRuntimeClient({ region: AWS_REGION })
-
-    let stream: ReadableStream<Uint8Array>
+    let summary: string
     try {
-      stream = await streamConverse(client, modelId, buildPrompt(transcript, truncated))
+      summary = await generateSummary(buildPrompt(transcript, truncated))
     } catch (firstError) {
       if (!isContextWindowError(firstError)) throw firstError
 
       console.warn(`[compact/summarize] Context window error, retrying with reduced transcript`)
       const { transcript: shorter, truncated: moreTruncated } = truncateTranscript(textMessages, 100_000)
-      stream = await streamConverse(client, modelId, buildPrompt(shorter, moreTruncated))
+      summary = await generateSummary(buildPrompt(shorter, moreTruncated))
     }
 
-    return new Response(stream, {
+    return new Response(summary, {
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },
     })
   } catch (error) {

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -333,7 +333,7 @@ export const useChatAPI = ({
       const response = await fetch(getApiUrl('session/compact/summarize'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders },
-        body: JSON.stringify({ messages: messagesForSummary, modelId: currentModelId }),
+        body: JSON.stringify({ messages: messagesForSummary }),
       })
 
       if (!response.ok) {
@@ -356,8 +356,7 @@ export const useChatAPI = ({
       logger.error('Error generating compact summary:', error)
       return null
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentModelId])
+  }, [])
 
   // List all current eventIds for the session (snapshot before sending summary)
   const listSessionEvents = useCallback(async (): Promise<string[]> => {

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -438,6 +438,11 @@ module "chat" {
 
   orchestrator_runtime_arn = module.runtime_orchestrator.runtime_arn
   orchestrator_runtime_url = module.runtime_orchestrator.runtime_invocation_url
+  bedrock_api_key_secret_arn = (
+    var.enable_mantle_models
+    ? data.aws_secretsmanager_secret.bedrock_api_key[0].arn
+    : ""
+  )
 
   frontend_build_args = {
     NEXT_PUBLIC_GOOGLE_MAPS_EMBED_API_KEY = local.google_maps_embed_api_key

--- a/infra/modules/chat/main.tf
+++ b/infra/modules/chat/main.tf
@@ -258,6 +258,21 @@ resource "aws_iam_role_policy_attachment" "ecs_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_role_policy" "ecs_execution_secrets" {
+  count = var.bedrock_api_key_secret_arn != "" ? 1 : 0
+
+  name = "${local.prefix}-ecs-exec-secrets"
+  role = aws_iam_role.ecs_execution.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = var.bedrock_api_key_secret_arn
+    }]
+  })
+}
+
 resource "aws_iam_role" "ecs_task" {
   name = "${local.prefix}-ecs-task"
   assume_role_policy = jsonencode({
@@ -381,6 +396,10 @@ resource "aws_ecs_task_definition" "frontend" {
       { name = "AGENTCORE_RUNTIME_URL", value = var.orchestrator_runtime_url },
       { name = "SOURCE_HASH", value = local.source_hash },
     ]
+    secrets = var.bedrock_api_key_secret_arn != "" ? [{
+      name      = "AWS_BEARER_TOKEN_BEDROCK"
+      valueFrom = var.bedrock_api_key_secret_arn
+    }] : []
     logConfiguration = {
       logDriver = "awslogs"
       options = {
@@ -391,7 +410,11 @@ resource "aws_ecs_task_definition" "frontend" {
     }
   }])
 
-  depends_on = [null_resource.codebuild_trigger]
+  depends_on = [
+    null_resource.codebuild_trigger,
+    aws_iam_role_policy_attachment.ecs_execution,
+    aws_iam_role_policy.ecs_execution_secrets,
+  ]
 }
 
 # ALB ingress uses CloudFront prefix list. Keep ingress inline to avoid the

--- a/infra/modules/chat/variables.tf
+++ b/infra/modules/chat/variables.tf
@@ -87,6 +87,12 @@ variable "orchestrator_runtime_url" {
   type = string
 }
 
+variable "bedrock_api_key_secret_arn" {
+  description = "Secrets Manager ARN for the Bedrock Mantle API key."
+  type        = string
+  default     = ""
+}
+
 # Build-time secrets passed as build args (e.g., Google Maps embed key, default keys)
 variable "frontend_build_args" {
   description = "Extra NEXT_PUBLIC_* build args (key → value)"


### PR DESCRIPTION
## Problem

Session compaction called Bedrock Converse with **whatever model the user had selected in the picker**, coupling a background maintenance task to the conversation model:

- Picking an expensive reasoning model made every compaction expensive.
- Picking a Mantle-only model **failed outright** — GPT-5.6 is served through the Responses API on the `bedrock-mantle` endpoint and is not reachable via Converse. After #184 made GPT-5.6 Terra the default, this is the common path, not an edge case.

## Fix

Compaction now always uses **GPT-5.6 Luna** through the Mantle Responses endpoint. Summarizing a transcript is a fixed, low-complexity task, so the cheapest tier is the right default and the cost no longer tracks the user's choice. The route stops accepting `modelId`, and `useChatAPI` stops sending it.

The response is returned whole rather than streamed. Converse gave incremental deltas, but the caller already awaited the full body before storing the summary, so the streaming machinery bought nothing.

**Terraform** injects the Mantle API key into the frontend ECS task from Secrets Manager, matching how the backend resolves it (`_get_bedrock_api_key`). Without this the route would throw `AWS_BEARER_TOKEN_BEDROCK is not configured` in any deployed environment — the env var only existed as a local-dev fallback.

Both the IAM grant and the `secrets` block are gated on the secret ARN being non-empty:

```hcl
secrets = var.bedrock_api_key_secret_arn != "" ? [{ ... }] : []
```

so deployments with `enable_mantle_models = false` are unaffected.

Also drops `@aws-sdk/client-bedrock-runtime`, which no longer has any importer in the frontend.

## Verification

| Check | Result |
| --- | --- |
| `npm run type-check` | pass |
| `npm test` | 525 passed |
| `npm run build` | pass |
| `npm ci --dry-run` (lockfile ↔ package.json) | pass |
| `terraform fmt -check -recursive infra/` | pass |
| `terraform validate` (`infra/environments/dev`) | pass |

## Note

Part of a stack splitting a large local change set. Depends on #184 (merged) for the GPT-5.6 model ids.