### PR TITLE
feat(models): move the Opus picker entry to Opus 5

### DIFF
--- a/chatbot-app/agentcore/src/agents/model_factory.py
+++ b/chatbot-app/agentcore/src/agents/model_factory.py
@@ -24,9 +24,17 @@ from strands.models import BedrockModel, CacheConfig
 logger = logging.getLogger(__name__)
 
 
-# Model IDs (substring match) that reject the `temperature` inference param:
-# Anthropic extended-thinking Opus, Sonnet 5, and OpenAI gpt-5.x reasoning models.
-NO_TEMPERATURE_MODELS = ("opus-4-7", "opus-4-8", "sonnet-5", "gpt-5")
+# Reasoning models that reject the `temperature` inference param. Listed by
+# exact ID rather than substring: a substring like "opus-5" also matches
+# "opus-4-5", which does accept temperature. Add an entry when a model is added
+# to the picker.
+NO_TEMPERATURE_MODELS = frozenset({
+    "us.anthropic.claude-opus-5",
+    "us.anthropic.claude-sonnet-5",
+    "openai.gpt-5.6-sol",
+    "openai.gpt-5.6-terra",
+    "openai.gpt-5.6-luna",
+})
 
 
 @dataclass(frozen=True)
@@ -68,7 +76,7 @@ NATIVE_MODEL_REGION_OVERRIDES: dict[str, str] = {
 
 
 def model_rejects_temperature(model_id: str) -> bool:
-    return any(tag in model_id for tag in NO_TEMPERATURE_MODELS)
+    return model_id in NO_TEMPERATURE_MODELS
 
 
 _bedrock_api_key: Optional[str] = None

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -737,11 +737,11 @@ class TestModelConfiguration:
 
         client.post(
             "/invocations",
-            json=_agui_payload(model_id="claude-3-opus")
+            json=_agui_payload(model_id="us.anthropic.claude-opus-5")
         )
 
         call_kwargs = mock_factory.call_args.kwargs
-        assert call_kwargs['model_id'] == "claude-3-opus"
+        assert call_kwargs['model_id'] == "us.anthropic.claude-opus-5"
 
     @patch('routers.chat.create_agent')
     def test_passes_temperature(self, mock_factory, mock_agent):

--- a/chatbot-app/agentcore/tests/unit/test_model_factory.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_factory.py
@@ -28,8 +28,7 @@ def _reset_key_cache():
 
 class TestTemperatureGuard:
     @pytest.mark.parametrize("model_id", [
-        "us.anthropic.claude-opus-4-7",
-        "us.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-opus-5",
         "us.anthropic.claude-sonnet-5",
         "openai.gpt-5.6-sol",
         "openai.gpt-5.6-terra",
@@ -45,6 +44,18 @@ class TestTemperatureGuard:
     ])
     def test_allows(self, model_id):
         assert model_rejects_temperature(model_id) is False
+
+    def test_guard_matches_whole_ids_not_substrings(self):
+        """Every entry must be matched as a whole ID.
+
+        A substring check would let a longer, unrelated ID that merely contains
+        an entry be treated as temperature-rejecting — e.g. a future
+        "…claude-opus-5-lite" or a "…claude-sonnet-5-preview" snapshot.
+        """
+        for entry in mf.NO_TEMPERATURE_MODELS:
+            assert model_rejects_temperature(entry) is True
+            assert model_rejects_temperature(f"{entry}-preview") is False
+            assert model_rejects_temperature(f"prefixed.{entry}") is False
 
 
 class TestBedrockRouting:
@@ -63,7 +74,7 @@ class TestBedrockRouting:
 
     def test_no_temperature_for_opus(self):
         with patch.object(mf, "BedrockModel") as MockBedrock:
-            build_model("us.anthropic.claude-opus-4-8", temperature=0.7)
+            build_model("us.anthropic.claude-opus-5", temperature=0.7)
             assert "temperature" not in MockBedrock.call_args.kwargs
 
     def test_no_cache_when_disabled(self):

--- a/chatbot-app/frontend/src/app/api/model/available-models/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/available-models/route.ts
@@ -13,8 +13,8 @@ export const runtime = 'nodejs'
 const AVAILABLE_MODELS = [
   // Claude (Anthropic) - native Bedrock, prompt caching
   {
-    id: 'us.anthropic.claude-opus-4-8',
-    name: 'Claude Opus 4.8',
+    id: 'us.anthropic.claude-opus-5',
+    name: 'Claude Opus 5',
     provider: 'Anthropic',
     description: 'Most intelligent model, best for complex tasks',
     noTemperature: true

--- a/mobile-app/src/lib/constants.ts
+++ b/mobile-app/src/lib/constants.ts
@@ -31,7 +31,7 @@ export interface ModelInfo {
 }
 
 export const AVAILABLE_MODELS: ModelInfo[] = [
-  { id: 'us.anthropic.claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic', description: 'Most intelligent model' },
+  { id: 'us.anthropic.claude-opus-5', name: 'Claude Opus 5', provider: 'Anthropic', description: 'Most intelligent model' },
   { id: 'us.anthropic.claude-sonnet-5', name: 'Claude Sonnet 5', provider: 'Anthropic', description: 'Balanced performance' },
   { id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0', name: 'Claude Haiku 4.5', provider: 'Anthropic', description: 'Fast and efficient' },
   { id: 'openai.gpt-5.6-sol', name: 'GPT-5.6 Sol', provider: 'OpenAI', description: 'Flagship frontier model' },

--- a/telegram-app/src/message-handler.ts
+++ b/telegram-app/src/message-handler.ts
@@ -18,7 +18,7 @@ import { bufferPhotoGroup } from "./media-group-buffer.js";
 const MODELS = [
   { id: "us.anthropic.claude-sonnet-5", label: "Sonnet 5" },
   { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Haiku 4.5" },
-  { id: "us.anthropic.claude-opus-4-8", label: "Opus 4.8" },
+  { id: "us.anthropic.claude-opus-5", label: "Opus 5" },
   { id: "openai.gpt-5.6-sol", label: "GPT-5.6 Sol" },
   { id: "openai.gpt-5.6-terra", label: "GPT-5.6 Terra" },
   { id: "openai.gpt-5.6-luna", label: "GPT-5.6 Luna" },


### PR DESCRIPTION
## Summary

Claude Opus 5 supersedes Opus 4.8 in the Opus line at the **same pricing** ($5/$25 per MTok, 1M context, 128K output), so the picker entry moves rather than growing a second Opus row.

Confirmed the inference profile is actually served in this account before switching — not assumed:

```
$ aws bedrock list-inference-profiles --region us-west-2
us.anthropic.claude-opus-5      ← available
us.anthropic.claude-opus-4-8
```

## The temperature guard could not just take one more entry

`model_rejects_temperature` matched on **substrings**:

```python
NO_TEMPERATURE_MODELS = ("opus-4-7", "opus-4-8", "sonnet-5", "gpt-5")
return any(tag in model_id for tag in NO_TEMPERATURE_MODELS)
```

Adding `"opus-5"` there also matches **`opus-4-5`** — a model that *does* accept `temperature` and is still served on Bedrock. The guard would have started stripping `temperature` from a model that wants it.

So the guard now matches whole IDs against a `frozenset`:

```python
NO_TEMPERATURE_MODELS = frozenset({
    "us.anthropic.claude-opus-5",
    "us.anthropic.claude-sonnet-5",
    "openai.gpt-5.6-sol", "openai.gpt-5.6-terra", "openai.gpt-5.6-luna",
})
return model_id in NO_TEMPERATURE_MODELS
```

An entry can no longer widen to an unrelated ID. That means the set needs **no defensive entries for models the picker doesn't offer** — so `opus-4-7` / `opus-4-8` drop out of the set and the tests along with them, and only currently-offered models remain.

**Trade-off:** the set must now list every ID the picker can send, where the substring form absorbed version suffixes. `test_guard_matches_whole_ids_not_substrings` asserts each entry matches only itself (`{entry}-preview` and `prefixed.{entry}` must not match), so reverting to substring matching fails CI instead of silently mis-stripping `temperature`.

## Verification

| Check | Result |
| --- | --- |
| `ruff check src/` | pass |
| `pytest tests/unit/` | 438 passed |
| `npm run type-check` (frontend) | pass |
| `npm test` (frontend) | 530 passed |
| `npm run build` (frontend) | pass |
| `npx tsc --noEmit` (mobile) | pass |
| `npm run build` (telegram) | pass |

**Mutation-checked** — each guard test was verified to actually fail on the bug it targets:

| Mutation | Result |
| --- | --- |
| Drop `claude-opus-5` from the set | 2 failed ✅ |
| Revert to substring matching | 1 failed ✅ |

The second one matters: an earlier version of that test passed under substring matching (it asserted `opus-4-5` isn't matched, which is vacuously true once 4.7/4.8 leave the set). It was rewritten to assert the property directly.

## Files

- `model_factory.py` — exact-match guard
- `available-models/route.ts`, `mobile-app/constants.ts`, `telegram-app/message-handler.ts` — picker entries
- `test_model_factory.py` — Opus 5 cases, legacy entries dropped, whole-ID test
- `test_chat_router.py` — `claude-3-opus` placeholder → Opus 5 (a generic pass-through fixture, not a registry assertion)