### PR TITLE
fix(oauth): make the 3LO flow work end to end

### DIFF
--- a/agentcore/mcp-runtime/requirements-dev.txt
+++ b/agentcore/mcp-runtime/requirements-dev.txt
@@ -1,4 +1,7 @@
-# Test and lint dependencies
+# Test and lint dependencies.
+# Runtime deps are included so test_runtime_dependencies.py can verify the
+# resolved versions actually provide the APIs the server imports.
+-r requirements.txt
 pytest>=7.0.0
 pytest-timeout>=2.0.0
 starlette>=0.27.0

--- a/agentcore/mcp-runtime/requirements.txt
+++ b/agentcore/mcp-runtime/requirements.txt
@@ -1,4 +1,6 @@
-mcp>=1.26.0
+# Upper bound required: mcp 2.0 removed mcp.server.fastmcp, which this server
+# imports. Matches the orchestrator's pin.
+mcp>=1.26.0,<2.0.0
 bedrock-agentcore
 httpx>=0.25.0
 boto3>=1.40.0

--- a/agentcore/mcp-runtime/src/agentcore_oauth.py
+++ b/agentcore/mcp-runtime/src/agentcore_oauth.py
@@ -125,7 +125,7 @@ class OAuthHelper:
         logger.info(f"[OAuth] Scopes: {scopes}")
         logger.info(f"[OAuth] Callback URL: {self.callback_url}")
 
-    async def get_access_token(self, force: bool = False) -> TokenResult:
+    async def get_access_token(self, force: bool = False, custom_state: Optional[str] = None) -> TokenResult:
         """Get OAuth access token from AgentCore Token Vault.
 
         This method bypasses the @requires_access_token decorator and directly
@@ -139,6 +139,9 @@ class OAuthHelper:
                 always starts a new 3LO flow, even if a cached token exists.
                 Use this after the provider returns 401/403 on a cached token
                 (Vault cannot detect server-side revocations on its own).
+            custom_state: Opaque string Identity echoes back to the callback
+                URL. We pass the elicitation ID so the callback page can
+                correlate the redirect without any browser-side storage.
 
         Returns:
             TokenResult: Contains either token (cache hit) or auth_url (consent needed)
@@ -157,7 +160,7 @@ class OAuthHelper:
 
         # Direct API call to get OAuth2 token
         try:
-            response = self._identity_client.dp_client.get_resource_oauth2_token(
+            kwargs = dict(
                 resourceCredentialProviderName=self.provider_name,
                 scopes=self.scopes,
                 oauth2Flow="USER_FEDERATION",
@@ -165,6 +168,9 @@ class OAuthHelper:
                 resourceOauth2ReturnUrl=self.callback_url,
                 forceAuthentication=force,
             )
+            if custom_state:
+                kwargs["customState"] = custom_state
+            response = self._identity_client.dp_client.get_resource_oauth2_token(**kwargs)
         except Exception as e:
             logger.error(f"[OAuth] Failed to get token from Identity service: {e}")
             raise
@@ -215,7 +221,11 @@ async def get_token_with_elicitation(
     """
     from mcp.server.elicitation import AcceptedUrlElicitation
 
-    result = await oauth.get_access_token(force=force)
+    # Generated before the token request so it can ride along as customState:
+    # Identity echoes it onto the callback redirect, which is how the frontend
+    # callback page correlates the redirect to this elicitation.
+    elicitation_id = str(uuid.uuid4())
+    result = await oauth.get_access_token(force=force, custom_state=elicitation_id)
 
     if result.token:
         return result.token
