### PR TITLE
ci: run Node 24 and drop the removed baseUrl option

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: chatbot-app/frontend/package-lock.json
 
@@ -248,7 +248,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: mobile-app/package-lock.json
 
@@ -272,7 +272,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: telegram-app/package-lock.json
 

--- a/chatbot-app/frontend/tsconfig.json
+++ b/chatbot-app/frontend/tsconfig.json
@@ -21,7 +21,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
Unblocks the stuck dependabot upgrades. Neither blocker was a stale pin on our side.

## CI ran Node 20 while production runs Node 24

Every runtime image is `node:24-alpine` (`chatbot-app/frontend/Dockerfile`, `telegram-app/Dockerfile`), but all three Node CI jobs pinned `node-version: "20"` — so CI was validating a different environment than what we ship.

That gap silently blocked upgrades:

| Package | Requires | Node 20 |
|---|---|---|
| jsdom 30.0.1 (#216) | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` | ✗ |
| @testing-library/jest-dom 7.0.0 (#214) | `>=22` | ✗ |

**#214 already merged on an unsupported combination.** npm treats `engines` as a warning, not an error, so CI passed it. main is currently running jest-dom 7 against Node 20. Matching the runtime version fixes that and lets #216 through.

## TypeScript 7 removed `baseUrl`

The only thing failing #215:

```
tsconfig.json(24,5): error TS5102: Option 'baseUrl' has been removed.
  Use '"paths": {"*": ["./*"]}' instead.
```

Our `paths` are already repo-relative (`"@/*": ["./src/*"]`), so `baseUrl: "."` was redundant — no path rewrite needed, just delete the line.

Landing this separately on purpose: it's verified against **both** compilers, so there's no ordering dependency with the TS bump.

| | tsc | tests | build |
|---|---|---|---|
| TS 5.8.3 (current) | 0 errors | 538 pass | compiles |
| TS 7.0.2 (#215) | 0 errors | — | — |

## Remaining dependabot PRs after this

- **#215** (TypeScript 7) — should go green once this lands; ready to merge after.
- **#216** (jsdom 30) — same; verified locally on Node 22 (538 tests pass, tsc clean).
- **#213** (@vitejs/plugin-react 6) — a different problem, not fixed here. It needs `vite ^8.0.0` and we're on 7.3.6, so it fails with `ERR_PACKAGE_PATH_NOT_EXPORTED: './internal'`. That's a paired vite 7→8 upgrade and deserves its own PR.

Closed as not viable: **#211** (mcp 2.0 — `strands-agents` requires `mcp<2.0.0`, `ResolutionImpossible`) and **#209** (playwright — the range mirrors nova-act's `playwright<=1.56.0,>=1.54.0`, and `--no-deps` means CI can't catch the conflict).