### PR TITLE
fix(infra): manage the 3LO workload identity in terraform

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -604,64 +604,22 @@ module "runtime_mcp_3lo" {
 # ============================================================
 # 3LO Workload Identity — OAuth callback URL registration
 # ============================================================
-# After the MCP 3LO Runtime is created, AgentCore auto-creates a
-# Workload Identity. We must update it with the frontend callback URL
-# so AgentCore redirects the user back after OAuth consent.
+# AgentCore creates a workload identity alongside the MCP 3LO runtime. The
+# 3LO flow requires our callback page to be registered on it as an
+# AllowedResourceOauth2ReturnUrl, otherwise GetResourceOauth2Token rejects
+# resourceOauth2ReturnUrl. Managed here (not in the runtime module) because the
+# URL comes from the chat module, and importing the service-created identity
+# keeps it declarative rather than a local-exec that silently no-ops.
 
-resource "null_resource" "mcp_3lo_workload_identity" {
-  triggers = {
-    runtime_arn  = module.runtime_mcp_3lo.runtime_arn
-    callback_url = "https://${module.chat.cloudfront_domain_name}/oauth-complete"
+resource "aws_bedrockagentcore_workload_identity" "mcp_3lo" {
+  name                                = module.runtime_mcp_3lo.workload_identity_name
+  allowed_resource_oauth2_return_urls = ["https://${module.chat.cloudfront_domain_name}/oauth-complete"]
+
+  lifecycle {
+    # AgentCore owns this identity's lifecycle: deleting it would break the
+    # runtime, and its name is derived from the runtime ID.
+    prevent_destroy = true
   }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      set -e
-
-      RUNTIME_ARN="${module.runtime_mcp_3lo.runtime_arn}"
-      CALLBACK_URL="https://${module.chat.cloudfront_domain_name}/oauth-complete"
-      REGION="${var.aws_region}"
-
-      # Get Workload Identity ARN from MCP 3LO Runtime (retry up to 60s for async provisioning)
-      WI_ARN=""
-      for i in 1 2 3 4 5 6; do
-        WI_ARN=$(python3 -c "
-import boto3, sys
-client = boto3.client('bedrock-agentcore-control', region_name='$REGION')
-resp = client.get_agent_runtime(agentRuntimeArn='$RUNTIME_ARN')
-wi = resp.get('workloadIdentityDetails', {}).get('workloadIdentityArn', '')
-print(wi, end='')
-" 2>/dev/null || echo "")
-        if [ -n "$WI_ARN" ]; then break; fi
-        echo "Waiting for Workload Identity provisioning... (attempt $i/6)"
-        sleep 10
-      done
-
-      if [ -z "$WI_ARN" ]; then
-        echo "WARNING: Workload Identity not available after 60s — skipping. Run 'terraform apply' again after runtime is fully provisioned."
-        exit 0
-      fi
-
-      echo "Workload Identity: $WI_ARN"
-      echo "Callback URL: $CALLBACK_URL"
-
-      # Extract workload identity name from ARN (last segment after /)
-      WI_NAME=$(echo "$WI_ARN" | grep -o '[^/]*$')
-
-      # Update Workload Identity with allowed callback URLs
-      python3 -c "
-import boto3
-client = boto3.client('bedrock-agentcore-control', region_name='$REGION')
-client.update_workload_identity(
-    name='$WI_NAME',
-    allowedResourceOauth2ReturnUrls=['$CALLBACK_URL']
-)
-print('Workload Identity updated successfully: $WI_NAME')
-"
-    EOT
-  }
-
-  depends_on = [module.runtime_mcp_3lo, module.chat]
 }
 
 # Store OAuth provider callback URLs in SSM for user reference.

--- a/infra/modules/runtime/outputs.tf
+++ b/infra/modules/runtime/outputs.tf
@@ -17,6 +17,16 @@ output "runtime_invocation_url" {
   ])
 }
 
+# Name of the workload identity AgentCore creates alongside the runtime.
+# Needed to register OAuth 2.0 return URLs for 3LO. Empty until the runtime
+# finishes provisioning.
+output "workload_identity_name" {
+  value = try(
+    basename(aws_bedrockagentcore_agent_runtime.this.workload_identity_details[0].workload_identity_arn),
+    ""
+  )
+}
+
 output "ecr_repository_url" {
   value = aws_ecr_repository.this.repository_url
 }

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -656,6 +656,18 @@ reconcile_registry_record_drift() {
 }
 
 # ------------------------------------------------------------
+# Is an address already tracked in state?
+# `terraform state list | grep -q` looks right but fails under `set -o
+# pipefail`: grep exits on the first match, terraform dies of SIGPIPE, and the
+# pipeline reports failure even on a hit. Capture first, then match.
+# ------------------------------------------------------------
+tf_state_has() {
+  local addr="$1" state
+  state=$(terraform state list 2>/dev/null || true)
+  printf '%s\n' "$state" | grep -qx "$addr"
+}
+
+# ------------------------------------------------------------
 # Import pre-existing OAuth2 credential providers into state.
 # Runs before apply. AgentCore keeps providers account-wide, so a partial
 # destroy (or a tool deleting them out-of-band) can leave state empty while
@@ -673,7 +685,7 @@ import_orphan_oauth_providers() {
     [ -z "$enabled" ] && continue
     addr="module.oauth_providers.aws_bedrockagentcore_oauth2_credential_provider.${p}[0]"
     # Already tracked — nothing to do.
-    if terraform state list 2>/dev/null | grep -qx "$addr"; then
+    if tf_state_has "$addr"; then
       continue
     fi
     # Best-effort probe: attempt import; ignore failure (resource may not exist).
@@ -685,6 +697,54 @@ import_orphan_oauth_providers() {
       echo ">>> Imported existing OAuth provider: $name"
     fi
   done
+}
+
+# ------------------------------------------------------------
+# Import the MCP 3LO workload identity into state.
+# AgentCore creates it with the runtime, so terraform can never create it —
+# without this, apply fails with "already exists". Name is only known after
+# the runtime exists, so this can't be a declarative import block.
+# ------------------------------------------------------------
+import_mcp_3lo_workload_identity() {
+  cd "$ENV_DIR"
+  local addr="aws_bedrockagentcore_workload_identity.mcp_3lo"
+  tf_state_has "$addr" && return 0
+
+  local runtime_arn wi_name
+  runtime_arn=$(terraform output -raw mcp_3lo_runtime_arn 2>/dev/null || true)
+  # First-ever apply: the runtime doesn't exist yet, so there is nothing to
+  # import. Terraform creates the resource, which no-ops into the identity
+  # AgentCore just made.
+  [ -z "$runtime_arn" ] && return 0
+
+  # GetAgentRuntime takes the runtime ID (the ARN's last segment), not the ARN.
+  wi_name=$("$DEPLOY_VENV/bin/python" - "${runtime_arn##*/}" "$AWS_REGION" <<'PY'
+import sys, boto3
+runtime_id, region = sys.argv[1], sys.argv[2]
+try:
+    c = boto3.client("bedrock-agentcore-control", region_name=region)
+    wi = c.get_agent_runtime(agentRuntimeId=runtime_id).get("workloadIdentityDetails", {})
+    print(wi.get("workloadIdentityArn", "").rpartition("/")[2], end="")
+except Exception as e:
+    sys.stderr.write(f"Could not resolve workload identity: {e}\n")
+PY
+)
+  if [ -z "$wi_name" ]; then
+    echo "WARNING: could not resolve the MCP 3LO workload identity name; apply may fail with 'already exists'."
+    return 0
+  fi
+
+  # Failure is reported, not swallowed: without the import, apply dies on
+  # "already exists" and 3LO silently loses its return URL.
+  if terraform import -var="aws_region=${AWS_REGION}" \
+      -var="enable_tavily=$([ "$SKIP_TAVILY" = true ] && echo false || echo true)" \
+      -var="enable_google_search=$([ "$SKIP_GOOGLE_SEARCH" = true ] && echo false || echo true)" \
+      -var="enable_google_maps=$([ "$SKIP_GOOGLE_MAPS" = true ] && echo false || echo true)" \
+      "$addr" "$wi_name" >/dev/null; then
+    echo ">>> Imported MCP 3LO workload identity: $wi_name"
+  else
+    echo "WARNING: failed to import workload identity $wi_name (see error above)."
+  fi
 }
 
 # ------------------------------------------------------------
@@ -716,6 +776,7 @@ case "$ACTION" in
   apply)
     tf_init_if_needed
     import_orphan_oauth_providers
+    import_mcp_3lo_workload_identity
     clean_failed_registry_stacks
     reconcile_registry_record_drift
     cd "$ENV_DIR"


### PR DESCRIPTION
The MCP 3LO workload identity's OAuth return URL was registered by hand during #219, because the `null_resource` provisioner that was supposed to own it never worked.

## Why the provisioner silently did nothing

It called `get_agent_runtime(agentRuntimeArn=...)`, but the API takes `agentRuntimeId`:

```
Parameter validation failed:
Missing required parameter in input: "agentRuntimeId"
Unknown parameter in input: "agentRuntimeArn"
```

That error was swallowed by `2>/dev/null || echo ""`, so the script only printed its "Workload Identity not available after 60s — skipping" warning and exited 0. `allowedResourceOauth2ReturnUrls` stayed empty, and 3LO fails in that state because `GetResourceOauth2Token` rejects a `resourceOauth2ReturnUrl` that isn't registered on the identity.

## Fix

Use the native `aws_bedrockagentcore_workload_identity` resource — there is no API call left to get wrong, and drift is corrected instead of ignored.

AgentCore creates this identity together with the runtime, so terraform can never create it; `deploy.sh` imports it first, the same pattern already used for the OAuth credential providers. A declarative `import` block can't express this because the name is only known once the runtime exists.

## Also: the state guard both importers shared

```bash
terraform state list | grep -qx "$addr"
```

`grep -q` exits on the first match and closes the pipe, so `terraform state list` (334 lines here) dies of SIGPIPE. Under the script's `set -o pipefail` the pipeline reports failure, meaning **a hit read as a miss** — the import ran anyway and errored with "Resource already managed by Terraform". It appeared to work when I tested it by hand only because short output fits in the pipe buffer; reproducing it inside a script exposed it. `tf_state_has()` captures first, then matches. This also fixes the latent case for OAuth providers.

## Verification

| Check | Result |
|---|---|
| Import path (removed from state, ran deploy.sh) | `>>> Imported MCP 3LO workload identity: ...` then `0 added, 0 changed` |
| Drift correction (cleared the URL via CLI, applied) | `0 added, 1 changed` — URL restored, confirmed against the live API |
| Idempotency (re-apply) | `0 added, 0 changed`, no warnings |
| Full plan | `No changes. Your infrastructure matches the configuration.` |

That last line is new: the provisioner re-ran on every single apply, so this is the first time the config actually converges.

`terraform validate` passes and `fmt -check` is clean.