### PR TITLE
ci: bump setup-python and setup-node to v7

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: npm
@@ -149,7 +149,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -189,7 +189,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -246,7 +246,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: npm
@@ -270,7 +270,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: npm


### PR DESCRIPTION
## Summary

Both actions [migrated their internals to ESM in v7](https://github.com/actions/setup-node) with **no change to inputs, outputs, or behavior**.

## The one breaking change, and why it doesn't apply

`setup-node@v7` removes the dummy `NODE_AUTH_TOKEN` fallback, so a workflow that sets `registry-url` without supplying the token can now fail (Yarn Classic and older npm break; pnpm warns).

This workflow sets neither and never publishes:

```
$ grep -rn 'registry-url\|NODE_AUTH_TOKEN\|npmrc' .github/
(no matches)
```

Both actions also require a runner at **v2.327.1 or later** for node24. All 9 jobs run on `ubuntu-latest`, which is well past that.

## Scope vs #172

Dependabot's #172 covers **5 of the 7** call sites. It was opened against `35bc3a98`, before the `infrastructure`, `mobile`, and `telegram` jobs existed — merging it would have **reverted those three jobs** (its workflow file has only 6 jobs). This PR bumps all 7, including the two `setup-node` uses in the new mobile and telegram jobs.

| Action | Call sites bumped |
| --- | --- |
| `actions/setup-python` | 4 (backend, gateway-lambda, a2a-agents, mcp-runtime) |
| `actions/setup-node` | 3 (frontend, mobile, telegram) |

## Verification

- YAML parses; all 9 jobs intact (`changes`, `backend`, `gateway-lambda`, `frontend`, `a2a-agents`, `mcp-runtime`, `infrastructure`, `mobile`, `telegram`)
- No `registry-url` / `NODE_AUTH_TOKEN` usage anywhere under `.github/`
- All jobs on GitHub-hosted `ubuntu-latest`

Since this PR edits the workflow file, the path filters route every job to run on it — so CI here is the actual test that all 7 bumped actions work.

I'll close #172 once this lands.