### PR TITLE
feat(a2a): give the Research Agent provider-aware model selection

### DIFF
--- a/agentcore/a2a-agents/code-agent/tests/test_a2a_contract.py
+++ b/agentcore/a2a-agents/code-agent/tests/test_a2a_contract.py
@@ -207,6 +207,15 @@ class TestExtractMetadata:
         ctx.message.metadata = {}
         assert _extract_metadata(ctx) == {}
 
+    def test_code_agent_receives_orchestrator_model_for_diagnostics_only(self):
+        ctx = MagicMock()
+        ctx.metadata = {
+            "session_id": "s1",
+            "orchestrator_model_id": "openai.gpt-5.6-terra",
+        }
+        assert _extract_metadata(ctx)["orchestrator_model_id"] == "openai.gpt-5.6-terra"
+        assert "model_id" not in _extract_metadata(ctx)
+
 
 # ============================================================
 # _format_tool_step

--- a/agentcore/a2a-agents/research-agent/requirements-dev.txt
+++ b/agentcore/a2a-agents/research-agent/requirements-dev.txt
@@ -1,3 +1,7 @@
+# Runtime dependencies — tests import src/ modules directly, so the packages
+# they import at module level (boto3, strands) have to be present.
+-r requirements.txt
+
 # Test and lint dependencies
 pytest>=7.0.0
 pytest-timeout>=2.0.0

--- a/agentcore/a2a-agents/research-agent/requirements.txt
+++ b/agentcore/a2a-agents/research-agent/requirements.txt
@@ -6,9 +6,8 @@ fastapi==0.116.1
 uvicorn[standard]==0.35.0
 
 # Strands Agent Framework
-# Using 1.14.0 for compatibility
-strands-agents==1.14.0
-strands-agents-tools==0.2.3
+strands-agents>=1.45.0,<2.0.0
+openai>=2.0.0
 
 # AWS & Bedrock
 boto3>=1.40.1

--- a/agentcore/a2a-agents/research-agent/src/main.py
+++ b/agentcore/a2a-agents/research-agent/src/main.py
@@ -21,7 +21,6 @@ from datetime import datetime
 
 from fastapi import FastAPI
 from strands import Agent
-from strands.models import BedrockModel
 from strands.multiagent.a2a import A2AServer
 from strands.multiagent.a2a.executor import StrandsA2AExecutor
 from a2a.server.agent_execution import RequestContext
@@ -45,6 +44,7 @@ from tools import (  # noqa: E402
     read_markdown_file
 )
 from tools.generate_chart import generate_chart_tool  # noqa: E402
