### PR TITLE
fix(oauth): keep the 3LO diagnostics out of removeConsole's path

### DIFF
--- a/chatbot-app/frontend/src/app/api/stream/elicitation-complete/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/elicitation-complete/route.ts
@@ -83,7 +83,9 @@ export async function POST(request: NextRequest) {
       },
     }))
 
-    console.log(`[Elicitation] Signalled in DynamoDB: user=${user.userId}, eid=${elicitationId}`)
+    // warn, not log: removeConsole strips console.log from production, which
+    // would leave the 3LO completion path with no server-side trace at all.
+    console.warn(`[Elicitation] Signalled in DynamoDB: user=${user.userId}, eid=${elicitationId}`)
 
     return NextResponse.json({ success: true })
 

--- a/chatbot-app/frontend/src/app/oauth-complete/page.tsx
+++ b/chatbot-app/frontend/src/app/oauth-complete/page.tsx
@@ -35,7 +35,10 @@ export default function OAuthCompletePage() {
     const oauthSessionUri = urlParams.get('session_id')
     const elicitationId = STATE_PARAM_ALIASES.map(p => urlParams.get(p)).find(Boolean)
 
-    console.log(
+    // warn, not log: next.config.js strips console.log from production builds,
+    // and this is the only record of which parameter AgentCore echoed
+    // customState back as — the one thing AWS doesn't document.
+    console.warn(
       `[OAuth] Callback received, session_id: ${oauthSessionUri}, ` +
       `elicitation: ${elicitationId}, params: ${[...urlParams.keys()].join(',')}`
     )


### PR DESCRIPTION
I asked for a browser-console line to confirm which parameter AgentCore echoes `customState` back as, and nothing appeared. The reason is in our own config, not the browser.

`next.config.js` strips `console.log` from production builds:

```js
compiler: {
  removeConsole: process.env.NODE_ENV === 'production' ? {
    exclude: ['error', 'warn']
  } : false,
},
```

So both 3LO diagnostic lines were absent from the deployed bundle — the callback page's parameter dump *and* the BFF's `[Elicitation] Signalled in DynamoDB`. This applies to server-side code too: `/ecs/chatbot-frontend` contains nothing but the Next.js startup banner, **zero `[BFF]` lines**. The completion path is currently unobservable in production, so if 3LO breaks again there's nothing to diagnose it with.

It also makes the one remaining open question unanswerable. AWS documents `customState` as "sent back to the callback URL" but never names the query parameter (#219), so the callback page accepts `state`/`customState`/`custom_state` and logs which one actually arrived — except that log never shipped.

## Fix

Promote both to `console.warn` — diagnostic-appropriate, and already in `removeConsole`'s exclude list. No new config, no new dependency.

## Verified against a real production build

| Version | Executable chunks | Source map only |
|---|---|---|
| `console.log` (before) | absent | present |
| `console.warn` (after) | `.next/static/chunks/`, `.next/server/chunks/ssr/` | — |

Ran `NODE_ENV=production next build` both ways and grepped the output, so this is checked in both directions rather than assumed. tsc clean, oauth-complete tests pass (5).

Once this deploys, the next 3LO authorization will finally reveal the real parameter name and the extra aliases can be dropped.