@@ -224,7 +234,7 @@ async def get_token_with_elicitation(
         elicit_result = await ctx.elicit_url(
             message=f"{service_name} authorization required",
             url=result.auth_url,
-            elicitation_id=str(uuid.uuid4()),
+            elicitation_id=elicitation_id,
         )
 
         if isinstance(elicit_result, AcceptedUrlElicitation):

--- a/agentcore/mcp-runtime/tests/test_oauth_helper.py
+++ b/agentcore/mcp-runtime/tests/test_oauth_helper.py
@@ -220,9 +220,12 @@ class TestGetTokenWithElicitation:
 
         call_count = 0
 
-        async def mock_get_access_token(force=False):
+        seen_custom_states = []
+
+        async def mock_get_access_token(force=False, custom_state=None):
             nonlocal call_count
             call_count += 1
+            seen_custom_states.append(custom_state)
             if call_count == 1:
                 return TokenResult(auth_url="https://consent.url")
             return TokenResult(token="post-consent-token")
@@ -237,6 +240,11 @@ class TestGetTokenWithElicitation:
             token = asyncio.run(get_token_with_elicitation(ctx, oauth, "Gmail"))
 
         assert token == "post-consent-token"
+        # The elicitation ID given to elicit_url must equal the customState of
+        # the auth-URL request: Identity echoes it back to the callback page,
+        # which is the only correlation channel between popup and elicitation.
+        elicit_kwargs = ctx.elicit_url.call_args.kwargs
+        assert seen_custom_states[0] == elicit_kwargs["elicitation_id"]
 
 
 # ============================================================

--- a/agentcore/mcp-runtime/tests/test_runtime_dependencies.py
+++ b/agentcore/mcp-runtime/tests/test_runtime_dependencies.py
@@ -1,0 +1,42 @@
+"""Verify the resolved runtime dependencies provide the APIs the server uses.
+
+conftest.py mocks the AWS SDKs so the unit tests can run offline, which means
+nothing else here exercises what pip actually installs. That gap let mcp 2.0 —
+which removed mcp.server.fastmcp — resolve into a deployed image and crash the
+runtime on startup. These tests import the real packages, so they fail at
+install time instead.
+"""
+
+import importlib
+
+
+def _import(name: str):
+    """Import for real, bypassing conftest's MagicMock entries."""
+    import sys
+
+    saved = {k: v for k, v in sys.modules.items() if k == name or k.startswith(name + ".")}
+    for k in saved:
+        del sys.modules[k]
+    try:
+        return importlib.import_module(name)
+    finally:
+        sys.modules.update(saved)
+
+
+def test_fastmcp_is_importable():
+    """mcp_server.py does `from mcp.server.fastmcp import FastMCP`."""
+    mod = _import("mcp.server.fastmcp")
+    assert hasattr(mod, "FastMCP")
+    assert hasattr(mod, "Context")
+
+
+def test_context_supports_url_elicitation():
+    """The 3LO flow pauses tools with ctx.elicit_url()."""
+    ctx = _import("mcp.server.fastmcp").Context
+    assert hasattr(ctx, "elicit_url")
+
+
+def test_accepted_url_elicitation_is_importable():
+    """agentcore_oauth.get_token_with_elicitation checks this result type."""
+    mod = _import("mcp.server.elicitation")
+    assert hasattr(mod, "AcceptedUrlElicitation")

--- a/chatbot-app/agentcore/src/agent/mcp/elicitation_bridge.py
+++ b/chatbot-app/agentcore/src/agent/mcp/elicitation_bridge.py
@@ -298,13 +298,6 @@ def _get_elicitation_store() -> ElicitationStore:
     return _store_instance
 
 
-# ── Public API ─────────────────────────────────────────────────────────
-
-def signal_elicitation_complete(session_id: str, elicitation_id: Optional[str] = None) -> None:
-    store = _get_elicitation_store()
-    store.signal_complete(session_id, elicitation_id)
-
-
 # ── Bridge registry ───────────────────────────────────────────────────
 
 _elicitation_bridges: dict[str, OAuthElicitationBridge] = {}

--- a/chatbot-app/agentcore/src/agent/mcp/elicitation_bridge.py
+++ b/chatbot-app/agentcore/src/agent/mcp/elicitation_bridge.py
@@ -7,10 +7,15 @@ This bridge:
 1. Pushes an event to the outbound queue (SSE stream picks it up)
 2. Waits for the frontend to signal completion via shared store (DynamoDB or in-memory)
 3. Calls CompleteResourceTokenAuth from orchestrator's workload identity context
-4. Returns the result to the MCPClient so the tool can resume
+4. Emits a completion event on the same queue so the frontend can close its dialog
+5. Returns the result to the MCPClient so the tool can resume
+
+The elicitation ID is the sole correlation key. It is a server-generated UUID
+that AgentCore Identity echoes back to the OAuth callback page as customState,
+so the popup needs nothing from browser storage to signal completion.
 
 Cloud mode uses DynamoDB for cross-container signaling (same pattern as StopSignalProvider).
-Local mode uses in-memory threading.Event for simplicity.
+Local mode uses in-memory state for simplicity.
 """
 
 import asyncio
@@ -75,15 +80,30 @@ class OAuthElicitationBridge:
                     await self._complete_token_auth(oauth_session_uri)
 
                 store.clear(self.session_id, elicitation_id)
+                await self._emit_resolution(elicitation_id, "completed")
                 return ElicitResult(action="accept")
             else:
                 logger.warning(f"[Elicitation] Timeout waiting for OAuth: {elicitation_id}")
                 store.clear(self.session_id, elicitation_id)
+                await self._emit_resolution(elicitation_id, "timeout")
                 return ElicitResult(action="cancel")
         except asyncio.TimeoutError:
             logger.warning(f"[Elicitation] Timeout waiting for OAuth: {elicitation_id}")
             store.clear(self.session_id, elicitation_id)
+            await self._emit_resolution(elicitation_id, "timeout")
             return ElicitResult(action="cancel")
+
+    async def _emit_resolution(self, elicitation_id: str, status: str):
+        """Tell the frontend (over its own SSE stream) that the elicitation is
+        settled, so it can dismiss the OAuth dialog without any popup->parent
+        channel (postMessage and shared storage both break across the OAuth
+        redirect chain)."""
+        await self._outbound_queue.put({
+            "type": "oauth_elicitation_resolved",
+            "elicitation_id": elicitation_id,
+            "status": status,
+            "session_id": self.session_id,
+        })
 
     async def _complete_token_auth(self, oauth_session_uri: str):
         """Call CompleteResourceTokenAuth from orchestrator's workload identity context."""
@@ -159,9 +179,13 @@ class DynamoDBElicitationStore(ElicitationStore):
         self._table_name = table_name
 
     def _get_key(self, session_id: str, elicitation_id: str) -> dict:
+        # Keyed by elicitation ID alone: it is a server-generated UUID, and the
+        # OAuth callback page can only present the ID it received as
+        # customState — it has no session context. session_id is kept as an
+        # attribute for observability.
         return {
-            "userId": {"S": f"ELICIT#{session_id}"},
-            "sk": {"S": f"EID#{elicitation_id}"},
+            "userId": {"S": f"ELICIT#{elicitation_id}"},
+            "sk": {"S": "META"},
         }
 
     def register_pending(self, session_id: str, elicitation_id: str, user_id: str) -> None:
@@ -171,6 +195,7 @@ class DynamoDBElicitationStore(ElicitationStore):
                 **self._get_key(session_id, elicitation_id),
                 "status": {"S": "pending"},
                 "ownerUserId": {"S": user_id},
+                "sessionId": {"S": session_id},
                 "ttl": {"N": str(int(time.time()) + 600)},
             },
         )
@@ -181,6 +206,7 @@ class DynamoDBElicitationStore(ElicitationStore):
             item = {
                 **self._get_key(session_id, eid),
                 "status": {"S": "completed"},
+                "sessionId": {"S": session_id},
                 "ttl": {"N": str(int(time.time()) + 600)},
             }
             if oauth_session_uri:

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -213,14 +213,6 @@ async def invocations(http_request: Request):
         logger.info(f"[Stop] Stop signal set for session={thread_id}, run={run_id}")
         return {"status": "stop_requested", "session_id": thread_id, "run_id": run_id}
 