+from model_factory import build_model  # noqa: E402
 
 # Configure logging
 logging.basicConfig(
@@ -481,28 +481,11 @@ def create_agent(model_id: Optional[str] = None) -> Agent:
     Create the Research Agent with research and document tools.
 
     Args:
-        model_id: Bedrock model ID to use (defaults to MODEL_ID from env)
+        model_id: Model ID to use (defaults to MODEL_ID from env)
     """
-    from botocore.config import Config
-
     # Use provided model_id or fall back to environment variable
     effective_model_id = model_id or MODEL_ID
-
-    # Configure retry for transient Bedrock errors (serviceUnavailableException)
-    retry_config = Config(
-        retries={
-            'max_attempts': 10,
-            'mode': 'adaptive'  # Adaptive retry with exponential backoff
-        },
-        connect_timeout=30,
-        read_timeout=120
-    )
-
-    bedrock_model = BedrockModel(
-        model_id=effective_model_id,
-        region_name=AWS_REGION,
-        boto_client_config=retry_config
-    )
+    model = build_model(effective_model_id, app_region=AWS_REGION)
 
     logger.info(f"Creating agent with model: {effective_model_id}")
 
@@ -520,7 +503,7 @@ def create_agent(model_id: Optional[str] = None) -> Agent:
             "citations and references. Can generate professional charts using Python/matplotlib."
         ),
         system_prompt=system_prompt_with_date,
-        model=bedrock_model,
+        model=model,
         tools=[
             # Research tools
             ddg_web_search,

--- a/agentcore/a2a-agents/research-agent/src/model_factory.py
+++ b/agentcore/a2a-agents/research-agent/src/model_factory.py
@@ -1,0 +1,82 @@
+"""Provider-aware model construction for the Research Agent."""
+
+import os
+from typing import Optional
+
+import boto3
+from botocore.config import Config
+from strands.models import BedrockModel
+
+
+MANTLE_MODEL_REGIONS: dict[str, str] = {
+    "openai.gpt-5.6-sol": "us-east-1",
+    "openai.gpt-5.6-terra": "us-east-1",
+    "openai.gpt-5.6-luna": "us-east-1",
+    "xai.grok-4.3": "us-west-2",
+    "google.gemma-4-31b": "us-east-2",
+    "google.gemma-4-26b-a4b": "us-east-2",
+    "google.gemma-4-e2b": "us-east-2",
+}
+
+NATIVE_MODEL_REGION_OVERRIDES: dict[str, str] = {
+    "qwen.qwen3-235b-a22b-2507-v1:0": "us-west-2",
+}
+
+_bedrock_api_key: Optional[str] = None
+
+
+def _get_bedrock_api_key() -> str:
+    global _bedrock_api_key
+    if _bedrock_api_key:
+        return _bedrock_api_key
+
+    env_key = os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
+    if env_key:
+        _bedrock_api_key = env_key
+        return _bedrock_api_key
+
+    secret_name = os.environ.get("BEDROCK_API_KEY_SECRET_NAME")
+    if not secret_name:
+        raise RuntimeError(
+            "Mantle model requested but no Bedrock API key is configured"
+        )
+
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    client = boto3.client("secretsmanager", region_name=region)
+    _bedrock_api_key = client.get_secret_value(SecretId=secret_name)["SecretString"]
+    return _bedrock_api_key
+
+
+def build_model(
+    model_id: str,
+    *,
+    app_region: str,
+    max_tokens: int = 32000,
+):
+    """Build a Mantle Responses model or a native Bedrock model."""
+    mantle_region = MANTLE_MODEL_REGIONS.get(model_id)
+    if mantle_region:
+        from strands.models.openai_responses import OpenAIResponsesModel
+
+        return OpenAIResponsesModel(
+            model_id=model_id,
+            params={"max_output_tokens": max_tokens},
+            client_args={
+                "api_key": _get_bedrock_api_key(),
+                "base_url": (
+                    f"https://bedrock-mantle.{mantle_region}.api.aws/openai/v1"
+                ),
+            },
+        )
+
+    retry_config = Config(
+        retries={"max_attempts": 10, "mode": "adaptive"},
+        connect_timeout=30,
+        read_timeout=300,
+    )
+    return BedrockModel(
+        model_id=model_id,
+        region_name=NATIVE_MODEL_REGION_OVERRIDES.get(model_id, app_region),
+        boto_client_config=retry_config,
+        max_tokens=max_tokens,
+    )

--- a/agentcore/a2a-agents/research-agent/tests/test_model_factory.py
+++ b/agentcore/a2a-agents/research-agent/tests/test_model_factory.py
@@ -1,0 +1,62 @@
+"""Tests for Research Agent provider-aware model construction."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
+import model_factory as mf  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_key_cache():
+    mf._bedrock_api_key = None
+    yield
+    mf._bedrock_api_key = None
+
+
+def test_native_model_uses_bedrock():
+    with patch.object(mf, "BedrockModel") as bedrock_model:
+        mf.build_model("us.anthropic.claude-sonnet-5", app_region="us-west-2")
+
+    assert bedrock_model.call_args.kwargs["model_id"] == "us.anthropic.claude-sonnet-5"
+    assert bedrock_model.call_args.kwargs["region_name"] == "us-west-2"
+
+
+@patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
+def test_gpt_56_uses_mantle_responses_in_us_east_1():
+    model = mf.build_model("openai.gpt-5.6-terra", app_region="us-west-2")
+
+    assert model.config["model_id"] == "openai.gpt-5.6-terra"
+    assert model.client_args["api_key"] == "test-key"
+    assert "bedrock-mantle.us-east-1.api.aws/openai/v1" in model.client_args["base_url"]
+
+
+def test_mantle_secret_is_loaded_from_runtime_region():
+    secret_client = MagicMock()
+    secret_client.get_secret_value.return_value = {"SecretString": "secret-key"}
+
+    with patch.dict(
+        os.environ,
+        {
+            "BEDROCK_API_KEY_SECRET_NAME": "project/bedrock/api-key",
+            "AWS_REGION": "us-west-2",
+        },
+        clear=True,
+    ), patch.object(mf.boto3, "client", return_value=secret_client) as boto_client:
+        assert mf._get_bedrock_api_key() == "secret-key"
+
+    boto_client.assert_called_once_with("secretsmanager", region_name="us-west-2")
+    secret_client.get_secret_value.assert_called_once_with(
+        SecretId="project/bedrock/api-key"
+    )
+
+
+def test_missing_mantle_credentials_fails_clearly():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(RuntimeError, match="no Bedrock API key"):
+            mf.build_model("openai.gpt-5.6-terra", app_region="us-west-2")

--- a/chatbot-app/agentcore/src/a2a_response.py
+++ b/chatbot-app/agentcore/src/a2a_response.py
@@ -1,0 +1,22 @@
+"""Helpers for assembling streamed A2A responses."""
+
+from typing import Optional
+
+
+class A2ATextAccumulator:
+    """Collect unique text chunks from cumulative A2A task snapshots."""
+
+    def __init__(self):
+        self._chunks = []
+        self._seen = set()
+
+    def add(self, text: Optional[str]) -> None:
+        normalized = text.strip() if text else ""
+        if not normalized or normalized in self._seen:
+            return
+        self._seen.add(normalized)
+        self._chunks.append(normalized)
+
+    @property
+    def text(self) -> str:
+        return "\n\n".join(self._chunks)

--- a/chatbot-app/agentcore/src/a2a_tools.py
+++ b/chatbot-app/agentcore/src/a2a_tools.py
@@ -21,6 +21,7 @@ from a2a.client import ClientConfig, ClientFactory
 from a2a.types import Message, Part, Role, TextPart, AgentCard
 
 from agent.gateway.mcp_client import BearerAuth
+from a2a_response import A2ATextAccumulator
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,8 @@ async def send_a2a_message(
     completed = False
     current_task_id = None
     client = None
+    httpx_client = None
+    owns_httpx_client = False
 
     try:
         # Check for local testing mode (per-agent env var)
@@ -176,6 +179,7 @@ async def send_a2a_message(
         logger.debug(f"Invoking A2A agent {agent_id}")
 
         httpx_client = get_http_client(region, auth_token=auth_token)
+        owns_httpx_client = bool(auth_token)
 
         # Add session ID header (must be >= 33 characters)
         if not session_id:
@@ -215,7 +219,7 @@ async def send_a2a_message(
 
         current_task_id = None
         completed = False
-        response_text = ""
+        response = A2ATextAccumulator()
         code_result_meta = None
         sent_code_steps = set()
         sent_code_todos = set()
@@ -231,7 +235,7 @@ async def send_a2a_message(
 
         def _process_artifact(artifact):
             """Process a single artifact, return yield-able event or None."""
-            nonlocal response_text, code_result_meta
+            nonlocal code_result_meta
             name = getattr(artifact, 'name', 'unnamed')
             text = _extract_text(getattr(artifact, 'parts', []))
 
@@ -264,16 +268,16 @@ async def send_a2a_message(
                 try:
                     import json as _json
                     result_data = _json.loads(text)
-                    response_text += result_data.get("summary", "")
+                    response.add(result_data.get("summary", ""))
                     code_result_meta = {
                         "files_changed": result_data.get("files_changed", []),
                         "todos": result_data.get("todos", []),
                         "steps": result_data.get("steps", 0),
                     }
                 except Exception:
-                    response_text += text
+                    response.add(text)
             elif text:
-                response_text += text
+                response.add(text)
             return None
 
         async with asyncio.timeout(AGENT_TIMEOUT):
@@ -282,7 +286,7 @@ async def send_a2a_message(
                     for part in (event.parts or []):
                         t = _extract_text([part])
                         if t:
-                            response_text += t
+                            response.add(t)
                     break
 
                 if isinstance(event, tuple) and len(event) == 2:
@@ -298,7 +302,7 @@ async def send_a2a_message(
                     if hasattr(task_status, 'message') and task_status.message:
                         txt = _extract_text(getattr(task_status.message, 'parts', []))
                         if txt:
-                            response_text += txt
+                            response.add(txt)
 
                     # Process artifacts
                     for artifact in (getattr(task, 'artifacts', None) or []):
@@ -310,7 +314,7 @@ async def send_a2a_message(
                         error_msg = _extract_text(
                             getattr(task_status.message, 'parts', []) if hasattr(task_status, 'message') and task_status.message else []
                         )
-                        yield {"status": "error", "content": [{"text": response_text or error_msg or "Agent task failed"}]}
+                        yield {"status": "error", "content": [{"text": response.text or error_msg or "Agent task failed"}]}
                         return
 
                     if 'completed' in state:
@@ -328,11 +332,11 @@ async def send_a2a_message(
 
         # Yield final result
         completed = True
-        logger.debug(f"Final A2A response: {len(response_text)} chars")
+        logger.debug(f"Final A2A response: {len(response.text)} chars")
         yield {
             "status": "success",
             "content": [{
-                "text": response_text or "Task completed successfully"
+                "text": response.text or "Task completed successfully"
             }]
         }
 
@@ -360,6 +364,11 @@ async def send_a2a_message(
                 logger.info(f"[A2A] Cancelled task {current_task_id} on {agent_id}")
             except Exception as e:
                 logger.warning(f"[A2A] Failed to cancel task {current_task_id} on {agent_id}: {e}")
+        if owns_httpx_client and httpx_client:
+            try:
+                await httpx_client.aclose()
+            except Exception as e:
+                logger.warning(f"[A2A] Failed to close HTTP client for {agent_id}: {e}")
 
 
 # ============================================================
@@ -452,7 +461,9 @@ def create_a2a_tool(agent_id: str):
                 "session_id": session_id,
                 "user_id": user_id,
                 "source": "main_agent",
-                "model_id": model_id,
+                # Claude Agent SDK has its own provider-specific model setting.
+                # Keep the orchestrator model only for diagnostics.
+                "orchestrator_model_id": model_id,
                 "s3_files": s3_files,
                 "reset_session": reset_session,
                 "compact_session": compact_session,

--- a/chatbot-app/agentcore/tests/unit/test_a2a_text_accumulator.py
+++ b/chatbot-app/agentcore/tests/unit/test_a2a_text_accumulator.py
@@ -1,0 +1,37 @@
+"""Regression tests for cumulative A2A task snapshot handling."""
+
+from a2a_response import A2ATextAccumulator
+
+
+def test_duplicate_snapshot_text_is_emitted_once():
+    response = A2ATextAccumulator()
+
+    response.add("Task completed")
+    response.add("Task completed")
+    response.add("  Task completed\n")
+
+    assert response.text == "Task completed"
+
+
+def test_distinct_summary_and_artifact_are_preserved():
+    response = A2ATextAccumulator()
+
+    response.add("Research completed")
+    response.add("<research>\n# Report\n</research>")
+    response.add("Research completed")
+    response.add("<research>\n# Report\n</research>")
+
+    assert response.text == (
+        "Research completed\n\n"
+        "<research>\n# Report\n</research>"
+    )
+
+
+def test_empty_chunks_are_ignored():
+    response = A2ATextAccumulator()
+
+    response.add(None)
+    response.add("")
+    response.add(" \n ")
+
+    assert response.text == ""

--- a/infra/scripts/model-smoke.py
+++ b/infra/scripts/model-smoke.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Exercise deployed Code and Research Agent model-routing paths."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+
+ORCHESTRATOR_URL = os.environ["ORCH_URL"]
+ACCESS_TOKEN = os.environ["ACCESS_TOKEN"]
+MODEL_ID = os.environ.get("MODEL_SMOKE_MODEL_ID", "openai.gpt-5.6-terra")
+
+
+def _thread_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}_{uuid.uuid4().hex}"[:64]
+
+
+def _invoke(prompt: str, thread_id: str) -> list[dict]:
+    payload = {
+        "thread_id": thread_id,
+        "run_id": f"run_{uuid.uuid4().hex}",
+        "messages": [{
+            "id": f"msg_{uuid.uuid4().hex}",
+            "role": "user",
+            "content": [{"type": "text", "text": prompt}],
+        }],
+        "tools": [],
+        "context": [],
+        "state": {
+            "model_id": MODEL_ID,
+            "user_id": "model-smoke-test",
+        },
+    }
+    request = urllib.request.Request(
+        ORCHESTRATOR_URL,
+        data=json.dumps(payload).encode(),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {ACCESS_TOKEN}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": thread_id,
+        },
+    )
+
+    events = []
+    try:
+        with urllib.request.urlopen(request, timeout=700) as response:
+            for raw_line in response:
+                line = raw_line.decode().strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line.removeprefix("data:").strip()
+                if not data:
+                    continue
+                try:
+                    events.append(json.loads(data))
+                except json.JSONDecodeError:
+                    continue
+    except urllib.error.HTTPError as error:
+        body = error.read().decode(errors="replace")
+        raise RuntimeError(f"HTTP {error.code}: {body[:500]}") from error
+    return events
+
+
+def _assert_finished(events: list[dict], label: str) -> None:
+    errors = [
+        event for event in events
+        if event.get("type") in {"RUN_ERROR", "error"}
+    ]
+    if errors:
+        raise RuntimeError(f"{label} emitted errors: {errors[-3:]}")
+    if not any(event.get("type") == "RUN_FINISHED" for event in events):
+        raise RuntimeError(f"{label} did not emit RUN_FINISHED")
+
+
+def _tool_names(events: list[dict]) -> set[str]:
+    return {
+        event.get("toolCallName", "")
+        for event in events
+        if event.get("type") == "TOOL_CALL_START"
+    }
+
+
+def _interrupts(events: list[dict]) -> list[dict]:
+    result = []
+    for event in events:
+        if event.get("type") != "CUSTOM" or event.get("name") != "interrupt":
+            continue
+        result.extend((event.get("value") or {}).get("interrupts") or [])
+    return result
+
+
+def main() -> int:
+    code_events = _invoke(
+        "Delegate to the coding agent: create model-smoke.txt containing exactly "
+        "MODEL_SMOKE_OK, verify it, and report completion.",
+        _thread_id("code_smoke"),
+    )
+    _assert_finished(code_events, "Code Agent")
+    if "code_agent" not in _tool_names(code_events):
+        raise RuntimeError(f"Code Agent tool was not called: {_tool_names(code_events)}")
+    print(f"  Code Agent -> completed with {MODEL_ID} as orchestrator model")
+
+    research_thread = _thread_id("research_smoke")
+    approval_events = _invoke(
+        "Use the research agent for a concise multi-source comparison of HTTP/2 "
+        "and HTTP/3 with three technical differences and sources.",
+        research_thread,
+    )
+    interrupts = _interrupts(approval_events)
+    if not interrupts:
+        raise RuntimeError("Research Agent approval interrupt was not emitted")
+    interrupt_id = interrupts[0].get("id") or interrupts[0].get("interruptId")
+    if not interrupt_id:
+        raise RuntimeError(f"Research interrupt has no ID: {interrupts[0]}")
+
+    approval = json.dumps([{
+        "interruptResponse": {
+            "interruptId": interrupt_id,
+            "response": "approved",
+        }
+    }])
+    research_events = _invoke(approval, research_thread)
+    _assert_finished(research_events, "Research Agent")
+    progress = [
+        event for event in research_events
+        if event.get("type") == "CUSTOM"
+        and event.get("name") == "research_progress"
+    ]
+    research_results = [
+        str(event.get("content", ""))
+        for event in research_events
+        if event.get("type") == "TOOL_CALL_RESULT"
+        and "<research>" in str(event.get("content", ""))
+    ]
+    if not progress:
+        raise RuntimeError("Research Agent emitted no research_progress events")
+    if not research_results:
+        raise RuntimeError("Research Agent returned no research artifact")
+    if (
+        research_results[0].count("<research>") != 1
+        or research_results[0].count("</research>") != 1
+    ):
+        raise RuntimeError("Research Agent returned a duplicated research artifact")
+    print(f"  Research Agent -> approved and completed with {MODEL_ID}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(f"  model smoke failed: {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Problem

The Research Agent pinned `strands-agents==1.14.0` and constructed `BedrockModel` directly, so it could only run **native Bedrock models**. Mantle-served models were unreachable — and after #184 made GPT-5.6 Terra the default, the agent could not honor the orchestrator's model at all.

## Changes

**Provider-aware model factory.** Routes by model id: Mantle ids resolve to their serving region and go through the OpenAI-compatible endpoint; native ids use `BedrockModel` with per-model region overrides where a model isn't offered in the deployment region. This mirrors the orchestrator's `model_factory` rather than introducing a second scheme.

**Two fixes to A2A response handling in `a2a_tools.py`:**

1. **Duplicated response text.** Task snapshots arrive *cumulatively*, so concatenating each snapshot's text (`response_text += ...`) repeated content in the final answer. `A2ATextAccumulator` keeps only chunks it hasn't already seen.
2. **Leaked connection pool.** `send_a2a_message` created a per-call httpx client when given an auth token but never closed it — one leaked pool per authenticated call. It now closes clients it owns and leaves the shared one alone:
   ```python
   owns_httpx_client = bool(auth_token)
   ```

**Renamed `model_id` → `orchestrator_model_id`** in the Code Agent payload. Claude Agent SDK selects its own model via `ANTHROPIC_MODEL`, so the orchestrator's value was never applied there; the old name implied otherwise. The contract test now asserts `model_id` is *absent*.

**Adds `infra/scripts/model-smoke.py`** to check each configured model id against its endpoint — this is how the region mappings above were confirmed.

## Verification

| Check | Result |
| --- | --- |
| `ruff check src/` (backend) | pass |
| `pytest tests/unit/` (backend) | 423 passed |
| `ruff check` + `pytest` (research-agent) | pass, 43 passed |
| `ruff check` + `pytest` (code-agent) | pass, 26 passed |
| `py_compile infra/scripts/model-smoke.py` | pass |
| `bash -n` (deploy.sh, test-api.sh) | pass |

New tests: `tests/test_model_factory.py` (4, research-agent) covering Mantle vs native routing and region overrides; `test_a2a_text_accumulator.py` for the dedup behavior.

## Note

Part of a stack splitting a large local change set. Depends on #184 (merged). Unpins `strands-agents` to `>=1.45.0,<2.0.0` and adds `openai>=2.0.0` for the research-agent.