### PR TITLE
chore(frontend): drop @aws-sdk/client-bedrock-runtime again

### DIFF
--- a/chatbot-app/frontend/package-lock.json
+++ b/chatbot-app/frontend/package-lock.json
@@ -13,7 +13,6 @@
         "@aws-amplify/ui-react": "^6.15.4",
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/client-bedrock-agentcore": "^3.1076.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1076.0",
         "@aws-sdk/client-dynamodb": "^3.1076.0",
         "@aws-sdk/client-s3": "^3.1076.0",
         "@aws-sdk/client-ssm": "^3.1076.0",
@@ -629,31 +628,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1076.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1076.0.tgz",
-      "integrity": "sha512-BmGgoX5iix1ZcMA6qOyM4NY9JZQ7TaNbP3bM4cAN/yl7SkodCE7D6CU72QTp/AQ1DphhEjfbiKM6rvkbYKyNrQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/credential-provider-node": "^3.972.59",
-        "@aws-sdk/eventstream-handler-node": "^3.972.23",
-        "@aws-sdk/middleware-eventstream": "^3.972.19",
-        "@aws-sdk/middleware-websocket": "^3.972.32",
-        "@aws-sdk/token-providers": "3.1076.0",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.1076.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1076.0.tgz",
@@ -1060,21 +1034,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.23.tgz",
-      "integrity": "sha512-palwWdW4JouKu2IFI6biJ9r6FlWLqr2pvVe/tNU1TkVEOjtPElD2aYF6Cox8TickL5OiOFkPDThixYPQ8LAr1g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.972.20",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.20.tgz",
@@ -1082,21 +1041,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.19.tgz",
-      "integrity": "sha512-r3CGU8gnLe+ugV2rcR8IPUE8AKg7znWkzrKR+pvnjFr8eXrTo1TU0O31CD3eCjNH5jUY4+r4d35MDFzazYWFkQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "@aws-sdk/types": "^3.973.14",
         "@smithy/core": "^3.27.0",
         "@smithy/types": "^4.15.0",
@@ -1134,38 +1078,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.32.tgz",
-      "integrity": "sha512-Qkg0Na1Xr4tSL1o/01Z6YhxWqvmJE0wTNFLNwDx9h3m/uVvgav4FPalqq7uh9qRRvwaPBwIfEvurXFi9Td57mg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/signature-v4": "^5.5.3",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/signature-v4": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.0.tgz",
-      "integrity": "sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
@@ -3907,9 +3819,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3925,9 +3834,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3945,9 +3851,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3963,9 +3866,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/chatbot-app/frontend/package.json
+++ b/chatbot-app/frontend/package.json
@@ -19,7 +19,6 @@
     "@aws-amplify/ui-react": "^6.15.4",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-bedrock-agentcore": "^3.1076.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.1076.0",
     "@aws-sdk/client-dynamodb": "^3.1076.0",
     "@aws-sdk/client-s3": "^3.1076.0",
     "@aws-sdk/client-ssm": "^3.1076.0",


### PR DESCRIPTION
## What happened

#190 removed this package when session compaction moved off Bedrock Converse. **#192 put it back** — my mistake: I built that PR's `package.json` from a snapshot taken before the removal landed, so the stale line came along with it.

```
$ git log --oneline -S'client-bedrock-runtime' -- chatbot-app/frontend/package.json
1f24f40 refactor(mcp): unify the MCP clients ...      (#192)  <- re-added
b49bea3 feat(compaction): summarize sessions ...      (#190)  <- removed
```

Nothing imports it. `BedrockRuntimeClient` and `ConverseStreamCommand` have no remaining references in `src/` or `__tests__/`.

Worth doing now rather than later: the pending frontend group update (#198) bumps it to `^3.1097.0`, so without this it gets carried forward — and kept current — as a dependency that shouldn't be installed at all.

## Verification

| Check | Result |
| --- | --- |
| `npm ci` | pass, 1127 packages |
| `npm run type-check` | pass |
| `npm test` | 530 passed |
| `npm run build` | pass |