### PR TITLE
ci: add infrastructure, mobile, and telegram jobs to PR check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,6 +17,9 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       a2a: ${{ steps.filter.outputs.a2a }}
       mcp: ${{ steps.filter.outputs.mcp }}
+      infra: ${{ steps.filter.outputs.infra }}
+      mobile: ${{ steps.filter.outputs.mobile }}
+      telegram: ${{ steps.filter.outputs.telegram }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -25,14 +28,28 @@ jobs:
           filters: |
             backend:
               - 'chatbot-app/agentcore/**'
+              - '.github/workflows/pr-check.yml'
             gateway:
               - 'agentcore/gateway-tools/**'
+              - '.github/workflows/pr-check.yml'
             frontend:
               - 'chatbot-app/frontend/**'
+              - '.github/workflows/pr-check.yml'
             a2a:
               - 'agentcore/a2a-agents/**'
+              - '.github/workflows/pr-check.yml'
             mcp:
               - 'agentcore/mcp-runtime/**'
+              - '.github/workflows/pr-check.yml'
+            infra:
+              - 'infra/**'
+              - '.github/workflows/pr-check.yml'
+            mobile:
+              - 'mobile-app/**'
+              - '.github/workflows/pr-check.yml'
+            telegram:
+              - 'telegram-app/**'
+              - '.github/workflows/pr-check.yml'
 
   backend:
     name: Backend (Python)
@@ -186,3 +203,81 @@ jobs:
 
       - name: Tests
         run: python -m pytest tests/ -v --tb=short
+
+  infrastructure:
+    name: Infrastructure (Terraform)
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.15.8"
+
+      - name: Format check
+        run: terraform fmt -check -recursive infra/
+
+      - name: Initialize without remote state
+        working-directory: infra/environments/dev
+        run: terraform init -backend=false -input=false
+
+      - name: Validate
+        working-directory: infra/environments/dev
+        run: terraform validate -no-color
+
+      - name: Check deploy script syntax
+        run: bash -n infra/scripts/deploy.sh infra/scripts/test-api.sh
+
+      - name: Check model smoke script syntax
+        run: python3 -m py_compile infra/scripts/model-smoke.py
+
+  mobile:
+    name: Mobile (TypeScript)
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile-app
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: mobile-app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  telegram:
+    name: Telegram (TypeScript)
+    needs: changes
+    if: needs.changes.outputs.telegram == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: telegram-app
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: telegram-app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Problem

Three deployable components have **no CI**. Terraform under `infra/`, the Expo app in `mobile-app/`, and the adapter in `telegram-app/` are built and validated by no job, so changes to them merge on review alone.

This is not hypothetical. Every recent PR touching those paths — #183, #190, #196, #197, #204 — had nothing but my local runs behind it. Two problems that landed in this window illustrate the gap:

- `mobile-app/package-lock.json` had drifted so far that **`npm ci` failed outright** (fixed in #196). A `mobile` job would have caught it at the commit that broke it.
- `mobile-app` accumulated **21 dependabot advisories**, 1 critical (#197), while every dependabot PR meant to fix them sat unmergeable.

## Changes

One job per component, gated on the existing `dorny/paths-filter` so unrelated PRs skip them:

| Job | Steps |
| --- | --- |
| `infrastructure` | `terraform fmt -check -recursive`, `init -backend=false`, `validate`, `bash -n` on deploy.sh/test-api.sh, `py_compile` on model-smoke.py |
| `mobile` | `npm ci`, `npx tsc --noEmit` |
| `telegram` | `npm ci`, `npm run build` |

These are exactly the commands I ran by hand to verify the PRs above, so the jobs codify existing practice rather than introducing new checks.

The path filters include `.github/workflows/pr-check.yml` itself, so editing a job re-runs it instead of skipping on the grounds that no component file changed.

## Note on scope

This PR contains **only** the three new jobs. The `--select E4,E7,E9,F` flags that originally accompanied this change are omitted — #186 moved that rule set into per-component `ruff.toml` files, which keeps a bare `ruff check` locally in agreement with CI. Adding the flags here would duplicate that.

## Verification

Each job's commands, reproduced locally against this branch:

| Check | Result |
| --- | --- |
| `terraform fmt -check -recursive infra/` | pass |
| `terraform init -backend=false` + `validate` | pass |
| `bash -n infra/scripts/{deploy,test-api}.sh` | pass |
| `python3 -m py_compile infra/scripts/model-smoke.py` | pass |
| `npm ci` + `npx tsc --noEmit` (mobile) | pass |
| `npm ci` + `npm run build` (telegram) | pass |

Also confirmed the YAML parses, that all 9 jobs and 8 filter outputs resolve, and that every referenced path exists.

This PR touches `infra/`-adjacent config only via the filter, so the new jobs should run on this PR itself — that's the real test.