-    # Elicitation complete — write to shared store (DynamoDB in cloud, in-memory locally)
-    if action == "elicitation_complete":
-        from agent.mcp.elicitation_bridge import signal_elicitation_complete
-        elicitation_id = state.get("elicitation_id")
-        signal_elicitation_complete(thread_id, elicitation_id)
-        logger.info(f"[Elicitation] Complete for session={thread_id}, elicitation_id={elicitation_id}")
-        return {"status": "elicitation_completed"}
-
     # Execution status — check if a buffered execution is still running
     if action == "execution_status":
         execution_id = state.get("execution_id")

--- a/chatbot-app/agentcore/src/streaming/agui_event_processor.py
+++ b/chatbot-app/agentcore/src/streaming/agui_event_processor.py
@@ -355,12 +355,19 @@ class AGUIStreamEventProcessor:
                     # Task-based polling: check bridge for pending elicitation events
                     elicit_event = elicitation_bridge.get_pending_event_nowait()
                     if elicit_event:
-                        yield self.formatter.format_event(
-                            "oauth_elicitation",
-                            authUrl=elicit_event["auth_url"],
-                            message=elicit_event.get("message", ""),
-                            elicitationId=elicit_event["elicitation_id"],
-                        )
+                        if elicit_event["type"] == "oauth_elicitation_resolved":
+                            yield self.formatter.format_event(
+                                "oauth_elicitation_resolved",
+                                elicitationId=elicit_event["elicitation_id"],
+                                status=elicit_event["status"],
+                            )
+                        else:
+                            yield self.formatter.format_event(
+                                "oauth_elicitation",
+                                authUrl=elicit_event["auth_url"],
+                                message=elicit_event.get("message", ""),
+                                elicitationId=elicit_event["elicitation_id"],
+                            )
 
                     if next_event_task is None:
                         next_event_task = asyncio.ensure_future(stream_aiter.__anext__())

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -427,35 +427,6 @@ class TestLifecycleActions:
 
         assert response.status_code == 400
 
-    @patch('agent.mcp.elicitation_bridge.get_bridge')
-    def test_elicitation_complete(self, mock_get_bridge):
-        """Test elicitation_complete action signals bridge."""
-        mock_bridge = MagicMock()
-        mock_get_bridge.return_value = mock_bridge
-
-        from routers.chat import router
-        from fastapi import FastAPI
-
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
-
-        response = client.post(
-            "/invocations",
-            json={
-                "thread_id": "test-session",
-                "run_id": str(uuid.uuid4()),
-                "state": {
-                    "action": "elicitation_complete",
-                    "user_id": "test-user",
-                    "elicitation_id": "elic-123"
-                }
-            }
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"status": "elicitation_completed"}
-
     def test_execution_status_not_found(self):
         """Test execution_status action returns not_found for unknown execution."""
         from routers.chat import router

--- a/chatbot-app/agentcore/tests/unit/test_elicitation_bridge.py
+++ b/chatbot-app/agentcore/tests/unit/test_elicitation_bridge.py
@@ -15,3 +15,16 @@ def test_completion_is_correlated_to_exact_elicitation_id():
 
     store.clear("session-1", "elicitation-1")
     store.clear("session-1", "elicitation-2")
+
+
+def test_dynamodb_store_keys_by_elicitation_id_alone():
+    """The OAuth callback page only knows the elicitation ID (echoed back as
+    customState); it has no chat-session context. The DynamoDB key must
+    therefore be derivable from the elicitation ID by itself."""
+    from agent.mcp.elicitation_bridge import DynamoDBElicitationStore
+
+    key_a = DynamoDBElicitationStore._get_key(None, "session-a", "eid-1")
+    key_b = DynamoDBElicitationStore._get_key(None, "session-b", "eid-1")
+
+    assert key_a == key_b
+    assert "eid-1" in key_a["userId"]["S"]

--- a/chatbot-app/frontend/__tests__/api/chat-federation.test.ts
+++ b/chatbot-app/frontend/__tests__/api/chat-federation.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  extractUserFromRequest: vi.fn(),
+  getSessionId: vi.fn(),
+  ensureSessionExists: vi.fn(),
+  invokeAgentCoreRuntime: vi.fn(),
+  createDefaultHookManager: vi.fn(),
+  getUserDisabledSkills: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-utils', () => ({
+  extractUserFromRequest: mocks.extractUserFromRequest,
+  getSessionId: mocks.getSessionId,
+  ensureSessionExists: mocks.ensureSessionExists,
+}))
+
+vi.mock('@/lib/agentcore-runtime-client', () => ({
+  invokeAgentCoreRuntime: mocks.invokeAgentCoreRuntime,
+}))
+
+vi.mock('@/lib/chat-hooks', () => ({
+  createDefaultHookManager: mocks.createDefaultHookManager,
+}))
+
+vi.mock('@/lib/dynamodb-client', () => ({
+  getUserDisabledSkills: mocks.getUserDisabledSkills,
+}))
+
+vi.mock('sharp', () => ({ default: vi.fn() }))
+
+function request(state: Record<string, unknown>) {
+  return {
+    headers: { get: vi.fn().mockReturnValue(null) },
+    signal: { addEventListener: vi.fn() },
+    json: vi.fn().mockResolvedValue({
+      threadId: 'session-1',
+      runId: 'run-1',
+      messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+      tools: [],
+      context: [],
+      state,
+    }),
+  }
+}
+
+/** Drain the streamed response so the handler body actually runs. */
+async function drain(response: Response) {
+  const reader = response.body?.getReader()
+  if (!reader) return
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done } = await reader.read()
+    if (done) break
+  }
+}
+
+function forwardedState() {
+  expect(mocks.invokeAgentCoreRuntime).toHaveBeenCalled()
+  return mocks.invokeAgentCoreRuntime.mock.calls[0][0].state as Record<string, unknown>
+}
+
+describe('POST /api/stream/chat — 3LO federation opt-out', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'true')
+    mocks.extractUserFromRequest.mockResolvedValue({ userId: 'user-1' })
+    mocks.getSessionId.mockReturnValue('session-1')
+    mocks.ensureSessionExists.mockResolvedValue({ isNew: false })
+    mocks.createDefaultHookManager.mockReturnValue({
+      executeBeforeHooks: vi.fn().mockResolvedValue(undefined),
+      executeAfterHooks: vi.fn().mockResolvedValue(undefined),
+    })
+    mocks.invokeAgentCoreRuntime.mockResolvedValue(
+      new ReadableStream({ start: (c) => c.close() })
+    )
+  })
+
+  // Mobile has no OAuth callback page, so it sends allow_user_federation=false.
+  // The BFF rebuilds state from scratch — the flag has to be carried across.
+  it('forwards allow_user_federation=false to the runtime', async () => {
+    const { POST } = await import('@/app/api/stream/chat/route')
+    await drain(await POST(request({ allow_user_federation: false }) as never))
+
+    expect(forwardedState().allow_user_federation).toBe(false)
+  })
+
+  it('omits the flag when the client does not opt out', async () => {
+    const { POST } = await import('@/app/api/stream/chat/route')
+    await drain(await POST(request({}) as never))
+
+    expect(forwardedState()).not.toHaveProperty('allow_user_federation')
+  })
+
+  it('treats a truthy value as the default rather than an opt-out', async () => {
+    const { POST } = await import('@/app/api/stream/chat/route')
+    await drain(await POST(request({ allow_user_federation: true }) as never))
+
+    expect(forwardedState()).not.toHaveProperty('allow_user_federation')
+  })
+})

