### PR TITLE
fix(a2a): repair the BearerAuth import broken by the MCP unification

### DIFF
--- a/chatbot-app/agentcore/src/a2a_tools.py
+++ b/chatbot-app/agentcore/src/a2a_tools.py
@@ -20,7 +20,7 @@ import httpx
 from a2a.client import ClientConfig, ClientFactory
 from a2a.types import Message, Part, Role, TextPart, AgentCard
 
-from agent.gateway.mcp_client import BearerAuth
+from agent.mcp.client import BearerAuth
 from a2a_response import A2ATextAccumulator
 
 logger = logging.getLogger(__name__)

--- a/chatbot-app/agentcore/tests/unit/test_module_imports.py
+++ b/chatbot-app/agentcore/tests/unit/test_module_imports.py
@@ -1,0 +1,34 @@
+"""Import checks for modules that are only imported lazily at runtime.
+
+Modules loaded inside a function body are invisible to both ruff and the rest
+of the suite, and ToolFilterRegistry swallows ImportError to degrade
+gracefully. A stale import in one of them therefore surfaces only as a missing
+tool in production, with a single warning in the logs. Import them here so a
+broken module path fails the build instead.
+"""
+import importlib
+
+import pytest
+
+# Modules reached only through a lazy import inside a function body.
+LAZILY_IMPORTED_MODULES = [
+    "a2a_tools",
+    "a2a_response",
+    "agent.mcp.client",
+    "agent.mcp.elicitation_bridge",
+    "agent.stop_signal",
+    "skill.tool_names",
+]
+
+
+@pytest.mark.parametrize("module_name", LAZILY_IMPORTED_MODULES)
+def test_lazily_imported_module_is_importable(module_name):
+    importlib.import_module(module_name)
+
+
+def test_a2a_tool_factory_resolves():
+    """ToolFilterRegistry logs and returns None on ImportError, so assert the
+    factory actually resolves rather than trusting the graceful path."""
+    from agent.tool_filter import ToolFilterRegistry
+
+    assert ToolFilterRegistry()._get_a2a_tool_factory() is not None


### PR DESCRIPTION
## Problem

`a2a_tools.py` still imports `BearerAuth` from `agent.gateway.mcp_client`, which #192 deleted. **Loading A2A tools raises `ModuleNotFoundError` on `main` right now:**

```
>>> import a2a_tools
ModuleNotFoundError: No module named 'agent.gateway'
```

My mistake in sequencing the stack: I deliberately kept the old import path in #191 so it wouldn't depend on #192, then didn't update it when #192 landed.

## Why nothing caught it

Two things hid it, and together they're worse than either alone:

1. `tool_filter` imports `a2a_tools` **inside a function body**, so ruff never resolves the name and `pytest` never triggers the import.
2. The surrounding `except ImportError` treats the failure as expected:
   ```python
   try:
       import a2a_tools
       self._a2a_tool_factory = a2a_tools.create_a2a_tool
   except ImportError:
       logger.warning("A2A tools module not available")
       return None
   ```

So the agent starts fine, logs one warning, and runs with **no A2A tools at all** — no error surfaces to the user. Backend CI was green on all 431 tests.

## Fix

Point the import at `agent.mcp.client`, where `BearerAuth` now lives.

Add `tests/unit/test_module_imports.py`, which imports each lazily loaded module and asserts the A2A factory actually resolves instead of trusting the graceful-degradation path:

```python
assert ToolFilterRegistry()._get_a2a_tool_factory() is not None
```

**Mutation-checked:** restoring the broken import makes exactly those two tests fail (`2 failed, 5 passed`), so this would not slip through again.

I also imported every module under `src/` to check for other stale paths from the refactor. The only remaining unresolved import is `nova_act`, which `requirements.txt` documents as a manual `--no-deps` install, not a defect.

## Verification

| Check | Result |
| --- | --- |
| `ruff check src/` | pass |
| `pytest tests/unit/` | 438 passed |
| `import a2a_tools` (was failing on main) | pass |