--- a/chatbot-app/frontend/__tests__/app/oauth-complete.test.tsx
+++ b/chatbot-app/frontend/__tests__/app/oauth-complete.test.tsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+
+import OAuthCompletePage from "@/app/oauth-complete/page"
+
+vi.mock("aws-amplify/auth", () => ({
+  fetchAuthSession: vi.fn(async () => ({
+    tokens: { accessToken: { toString: () => "access-token" } },
+  })),
+}))
+
+const SESSION_URI = "urn:ietf:params:oauth:request_uri:abc123"
+
+function renderWithQuery(query: string) {
+  window.history.replaceState({}, "", `/oauth-complete?${query}`)
+  return render(<OAuthCompletePage />)
+}
+
+describe("OAuthCompletePage", () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    fetchMock = vi.fn(async () => ({ ok: true, status: 200 }) as unknown as Response)
+    vi.stubGlobal("fetch", fetchMock)
+    vi.spyOn(window, "close").mockImplementation(() => {})
+  })
+
+  // AWS documents that customState is echoed to the callback URL but never
+  // names the query parameter, so every plausible spelling must work.
+  it.each(["state", "customState", "custom_state"])(
+    "completes the flow when the elicitation ID arrives as %s",
+    async (param) => {
+      renderWithQuery(
+        `session_id=${encodeURIComponent(SESSION_URI)}&${param}=elicitation-123`
+      )
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(url).toBe("/api/stream/elicitation-complete")
+      expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+        elicitationId: "elicitation-123",
+        oauthSessionUri: SESSION_URI,
+      })
+    }
+  )
+
+  it("fails without calling the BFF when no state parameter is present", async () => {
+    renderWithQuery(`session_id=${encodeURIComponent(SESSION_URI)}`)
+
+    expect(await screen.findByText("Authorization Failed")).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("fails without calling the BFF when session_id is missing", async () => {
+    renderWithQuery("state=elicitation-123")
+
+    expect(await screen.findByText("Authorization Failed")).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/chatbot-app/frontend/__tests__/components/OAuthElicitationDialog.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/OAuthElicitationDialog.test.tsx
@@ -26,7 +26,6 @@ describe("OAuthElicitationDialog", () => {
     render(
       <OAuthElicitationDialog
         oauth={oauth}
-        sessionId="session-123"
         onCancel={vi.fn()}
       />
     )
@@ -35,14 +34,13 @@ describe("OAuthElicitationDialog", () => {
     expect(screen.getByRole("button", { name: "Continue" })).toBeInTheDocument()
   })
 
-  it("opens the authorization URL and persists callback context", () => {
+  it("opens the authorization URL without touching browser storage", () => {
     const focus = vi.fn()
     const open = vi.spyOn(window, "open").mockReturnValue({ focus } as unknown as Window)
 
     render(
       <OAuthElicitationDialog
         oauth={oauth}
-        sessionId="session-123"
         onCancel={vi.fn()}
       />
     )
@@ -54,13 +52,9 @@ describe("OAuthElicitationDialog", () => {
       "width=500,height=700,scrollbars=yes,resizable=yes"
     )
     expect(focus).toHaveBeenCalled()
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      "oauth_pending",
-      JSON.stringify({
-        sessionId: "session-123",
-        elicitationId: "elicitation-123",
-      })
-    )
+    // The elicitation ID travels via AgentCore customState, not storage —
+    // storage is invisible to the popup across the OAuth redirect chain.
+    expect(localStorage.setItem).not.toHaveBeenCalled()
   })
 
   it("shows recovery guidance when the popup is blocked", () => {
@@ -69,7 +63,6 @@ describe("OAuthElicitationDialog", () => {
     render(
       <OAuthElicitationDialog
         oauth={oauth}
-        sessionId="session-123"
         onCancel={vi.fn()}
       />
     )
@@ -85,7 +78,6 @@ describe("OAuthElicitationDialog", () => {
     render(
       <OAuthElicitationDialog
         oauth={oauth}
-        sessionId="session-123"
         onCancel={onCancel}
       />
     )

--- a/chatbot-app/frontend/src/app/api/stream/chat/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/chat/route.ts
@@ -160,6 +160,9 @@ export async function POST(request: NextRequest) {
     let request_type: string | undefined = state.request_type
     let selected_artifact_id: string | undefined = state.selected_artifact_id
     let system_prompt: string | undefined = state.system_prompt
+    // Clients without an OAuth callback page (mobile) opt out of 3LO skills.
+    // Only an explicit false disables them, so web keeps the default.
+    const allow_user_federation: boolean = state.allow_user_federation !== false
 
     // Extract user message from the last element of body.messages.
     // content may be a string (text-only) or an InputContentPart[] (multimodal).
@@ -395,6 +398,7 @@ export async function POST(request: NextRequest) {
             ...(selected_artifact_id && { selected_artifact_id }),
             ...(request_type && { request_type }),
             ...(disabled_skills.length > 0 && { disabled_skills }),
+            ...(!allow_user_federation && { allow_user_federation: false }),
           }
 
           const aguiBody = {

--- a/chatbot-app/frontend/src/app/api/stream/elicitation-complete/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/elicitation-complete/route.ts
@@ -1,15 +1,17 @@
 /**
  * Elicitation Complete API endpoint
  *
- * Writes the OAuth completion signal directly to the shared DynamoDB store
- * that the orchestrator's elicitation_bridge reads. We do NOT call the
- * orchestrator runtime here — the runtime only trusts user JWTs, and this
- * request originates from a popup context where the Amplify session is
- * sometimes not hydrated yet. The BFF (ECS task) has IAM permissions on the
- * shared DynamoDB users table, so it can write the signal directly.
+ * The OAuth callback page posts here after AgentCore Identity redirects the
+ * user's browser back with session_id + state (= elicitation ID). This is the
+ * "user verification" step of AgentCore's session-binding flow: we verify the
+ * caller's Cognito session and that they own the pending elicitation, then
+ * write the completion signal to the shared DynamoDB store that the
+ * orchestrator's elicitation_bridge polls. The bridge then calls
+ * CompleteResourceTokenAuth from its own workload identity context.
  *
- * Keeping the backend's /invocations handler for `elicitation_complete`
- * is also fine for local/dev testing, but cloud traffic skips it.
+ * We do NOT call the orchestrator runtime here — the runtime only trusts user
+ * JWTs, and the BFF (ECS task) already has IAM permissions on the shared
+ * DynamoDB table.
  */
 import { NextRequest, NextResponse } from 'next/server'
 import {
@@ -18,7 +20,6 @@ import {
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { extractUserFromRequest } from '@/lib/auth-utils'
-import { getSession } from '@/lib/dynamodb-client'
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
 const TABLE_NAME = process.env.DYNAMODB_USERS_TABLE || 'strands-agent-chatbot-users-v2'
@@ -35,25 +36,19 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json().catch(() => ({}))
-    const sessionId: string | undefined = body.sessionId
     const elicitationId: string | undefined = body.elicitationId
     const oauthSessionUri: string | undefined = body.oauthSessionUri
 
-    if (!sessionId || !elicitationId || !oauthSessionUri) {
+    if (!elicitationId || !oauthSessionUri) {
       return NextResponse.json(
-        { error: 'sessionId, elicitationId, and oauthSessionUri are required' },
+        { error: 'elicitationId and oauthSessionUri are required' },
         { status: 400 }
       )
     }
 
-    const session = await getSession(user.userId, sessionId)
-    if (!session) {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 })
-    }
-
     const key = {
-      userId: { S: `ELICIT#${sessionId}` },
-      sk: { S: `EID#${elicitationId}` },
+      userId: { S: `ELICIT#${elicitationId}` },
+      sk: { S: 'META' },
     }
     const pending = await dynamoClient.send(new GetItemCommand({
       TableName: TABLE_NAME,
@@ -88,7 +83,7 @@ export async function POST(request: NextRequest) {
       },
     }))
 
-    console.log(`[Elicitation] Signalled in DynamoDB: user=${user.userId}, session=${sessionId}, eid=${elicitationId}`)
+    console.log(`[Elicitation] Signalled in DynamoDB: user=${user.userId}, eid=${elicitationId}`)
 
     return NextResponse.json({ success: true })
 

--- a/chatbot-app/frontend/src/app/oauth-complete/page.tsx
+++ b/chatbot-app/frontend/src/app/oauth-complete/page.tsx
@@ -3,6 +3,25 @@
 import { useEffect, useState, useRef } from 'react'
 import { fetchAuthSession } from 'aws-amplify/auth'
 
+/**
+ * OAuth 3LO callback page (AgentCore Identity session binding).
+ *
+ * AgentCore redirects here after the user consents at the provider, appending:
+ *   - session_id: the Identity authorization session URI, needed for
+ *     CompleteResourceTokenAuth
+ *   - our customState — the elicitation ID the backend generated when it
+ *     requested the authorization URL. AWS documents that customState is
+ *     "sent back to the callback URL" but does not name the parameter, so we
+ *     read the plausible spellings and log the rest.
+ *
+ * Everything needed to complete the flow arrives in the URL, so this page
+ * works regardless of window.opener or storage partitioning in the popup.
+ * The BFF verifies the caller's Cognito session and elicitation ownership
+ * before completing — that is the "user verification" step the AgentCore
+ * session-binding flow requires.
+ */
+
+const STATE_PARAM_ALIASES = ['state', 'customState', 'custom_state']
 export default function OAuthCompletePage() {
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading')
   const [message, setMessage] = useState('Completing authorization...')
@@ -14,8 +33,12 @@ export default function OAuthCompletePage() {
 
     const urlParams = new URLSearchParams(window.location.search)
     const oauthSessionUri = urlParams.get('session_id')
+    const elicitationId = STATE_PARAM_ALIASES.map(p => urlParams.get(p)).find(Boolean)
 
-    console.log(`[OAuth] Callback received, session_id: ${oauthSessionUri}`)
+    console.log(
+      `[OAuth] Callback received, session_id: ${oauthSessionUri}, ` +
+      `elicitation: ${elicitationId}, params: ${[...urlParams.keys()].join(',')}`
+    )
 
     if (!oauthSessionUri) {
       setStatus('error')
@@ -23,24 +46,13 @@ export default function OAuthCompletePage() {
       return
     }
 
-    // Read pending OAuth context saved by the parent window before opening this popup.
-    // Cross-origin OAuth redirects null out window.opener, so we cannot rely on postMessage.
-    let pending: { sessionId?: string; elicitationId?: string } = {}
-    try {
-      const raw = localStorage.getItem('oauth_pending')
-      if (raw) {
-        pending = JSON.parse(raw)
-        localStorage.removeItem('oauth_pending')
-      }
-    } catch { /* ignore parse errors */ }
+    if (!elicitationId) {
+      setStatus('error')
+      setMessage('No authorization state found in URL. Start the authorization from the chat again.')
+      return
+    }
 
     const signalCompletion = async () => {
-      if (!pending.sessionId || !pending.elicitationId) {
-        setStatus('error')
-        setMessage('The pending authorization request was not found. Please try again.')
-        return false
-      }
-
       try {
         const authSession = await fetchAuthSession()
         const accessToken = authSession.tokens?.accessToken?.toString()
@@ -54,37 +66,18 @@ export default function OAuthCompletePage() {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${accessToken}`,
           },
-          body: JSON.stringify({
-            sessionId: pending.sessionId,
-            elicitationId: pending.elicitationId,
-            oauthSessionUri,
-          }),
+          body: JSON.stringify({ elicitationId, oauthSessionUri }),
         })
         if (!response.ok) {
           throw new Error(`OAuth completion failed (${response.status})`)
         }
+        return true
       } catch (e) {
         console.error('[OAuth] Failed to signal via BFF:', e)
         setStatus('error')
         setMessage('Could not verify the authorization session. Please try again.')
         return false
       }
-
-      if (window.opener && !window.opener.closed) {
-        try {
-          window.opener.postMessage(
-            { type: 'oauth_elicitation_complete', sessionId: oauthSessionUri },
-            window.location.origin
-          )
-        } catch (e) {
-          console.warn('[OAuth] Could not notify parent window:', e)
-        }
-      }
-      localStorage.setItem('oauth_completed', JSON.stringify({
-        elicitationId: pending.elicitationId,
-        completedAt: Date.now(),
-      }))
-      return true
     }
 
     signalCompletion().then((completed) => {

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -1132,7 +1132,6 @@ export function ChatInterface() {
       {pendingOAuth && (
         <OAuthElicitationDialog
           oauth={pendingOAuth}
-          sessionId={sessionId}
           onCancel={cancelOAuth}
         />
       )}

--- a/chatbot-app/frontend/src/components/OAuthElicitationDialog.tsx
+++ b/chatbot-app/frontend/src/components/OAuthElicitationDialog.tsx
@@ -15,24 +15,19 @@ import { PendingOAuthState } from "@/types/events"
 
 interface OAuthElicitationDialogProps {
   oauth: PendingOAuthState
-  sessionId: string
   onCancel: () => void
 }
 
 export function OAuthElicitationDialog({
   oauth,
-  sessionId,
   onCancel,
 }: OAuthElicitationDialogProps) {
   const [popupBlocked, setPopupBlocked] = useState(false)
 
   const openAuthorization = () => {
     setPopupBlocked(false)
-    localStorage.setItem("oauth_pending", JSON.stringify({
-      sessionId,
-      elicitationId: oauth.elicitationId,
-    }))
-
+    // No context handoff needed: AgentCore echoes the elicitation ID back to
+    // the callback page as the `state` query parameter.
     const popup = window.open(
       oauth.authUrl,
       "oauth_popup",

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -7,7 +7,6 @@ import { useChatAPI, SessionPreferences } from './useChatAPI'
 import { usePolling, hasOngoingA2ATools, A2A_TOOLS_REQUIRING_POLLING } from './usePolling'
 import { getApiUrl } from '@/config/environment'
 import { generateSessionId } from '@/config/session'
-import { fetchAuthSession } from 'aws-amplify/auth'
 import { apiGet, apiPost } from '@/lib/api-client'
 
 import { WorkspaceDocument } from './useStreamEvents'
@@ -387,56 +386,11 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     setSessionState(prev => ({ ...prev, browserSession: null }))
   }, [sessionId])
 
-  // ==================== OAUTH COMPLETION LISTENER ====================
-  // Listen for postMessage from OAuth popup window (or popup-close fallback)
-  const oauthSignalledRef = useRef<string | null>(null)
-  useEffect(() => {
-    const handleOAuthMessage = async (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) return
-      if (event.data?.type !== 'oauth_elicitation_complete') return
-
-      const elicitationId = sessionState.pendingOAuth?.elicitationId
-      if (!elicitationId || !sessionState.pendingOAuth) return
-
-      // Deduplicate: only signal once per elicitation (postMessage + popup-close can both fire)
-      if (oauthSignalledRef.current === elicitationId) return
-      oauthSignalledRef.current = elicitationId
-
-      console.log('[useChat] OAuth elicitation completion signal:', event.data)
-
-      try {
-        // BFF writes the completion signal directly to DynamoDB; no auth
-        // header needed. The orchestrator's elicitation_bridge polls DDB.
-        await fetch('/api/stream/elicitation-complete', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sessionId, elicitationId, oauthSessionUri: event.data.sessionId }),
-        })
-      } catch (error) {
-        console.error('[useChat] Failed to signal elicitation complete:', error)
-      }
-
-      setSessionState(prev => ({ ...prev, pendingOAuth: null }))
-    }
-
-    const handleOAuthStorage = (event: StorageEvent) => {
-      if (event.key !== 'oauth_completed' || !event.newValue) return
-      try {
-        const completed = JSON.parse(event.newValue)
-        if (completed.elicitationId !== sessionState.pendingOAuth?.elicitationId) return
-        setSessionState(prev => ({ ...prev, pendingOAuth: null }))
-      } catch {
-        // Ignore malformed cross-window completion signals.
-      }
-    }
-
-    window.addEventListener('message', handleOAuthMessage)
-    window.addEventListener('storage', handleOAuthStorage)
-    return () => {
-      window.removeEventListener('message', handleOAuthMessage)
-      window.removeEventListener('storage', handleOAuthStorage)
-    }
-  }, [sessionState.pendingOAuth, sessionId])
+  // NOTE: OAuth completion is signalled by the popup callback page directly
+  // to the BFF (the elicitation ID travels via AgentCore's customState, so no
+  // popup->parent channel is needed). The dialog here is dismissed by the
+  // `oauth_elicitation_resolved` SSE event from the backend once the paused
+  // tool resumes — see useStreamEvents.
 
   // ==================== ACTIONS ====================
   const newChat = useCallback(async () => {
@@ -729,7 +683,6 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   }, [sendStopSignal, resetStreamingState])
 
   const cancelOAuth = useCallback(() => {
-    localStorage.removeItem('oauth_pending')
     setSessionState(prev => ({ ...prev, pendingOAuth: null }))
     void stopGeneration()
   }, [stopGeneration])

--- a/chatbot-app/frontend/src/hooks/useStreamEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useStreamEvents.ts
@@ -1020,7 +1020,6 @@ export const useStreamEvents = ({
 
     console.log(`[OAuth Elicitation] Authorization required for ${serviceName}:`, ev.authUrl)
 
-    const chatSessionId = sessionId
     setSessionState(prev => ({
       ...prev,
       pendingOAuth: {
@@ -1030,17 +1029,19 @@ export const useStreamEvents = ({
         elicitationId: ev.elicitationId,
       }
     }))
+  }, [setSessionState])
 
-    // Persist pending OAuth context so the popup can signal completion
-    // even when window.opener is lost after cross-origin OAuth redirects.
-    try {
-      localStorage.setItem('oauth_pending', JSON.stringify({
-        sessionId: chatSessionId,
-        elicitationId: ev.elicitationId,
-      }))
-    } catch { /* quota exceeded — postMessage fallback still works */ }
-
-  }, [setSessionState, sessionId])
+  // Backend settled the elicitation (completed or timed out) — dismiss the
+  // dialog. The completion itself was signalled popup -> BFF -> DynamoDB, so
+  // this stream event is the only popup-independent way to update parent UI.
+  const handleOAuthElicitationResolvedEvent = useCallback((data: CustomEvent) => {
+    const ev = (data as any).value
+    console.log(`[OAuth Elicitation] Resolved (${ev.status}):`, ev.elicitationId)
+    setSessionState(prev => {
+      if (prev.pendingOAuth && prev.pendingOAuth.elicitationId !== ev.elicitationId) return prev
+      return { ...prev, pendingOAuth: null }
+    })
+  }, [setSessionState])
 
   // Swarm Mode event handlers
   const isCodeAgentExec = (t: ToolExecution) =>
@@ -1516,6 +1517,9 @@ export const useStreamEvents = ({
             case 'oauth_elicitation':
               handleOAuthElicitationEvent(customEvent)
               break
+            case 'oauth_elicitation_resolved':
+              handleOAuthElicitationResolvedEvent(customEvent)
+              break
             case 'code_agent_started':
               handleCodeAgentStartedEvent(customEvent)
               break
@@ -1593,6 +1597,7 @@ export const useStreamEvents = ({
     handleBrowserProgressEvent,
     handleResearchProgressEvent,
     handleOAuthElicitationEvent,
+    handleOAuthElicitationResolvedEvent,
     handleCodeAgentStartedEvent,
     handleCodeAgentHeartbeatEvent,
     handleCodeStepEvent,

--- a/infra/modules/oauth-providers/main.tf
+++ b/infra/modules/oauth-providers/main.tf
@@ -37,21 +37,17 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "google" {
 resource "aws_bedrockagentcore_oauth2_credential_provider" "github" {
   count = local.github_enabled ? 1 : 0
 
-  name                       = "github-oauth-provider"
-  credential_provider_vendor = "CustomOauth2"
+  name = "github-oauth-provider"
+
+  # Built-in vendor, not CustomOauth2: GitHub publishes no discovery document,
+  # so a custom provider can't describe the authorize request and Identity
+  # rejects it with 400 "Invalid request".
+  credential_provider_vendor = "GithubOauth2"
 
   oauth2_provider_config {
-    custom_oauth2_provider_config {
+    github_oauth2_provider_config {
       client_id     = var.github_client_id
       client_secret = var.github_client_secret
-
-      oauth_discovery {
-        authorization_server_metadata {
-          issuer                 = "https://github.com"
-          authorization_endpoint = "https://github.com/login/oauth/authorize"
-          token_endpoint         = "https://github.com/login/oauth/access_token"
-        }
-      }
     }
   }
 

--- a/mobile-app/src/hooks/useChat.ts
+++ b/mobile-app/src/hooks/useChat.ts
@@ -193,7 +193,7 @@ export function useChat({ sessionId, modelId, onTitleUpdated }: UseChatOptions) 
     )
   }, [attemptReconnect, handleEvent, resetStreamState, resetReconnect])
 
-  const { sendMessage: streamSend, stopStream: rawStopStream, abortStream, completeElicitation } = useChatStream({
+  const { sendMessage: streamSend, stopStream: rawStopStream, abortStream } = useChatStream({
     sessionId,
     modelId,
     onEvent: handleEvent,
@@ -484,15 +484,12 @@ export function useChat({ sessionId, modelId, onTitleUpdated }: UseChatOptions) 
     [pendingInterrupt, setPendingInterrupt, streamSend],
   )
 
-  const dismissOAuth = useCallback(
-    async () => {
-      if (pendingOAuth) {
-        await completeElicitation(pendingOAuth.elicitationId)
-      }
-      setPendingOAuth(null)
-    },
-    [pendingOAuth, completeElicitation, setPendingOAuth],
-  )
+  // Only reachable if the backend ever streams an elicitation despite
+  // allow_user_federation=false: dismiss locally and let the paused tool time
+  // out. There is no callback page here to complete authorization with.
+  const dismissOAuth = useCallback(() => {
+    setPendingOAuth(null)
+  }, [setPendingOAuth])
 
   return {
     messages,

--- a/mobile-app/src/hooks/useChatStream.ts
+++ b/mobile-app/src/hooks/useChatStream.ts
@@ -93,6 +93,11 @@ export function useChatStream({
           system_prompt: '',
           selected_artifact_id: null,
           enabled_tools: [],
+          // 3LO skills (gmail, github, notion, google-calendar) need the OAuth
+          // callback page the web app hosts; there is no deep-link equivalent
+          // here, so the backend omits them instead of offering tools that
+          // cannot complete authorization. Same flag telegram-app sets.
+          allow_user_federation: false,
         },
       }
 
@@ -140,14 +145,7 @@ export function useChatStream({
     }
   }, [sessionId, abortStream])
 
-  const completeElicitation = useCallback(
-    async (elicitationId?: string) => {
-      await apiPost(ENDPOINTS.elicitationComplete, { sessionId, elicitationId })
-    },
-    [sessionId],
-  )
-
   const getIsStreaming = useCallback(() => handleRef.current?.active ?? false, [])
 
-  return { sendMessage, stopStream, abortStream, completeElicitation, getIsStreaming }
+  return { sendMessage, stopStream, abortStream, getIsStreaming }
 }

--- a/mobile-app/src/lib/constants.ts
+++ b/mobile-app/src/lib/constants.ts
@@ -9,7 +9,6 @@ export const TEXT_BUFFER_FLUSH_MS = 120
 export const ENDPOINTS = {
   chat: '/api/stream/chat',
   stop: '/api/stream/stop',
-  elicitationComplete: '/api/stream/elicitation-complete',
   sessionNew: '/api/session/new',
   sessionList: '/api/session/list',
   sessionDelete: '/api/session/delete',

--- a/mobile-app/src/types/chat.ts
+++ b/mobile-app/src/types/chat.ts
@@ -107,6 +107,8 @@ export interface RunAgentInput {
     system_prompt: string
     selected_artifact_id: null
     enabled_tools: string[]
+    /** false opts out of 3LO skills, which need an OAuth callback page. */
+    allow_user_federation?: boolean
   }
 }
 


### PR DESCRIPTION
GitHub/Gmail 3LO authorization failed with "The pending authorization request was not found." This fixes the three independent causes and removes the workarounds that were papering over the first one.

Verified end to end against the deployed stack — the orchestrator logged a full round trip:

```
[Elicitation] Waiting for OAuth completion: 7400a4ed-...
[Elicitation] OAuth completed: 7400a4ed-...
[Elicitation] CompleteResourceTokenAuth succeeded
```

## 1. GitHub provider used the wrong vendor (`aa94d6f`)

The provider was `CustomOauth2` with a hand-written `authorization_server_metadata` block. GitHub publishes no discovery document, so Identity could not describe the authorize request and rejected it with `400 Invalid request`. Switched to the built-in `GithubOauth2` vendor.

This reissues the provider callback URL, which has to be re-registered in the GitHub OAuth App.

## 2. Completion signal had no reliable path back (`38ce23e`)

The popup handed the elicitation ID to the chat tab through `localStorage`, with `postMessage` and storage-event fallbacks. All three break across the cross-site OAuth redirect chain — partitioned storage, lost `window.opener`.

Use the mechanism AgentCore Identity provides: pass the elicitation ID as `customState` on `GetResourceOauth2Token`, which Identity echoes onto the callback redirect. The callback page then needs nothing from browser storage, and the chat tab's dialog is dismissed by a new `oauth_elicitation_resolved` SSE event once the paused tool resumes. Net deletion — all three fallbacks are gone.

Also registered the callback URL as an `AllowedResourceOauth2ReturnUrl` on the workload identity, which the spec requires and which was empty.

AWS documents `customState` as "sent back to the callback URL" but never names the query parameter, and the official sample callback server reads only `session_id`. The callback page therefore accepts `state`/`customState`/`custom_state` and logs the parameter names it actually received, so the real name can be confirmed from a deploy and the rest dropped.

## 3. mcp 2.0 crashed the MCP runtime on startup (`f5b10b4`)

Surfaced while deploying the above:

```
File "/app/src/mcp_server.py", line 16
from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

`mcp>=1.26.0` had no upper bound, so rebuilding resolved mcp 2.0.0, which removed `mcp.server.fastmcp`. With the container dead, github/gmail/notion tools resolved to an empty list and tool calls failed before OAuth could start. The orchestrator already pinned `<2.0.0`; this matches it.

Nothing caught it because `conftest.py` mocks the AWS SDKs and `requirements-dev.txt` omitted the runtime deps, so no test imported what pip installs. `requirements.txt` is now pulled into the dev file, and `test_runtime_dependencies.py` imports the real packages.

## 4. Mobile could only strand the user (`aef4270`)

Mobile has no OAuth callback page — `expo-web-browser` opens an in-app browser with no deep-link return — but still advertised the 3LO skills, and on dismissal posted `{sessionId, elicitationId}` to an endpoint that has required `oauthSessionUri` since #192, getting a 400. The elicitation sat until the bridge's 5-minute timeout.

Set `allow_user_federation=false`, the flag telegram-app already uses, so the backend omits those skills. The BFF rebuilds `state` from the client payload, so it now carries the flag through; only an explicit `false` counts, keeping web on the default.

Dropped the unreachable completion paths with it: mobile's `completeElicitation`, the runtime's `elicitation_complete` action, and `signal_elicitation_complete`. That action never passed `oauthSessionUri`, so it could not call `CompleteResourceTokenAuth` — it reported success while leaving the token unsaved.

## Tests

New tests, each checked against a mutation rather than just passing:

| Test | Mutation that must fail it |
|---|---|
| `oauth-complete.test.tsx` | narrowing the aliases to `['state']` → 2 fail |
| `test_runtime_dependencies.py` | removing the `<2.0.0` pin → 2 fail |
| `chat-federation.test.ts` | dropping the forwarding → opt-out case fails; `Boolean(...)` instead of `!== false` → default case fails |

Backend ruff clean, 438 unit + 136 integration pass. mcp-runtime ruff clean, 28 pass. Frontend tsc clean, 538 pass, build compiles. Mobile and telegram tsc clean.

## Follow-ups, not in this PR

- The workload-identity return URL is registered via CLI; the `null_resource` provisioner that should own it left the list empty. Worth persisting in terraform.
- Notion has no built-in vendor, so it stays on `CustomOauth2` and will likely keep failing for the same reason as GitHub.