### PR TITLE
fix(research): keep the approval usable and isolate concurrent runs

### DIFF
--- a/agentcore/a2a-agents/research-agent/src/async_tasks.py
+++ b/agentcore/a2a-agents/research-agent/src/async_tasks.py
@@ -1,0 +1,72 @@
+"""Tracks in-flight research so /ping can report it to AgentCore Runtime.
+
+AgentCore decides whether a runtime session is idle from the /ping status: a
+session reporting "Healthy" is idle-eligible and its microVM is terminated after
+idleRuntimeSessionTimeout (default 15 minutes), while "HealthyBusy" keeps it
+alive up to maxLifetime (default 8 hours).
+
+This matters here because the A2A SDK keeps consuming a task's events after the
+client disconnects (DefaultRequestHandler.on_message_send_stream spawns a
+background consumer on CancelledError). Research therefore outlives the request
+that started it, and without this the platform can reclaim the container while
+the report is still being written.
+
+Kept separate from the orchestrator's copy: the two runtimes are independent
+images with no shared package.
+"""
+
+import itertools
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_active: Dict[int, Dict[str, Any]] = {}
+_ids = itertools.count(1)
+
+
+def begin(name: str, metadata: Optional[Dict[str, Any]] = None) -> int:
+    """Register in-flight work and return the id used to end it."""
+    with _lock:
+        task_id = next(_ids)
+        _active[task_id] = {"name": name, "started_at": time.time(), "metadata": metadata or {}}
+        count = len(_active)
+    logger.info(f"[AsyncTask] Started {name} (id={task_id}, active={count})")
+    return task_id
+
+
+def end(task_id: int) -> bool:
+    """Mark work complete. Returns False if the id was unknown or already ended."""
+    with _lock:
+        task = _active.pop(task_id, None)
+        count = len(_active)
+    if task is None:
+        # end() runs from finally blocks that can be reached twice; losing the
+        # container would be worse than tolerating a stray id.
+        logger.warning(f"[AsyncTask] Unknown task id {task_id}")
+        return False
+    logger.info(
+        f"[AsyncTask] Completed {task['name']} (id={task_id}, "
+        f"{time.time() - task['started_at']:.1f}s, active={count})"
+    )
+    return True
+
+
+def ping_status() -> str:
+    """The status string AgentCore Runtime expects from /ping.
+
+    time_of_last_update is intentionally omitted: a timestamp that advances on
+    every ping reads as a continuous status change, which stops the idle timeout
+    from ever firing and keeps sessions alive until maxLifetime.
+    """
+    with _lock:
+        return "HealthyBusy" if _active else "Healthy"
+
+
+def reset() -> None:
+    """Drop all registrations. For tests."""
+    with _lock:
+        _active.clear()

--- a/agentcore/a2a-agents/research-agent/src/main.py
+++ b/agentcore/a2a-agents/research-agent/src/main.py
@@ -14,7 +14,8 @@ For local testing:
 import logging
 import os
 import sys
-import uuid
+import contextvars
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 from datetime import datetime
@@ -45,6 +46,7 @@ from tools import (  # noqa: E402
 )
 from tools.generate_chart import generate_chart_tool  # noqa: E402
 from model_factory import build_model  # noqa: E402
+import async_tasks  # noqa: E402
 
 # Configure logging
 logging.basicConfig(
@@ -54,10 +56,37 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _RequestState:
+    """Per-request streaming state.
+
+    Step numbering and the report location belong to one research run. Holding
+    them on the executor made them shared: the executor is a single instance, so
+    two researches running at once traded step numbers and could resolve each
+    other's report. See tests/test_concurrent_research.py.
+    """
+
+    session_id: Optional[str]
+    user_id: str
+    model_id: Optional[str] = None
+    current_tool_use_id: Optional[str] = None
+    step_counter: int = 0
+
+
+# Each A2A request runs as its own asyncio task, and a ContextVar read resolves to
+# the value set by that task. Preferred over a dict keyed on the request: there is
+# no key to collide, and nothing to clean up when a request ends — the value goes
+# out of scope with its task.
+_request_state: contextvars.ContextVar[_RequestState] = contextvars.ContextVar("research_request_state")
+
+
 class MetadataAwareExecutor(StrandsA2AExecutor):
     """
     Custom A2A Executor that extracts metadata (model_id, session_id, user_id)
     from RequestContext and passes to agent's invocation_state.
+
+    Agents are built per A2A context by the base class (agent_factory mode), so
+    concurrent researches never share conversation state.
     """
 
     # Tool name to user-friendly status mapping
@@ -71,19 +100,31 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
         "generate_chart_tool": "Generating chart",
     }
 
-    def __init__(self, agent_cache: dict):
+    def __init__(self, agent_factory):
         """
-        Initialize with agent cache instead of single agent.
-
         Args:
-            agent_cache: Dict mapping model_id to Agent instances
+            agent_factory: Callable ``(context_id, model_id) -> Agent``. The base
+                class calls its factory once per A2A context and gives each
+                context its own agent and lock, which is what isolates concurrent
+                researches.
         """
-        # Don't call super().__init__() since we'll override agent selection
-        self.agent_cache = agent_cache
-        self._current_tool_use_id = None  # Track current tool to avoid duplicate updates
-        self._step_counter = 0  # Counter for step artifacts
+        # The base class's factory takes only context_id; the model to use arrives
+        # per request in the message metadata, which _execute_streaming has already
+        # put in the request state by the time the factory runs.
+        self._agent_builder = agent_factory
+        super().__init__(agent_factory=self._build_context_agent)
 
-    async def _handle_streaming_event(self, event: dict, updater: TaskUpdater) -> None:
+    def _build_context_agent(self, context_id: str) -> Agent:
+        """Build this context's agent using the requesting call's model.
+
+        model_id is None when no request is in flight, which is how the base class
+        builds a representative agent for the AgentCard at startup. build_agent
+        maps that to the default model.
+        """
+        state = _request_state.get(None)
+        return self._agent_builder(context_id, state.model_id if state else None)
+
+    async def _handle_streaming_event(self, event: dict, updater: TaskUpdater, stream_state=None) -> None:
         """
         Override to stream tool execution status in real-time.
 
@@ -92,7 +133,11 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
         - tool_result: When a tool completes
         - data: Text content being generated (thinking)
         - result: Final agent result
+
+        stream_state is the base class's A2A-compliant streaming state; accepted
+        to match its signature and passed through untouched.
         """
+        state = _request_state.get()
         event_type = event.get("type", "unknown")
         event_keys = list(event.keys())
         logger.debug(f"[MetadataAwareExecutor] Event - type: {event_type}, keys: {event_keys}")
@@ -105,9 +150,9 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
             tool_name = tool_use.get("name", "")
 
             # Only send update if this is a new tool (avoid duplicates from streaming chunks)
-            if tool_use_id and tool_use_id != self._current_tool_use_id:
-                self._current_tool_use_id = tool_use_id
-                self._step_counter += 1
+            if tool_use_id and tool_use_id != state.current_tool_use_id:
+                state.current_tool_use_id = tool_use_id
+                state.step_counter += 1
 
                 # Get user-friendly status message
                 status_message = self.TOOL_STATUS_MAP.get(tool_name, f"Running {tool_name}")
@@ -127,14 +172,14 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
 
                 await updater.add_artifact(
                     parts=[Part(root=TextPart(text=step_text))],
-                    name=f"research_step_{self._step_counter}"
+                    name=f"research_step_{state.step_counter}"
                 )
-                logger.info(f"[MetadataAwareExecutor] Streamed step {self._step_counter}: {status_message}")
+                logger.info(f"[MetadataAwareExecutor] Streamed step {state.step_counter}: {status_message}")
 
         # Handle tool result - could add completion status here if needed
         elif event.get("type") == "tool_result":
             # Tool completed - reset current tool tracking
-            self._current_tool_use_id = None
+            state.current_tool_use_id = None
 
         # Handle text data (thinking/response generation)
         elif "data" in event:
@@ -144,17 +189,16 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
 
         # Handle final result
         elif "result" in event:
-            await self._handle_agent_result(event["result"], updater)
+            await self._handle_agent_result(event["result"], updater, stream_state)
 
     async def _execute_streaming(self, context: RequestContext, updater: TaskUpdater) -> None:
         """
-        Override to inject metadata into invocation_state and use appropriate model.
-        """
-        # Reset step tracking for new request
-        self._current_tool_use_id = None
-        self._step_counter = 0
+        Override to inject metadata into invocation_state.
 
-        # Extract metadata from RequestContext (need session_id early for file cleanup)
+        Agent selection is the base class's job in agent_factory mode: it builds
+        one agent per A2A context and serializes only within that context.
+        """
+        # Extract metadata from RequestContext
         # Try both params.metadata (MessageSendParams) and message.metadata (Message)
         # Streaming client may put metadata in Message.metadata
         metadata = context.metadata  # MessageSendParams.metadata
@@ -167,37 +211,9 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
 
         logger.info(f"[MetadataAwareExecutor] Extracted metadata - model_id: {model_id}, session_id: {session_id}, user_id: {user_id}")
 
-        # Clear previous research file for this session (prevent cumulative results)
-        if session_id:
-            try:
-                from report_manager import get_report_manager
-                manager = get_report_manager(session_id, user_id)
-                markdown_file = os.path.join(manager.workspace, "research_report.md")
-                if os.path.exists(markdown_file):
-                    os.remove(markdown_file)
-                    logger.info(f"[MetadataAwareExecutor] Cleared previous research file: {markdown_file}")
-            except Exception as e:
-                logger.warning(f"[MetadataAwareExecutor] Failed to clear previous research file: {e}")
-
-        # Get or create agent with specified model_id
-        if model_id and model_id in self.agent_cache:
-            agent = self.agent_cache[model_id]
-            logger.info(f"[MetadataAwareExecutor] Using cached agent with model: {model_id}")
-        elif model_id:
-            # Create new agent with this model_id
-            logger.info(f"[MetadataAwareExecutor] Creating new agent with model: {model_id}")
-            agent = create_agent(model_id)
-            self.agent_cache[model_id] = agent
-        else:
-            # Fallback to default agent
-            default_model = MODEL_ID
-            if default_model not in self.agent_cache:
-                self.agent_cache[default_model] = create_agent(default_model)
-            agent = self.agent_cache[default_model]
-            logger.info(f"[MetadataAwareExecutor] Using default agent with model: {default_model}")
-
-        # Temporarily set self.agent for parent class methods
-        self.agent = agent
+        # No pre-run clearing of research_report.md: the session id is scoped per
+        # research now, so there is no stale file to clear, and deleting by
+        # session would destroy a concurrent research's in-progress report.
 
         # Convert A2A message parts to Strands ContentBlocks
         if context.message and hasattr(context.message, "parts"):
@@ -218,14 +234,26 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
 
         logger.info(f"[MetadataAwareExecutor] Invoking agent with invocation_state: {invocation_state}")
 
-        # Store session info for _handle_agent_result
-        self._current_session_id = session_id
-        self._current_user_id = user_id
+        # Scope streaming state to this request so concurrent researches cannot
+        # trade step numbers or resolve each other's report. Set before the base
+        # class builds this context's agent, which reads model_id from here.
+        _request_state.set(_RequestState(session_id=session_id, user_id=user_id, model_id=model_id))
+
+        # Report this research to /ping as in-flight work. The A2A SDK keeps
+        # consuming events after the client disconnects, so the run outlives the
+        # request and the platform would otherwise reclaim the container while
+        # the report is still being written.
+        task_id = async_tasks.begin("research", {"session_id": session_id})
 
         try:
-            # Use agent.stream_async with invocation_state
-            async for event in agent.stream_async(content_blocks, invocation_state=invocation_state):
-                await self._handle_streaming_event(event, updater)
+            # Delegate to the base class so the per-context agent and lock apply.
+            await self._run_with_context_agent(
+                context.context_id,
+                content_blocks,
+                invocation_state,
+                updater,
+                None,
+            )
         except Exception as e:
             error_msg = str(e)
             # Check for Bedrock service errors
@@ -245,10 +273,17 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
             else:
                 logger.exception("Error in streaming execution")
             raise
+        finally:
+            # Always release, including on cancellation: a task left registered
+            # keeps reporting HealthyBusy and pins the session until maxLifetime.
+            async_tasks.end(task_id)
 
-    async def _handle_agent_result(self, result, updater: TaskUpdater) -> None:
+    async def _handle_agent_result(self, result, updater: TaskUpdater, stream_state=None) -> None:
         """
         Override to add markdown content along with agent result before completing.
+
+        stream_state is the base class's A2A-compliant streaming state; accepted
+        to match its signature.
         """
         # Add agent's summary response first (if any)
         if final_content := str(result):
@@ -257,9 +292,11 @@ class MetadataAwareExecutor(StrandsA2AExecutor):
                 name="agent_response",
             )
 
-        # Read markdown file and add as main artifact
-        session_id = getattr(self, '_current_session_id', None)
-        user_id = getattr(self, '_current_user_id', 'default_user')
+        # Read markdown file and add as main artifact. The session comes from
+        # this request's state, never a field shared with other researches.
+        state = _request_state.get()
+        session_id = state.session_id
+        user_id = state.user_id
 
         if session_id:
             try:
@@ -539,38 +576,24 @@ def create_app() -> FastAPI:
         version="1.0.0"
     )
 
-    # Agent cache for reusing agents with the same model_id
-    agent_cache = {}
+    def build_agent(context_id: str, model_id: Optional[str] = None) -> Agent:
+        """Build a dedicated agent for one A2A context.
 
-    def get_or_create_agent(model_id: Optional[str] = None) -> Agent:
-        """Get cached agent or create new one with specified model_id"""
+        Deliberately not cached by model: agents are no longer shared across
+        contexts, which is what stops two concurrent researches from interleaving
+        their conversation state. Construction is cheap next to a research run.
+        """
         effective_model_id = model_id or MODEL_ID
+        logger.info(f"Creating agent for context {context_id} with model: {effective_model_id}")
+        return create_agent(effective_model_id)
 
-        if effective_model_id not in agent_cache:
-            logger.info(f"Creating new agent instance with model: {effective_model_id}")
-            agent_cache[effective_model_id] = create_agent(effective_model_id)
-        else:
-            logger.info(f"Reusing cached agent with model: {effective_model_id}")
-
-        return agent_cache[effective_model_id]
-
-    # Create default agent for A2A Server initialization (required but will be overridden by MetadataAwareExecutor)
-    default_agent = get_or_create_agent()
-
-    # Create Custom Executor with agent cache
-    custom_executor = MetadataAwareExecutor(agent_cache=agent_cache)
-
-    # Create Custom Request Handler with our executor
     task_store = InMemoryTaskStore()
-    custom_request_handler = DefaultRequestHandler(
-        agent_executor=custom_executor,
-        task_store=task_store
-    )
 
-    # Create A2A server with custom request handler
-    # Note: We still need to pass an agent to A2AServer for AgentCard generation
+    # A2AServer builds its own executor, which we replace below with ours; it is
+    # given the factory so it derives the AgentCard from a representative agent
+    # instead of a second long-lived default one.
     a2a_server = A2AServer(
-        agent=default_agent,  # Used only for AgentCard metadata
+        agent_factory=build_agent,
         http_url=runtime_url,
         serve_at_root=True,
         host="0.0.0.0",
@@ -580,76 +603,31 @@ def create_app() -> FastAPI:
         task_store=task_store  # Share the same task store
     )
 
-    # Override the request_handler with our custom one
-    a2a_server.request_handler = custom_request_handler
+    # Swap in our executor: A2AServer has no hook for a custom one, and we need
+    # the metadata extraction and research_step artifacts it adds.
+    a2a_server.request_handler = DefaultRequestHandler(
+        agent_executor=MetadataAwareExecutor(agent_factory=build_agent),
+        task_store=task_store
+    )
 
     logger.info(f"A2A Server configured with MetadataAwareExecutor at {runtime_url}")
 
     @app.get("/ping")
     def ping():
-        """Health check endpoint."""
+        """Report liveness to AgentCore Runtime.
+
+        The status is the platform's only signal for whether this session is
+        idle: "Healthy" makes the microVM eligible for termination after
+        idleRuntimeSessionTimeout, "HealthyBusy" keeps it alive while research is
+        still running. Must stay non-blocking — blocking here would let a busy
+        event loop get the container reclaimed mid-research.
+        """
         return {
-            "status": "healthy",
+            "status": async_tasks.ping_status(),
             "agent": "Research Agent",
             "version": "1.0.0",
             "skills": ["research_topic", "generate_report"]
         }
-
-    @app.post("/research")
-    async def research_topic(request: dict):
-        """
-        Direct endpoint for local testing (non-A2A).
-
-        Request body:
-        {
-            "topic": "Research topic or question",
-            "session_id": "optional-session-id"
-        }
-        """
-        topic = request.get("topic", "")
-        session_id = request.get("session_id", str(uuid.uuid4()))
-
-        if not topic:
-            return {"error": "topic is required"}
-
-        try:
-            logger.info(f"Starting research on topic: {topic} (session: {session_id})")
-
-            # Get default agent
-            agent = get_or_create_agent()
-
-            # Run agent with invocation_state to pass session_id to tools
-            result = await agent.invoke_async(
-                f"Research this topic and create a comprehensive report: {topic}",
-                invocation_state={"request_state": {"session_id": session_id}}
-            )
-
-            # Read the generated markdown document
-            from report_manager import get_report_manager
-            import os
-            manager = get_report_manager(session_id)
-
-            # Read markdown file from workspace
-            markdown_file = os.path.join(manager.workspace, "research_report.md")
-            markdown_content = ""
-            if os.path.exists(markdown_file):
-                with open(markdown_file, 'r', encoding='utf-8') as f:
-                    markdown_content = f.read()
-            else:
-                markdown_content = "No markdown file generated"
-
-            return {
-                "status": "success",
-                "session_id": session_id,
-                "topic": topic,
-                "markdown": markdown_content,
-                "markdown_file": markdown_file,
-                "agent_response": result.output if hasattr(result, 'output') else str(result)
-            }
-
-        except Exception as e:
-            logger.error(f"Error in research_topic: {e}")
-            return {"error": str(e)}
 
     # Mount A2A server with MetadataAwareExecutor
     # This handles ALL A2A protocol endpoints including /, /ping, /.well-known/agent-card.json

--- a/agentcore/a2a-agents/research-agent/tests/test_async_tasks.py
+++ b/agentcore/a2a-agents/research-agent/tests/test_async_tasks.py
@@ -1,0 +1,199 @@
+"""Tests for research task tracking and the /ping status it drives.
+
+Research outlives the request that starts it (the A2A SDK keeps consuming events
+after the client disconnects), so this status is what stops AgentCore Runtime
+from reclaiming the container mid-report. A stuck "HealthyBusy" leaks the session
+until maxLifetime; a premature "Healthy" loses the research.
+"""
+import asyncio
+import os
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+os.environ.setdefault("AWS_REGION", "us-west-2")
+os.environ.setdefault("ARTIFACT_BUCKET", "test-bucket")
+
+import async_tasks  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    async_tasks.reset()
+    yield
+    async_tasks.reset()
+
+
+class TestPingStatus:
+    def test_idle_when_nothing_is_registered(self):
+        assert async_tasks.ping_status() == "Healthy"
+
+    def test_busy_while_research_runs(self):
+        async_tasks.begin("research")
+        assert async_tasks.ping_status() == "HealthyBusy"
+
+    def test_idle_again_once_research_ends(self):
+        task_id = async_tasks.begin("research")
+        async_tasks.end(task_id)
+        assert async_tasks.ping_status() == "Healthy"
+
+    def test_stays_busy_until_the_last_research_ends(self):
+        first = async_tasks.begin("research-1")
+        second = async_tasks.begin("research-2")
+        async_tasks.end(first)
+        assert async_tasks.ping_status() == "HealthyBusy", (
+            "one research finishing marked the session idle while another ran"
+        )
+        async_tasks.end(second)
+        assert async_tasks.ping_status() == "Healthy"
+
+    def test_reused_id_does_not_end_another_task(self):
+        first = async_tasks.begin("research-1")
+        async_tasks.end(first)
+        async_tasks.begin("research-2")
+        assert async_tasks.end(first) is False
+        assert async_tasks.ping_status() == "HealthyBusy"
+
+    def test_unknown_id_is_reported_not_raised(self):
+        assert async_tasks.end(9999) is False
+
+    def test_concurrent_registration_from_threads(self):
+        ids, ids_lock = [], threading.Lock()
+
+        def worker():
+            task_id = async_tasks.begin("threaded")
+            with ids_lock:
+                ids.append(task_id)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(set(ids)) == 20
+        for task_id in ids:
+            async_tasks.end(task_id)
+        assert async_tasks.ping_status() == "Healthy"
+
+
+class TestPingEndpointContract:
+    """The endpoint must report the tracker, using the platform's spellings."""
+
+    def test_reports_the_tracker_status(self):
+        import main
+
+        app = main.create_app()
+        route = next(r for r in app.routes if getattr(r, "path", None) == "/ping")
+
+        assert route.endpoint()["status"] == "Healthy"
+        async_tasks.begin("research")
+        assert route.endpoint()["status"] == "HealthyBusy"
+
+    # A timestamp that advances on every ping reads as a continuous status
+    # change, which stops the idle timeout from firing and exhausts the quota.
+    def test_omits_time_of_last_update(self):
+        import main
+
+        app = main.create_app()
+        route = next(r for r in app.routes if getattr(r, "path", None) == "/ping")
+        assert "time_of_last_update" not in route.endpoint()
+
+
+class TestExecutorRegistersResearch:
+    """The executor has to register work, or /ping never reports it."""
+
+    def _context(self):
+        from a2a.types import Part, TextPart
+
+        ctx = MagicMock()
+        ctx.metadata = {"session_id": "s" + "1" * 32, "user_id": "u1", "model_id": "m"}
+        ctx.context_id = "ctx-1"
+        message = MagicMock()
+        message.metadata = ctx.metadata
+        message.parts = [Part(root=TextPart(kind="text", text="research this"))]
+        ctx.message = message
+        return ctx
+
+    def _updater(self):
+        updater = MagicMock()
+        updater.add_artifact = MagicMock(side_effect=lambda *a, **k: asyncio.sleep(0))
+        updater.complete = MagicMock(side_effect=lambda *a, **k: asyncio.sleep(0))
+        return updater
+
+    def test_reports_busy_while_the_agent_streams(self):
+        import main
+
+        seen = []
+
+        agent = MagicMock()
+
+        async def stream_async(content_blocks, invocation_state=None, **kwargs):
+            seen.append(async_tasks.ping_status())
+            if False:
+                yield {}
+
+        agent.stream_async = stream_async
+        executor = main.MetadataAwareExecutor(agent_factory=lambda context_id, model_id=None: agent)
+        asyncio.run(executor._execute_streaming(self._context(), self._updater()))
+
+        assert seen == ["HealthyBusy"], (
+            "research ran without being registered, so the platform could "
+            "reclaim the container mid-report"
+        )
+
+    def test_releases_the_task_when_research_completes(self):
+        import main
+
+        agent = MagicMock()
+
+        async def stream_async(content_blocks, invocation_state=None, **kwargs):
+            if False:
+                yield {}
+
+        agent.stream_async = stream_async
+        executor = main.MetadataAwareExecutor(agent_factory=lambda context_id, model_id=None: agent)
+        asyncio.run(executor._execute_streaming(self._context(), self._updater()))
+
+        assert async_tasks.ping_status() == "Healthy"
+
+    def test_releases_the_task_when_research_fails(self):
+        """A task left registered pins the session until maxLifetime."""
+        import main
+
+        agent = MagicMock()
+
+        async def stream_async(content_blocks, invocation_state=None, **kwargs):
+            raise RuntimeError("model exploded")
+            yield {}
+
+        agent.stream_async = stream_async
+        executor = main.MetadataAwareExecutor(agent_factory=lambda context_id, model_id=None: agent)
+        with pytest.raises(RuntimeError):
+            asyncio.run(executor._execute_streaming(self._context(), self._updater()))
+
+        assert async_tasks.ping_status() == "Healthy", (
+            "a failed research stayed registered and would pin the session"
+        )
+
+    def test_releases_the_task_when_research_is_cancelled(self):
+        """Stop/disconnect cancels the run; the registration must not survive it."""
+        import main
+
+        agent = MagicMock()
+
+        async def stream_async(content_blocks, invocation_state=None, **kwargs):
+            raise asyncio.CancelledError()
+            yield {}
+
+        agent.stream_async = stream_async
+        executor = main.MetadataAwareExecutor(agent_factory=lambda context_id, model_id=None: agent)
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(executor._execute_streaming(self._context(), self._updater()))
+
+        assert async_tasks.ping_status() == "Healthy"

--- a/agentcore/a2a-agents/research-agent/tests/test_concurrent_research.py
+++ b/agentcore/a2a-agents/research-agent/tests/test_concurrent_research.py
@@ -1,0 +1,313 @@
+"""Regression tests for two research requests running at the same time.
+
+These drive the real MetadataAwareExecutor rather than stubs, because every bug
+they cover comes from state living on the shared executor instance — stubs would
+reproduce the intended design, not the defect.
+
+Concurrency is currently unreachable: the orchestrator holds one A2A stream open
+per research call, so a second call cannot start until the first returns. Making
+research non-blocking removes that accidental serialisation, which is why these
+are pinned now rather than after the change.
+
+Each test states the user-visible failure it prevents; the shared-state cause is
+an implementation detail that a fix is free to restructure.
+"""
+import asyncio
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# Importing main constructs the default agent and the A2A server, both of which
+# read configuration from the environment. Set it before the import below.
+os.environ.setdefault("AWS_REGION", "us-west-2")
+os.environ.setdefault("ARTIFACT_BUCKET", "test-bucket")
+
+import main  # noqa: E402
+import report_manager  # noqa: E402
+
+
+SESSION_A = "session-a" + "a" * 32
+SESSION_B = "session-b" + "b" * 32
+
+
+@pytest.fixture
+def workspaces(tmp_path, monkeypatch):
+    """Resolve report workspaces under tmp_path, with no cache shared between tests.
+
+    get_report_manager memoises by session id at module scope, so without this a
+    manager built by one test would hand another test a stale workspace.
+    """
+    monkeypatch.setattr(report_manager, "_managers", {})
+    real_init = report_manager.ReportManager.__init__
+
+    def init_under_tmp(self, session_id, user_id=None, base_dir=None):
+        real_init(self, session_id, user_id, base_dir=str(tmp_path))
+
+    monkeypatch.setattr(report_manager.ReportManager, "__init__", init_under_tmp)
+    return report_manager.get_report_manager
+
+
+class RecordingUpdater:
+    """TaskUpdater double that records which request emitted each artifact."""
+
+    def __init__(self, label, sink):
+        self.label = label
+        self.sink = sink
+
+    async def add_artifact(self, parts, name=None):
+        self.sink.append({"request": self.label, "name": name})
+
+    async def complete(self, *args, **kwargs):
+        pass
+
+    async def update_status(self, *args, **kwargs):
+        pass
+
+    async def failed(self, *args, **kwargs):
+        pass
+
+
+def make_context(session_id, label, model_id):
+    """A RequestContext carrying real Parts — the executor validates their type."""
+    from a2a.types import Part, TextPart
+
+    ctx = MagicMock()
+    ctx.metadata = {"session_id": session_id, "user_id": "u1", "model_id": model_id}
+    ctx.context_id = f"ctx-{label}"
+    message = MagicMock()
+    message.metadata = ctx.metadata
+    message.parts = [Part(root=TextPart(kind="text", text=f"research {label}"))]
+    ctx.message = message
+    return ctx
+
+
+def tool_streaming_agent(label, tool_count, gate=None):
+    """Agent whose stream yields `tool_count` distinct tool_use events.
+
+    Awaits between events so the two requests genuinely interleave on the loop
+    instead of running to completion one after the other.
+    """
+    agent = MagicMock()
+
+    async def stream_async(content_blocks, invocation_state=None, **kwargs):
+        for index in range(tool_count):
+            yield {
+                "type": "tool_use_stream",
+                "current_tool_use": {
+                    "toolUseId": f"{label}-tool-{index}",
+                    "name": "web_search",
+                    "input": {"query": f"{label} query {index}"},
+                },
+            }
+            if gate is not None and index == 0:
+                gate.set()  # let the other request start mid-stream
+            await asyncio.sleep(0)
+
+    agent.stream_async = stream_async
+    return agent
+
+
+def result_emitting_agent(label, gate=None):
+    """Agent that streams one tool event then finishes, so the result path runs."""
+    agent = MagicMock()
+
+    async def stream_async(content_blocks, invocation_state=None, **kwargs):
+        yield {
+            "type": "tool_use_stream",
+            "current_tool_use": {
+                "toolUseId": f"{label}-tool-0",
+                "name": "web_search",
+                "input": {"query": f"{label} query"},
+            },
+        }
+        if gate is not None:
+            gate.set()
+        await asyncio.sleep(0)
+        result = MagicMock()
+        result.stop_reason = "end_turn"
+        result.__str__ = lambda self, label=label: f"{label} summary"
+        yield {"result": result}
+
+    agent.stream_async = stream_async
+    return agent
+
+
+async def run_interleaved(executor, artifacts, tool_count=3):
+    """Run two requests concurrently, B starting midway through A."""
+    gate = asyncio.Event()
+    agents = {
+        "model-A": tool_streaming_agent("A", tool_count, gate=gate),
+        "model-B": tool_streaming_agent("B", tool_count),
+    }
+
+    executor._agent_builder = lambda context_id, model_id=None: agents[model_id]
+
+    async def request_a():
+        await executor._execute_streaming(
+            make_context(SESSION_A, "A", "model-A"),
+            RecordingUpdater("A", artifacts),
+        )
+
+    async def request_b():
+        await gate.wait()
+        await executor._execute_streaming(
+            make_context(SESSION_B, "B", "model-B"),
+            RecordingUpdater("B", artifacts),
+        )
+
+    await asyncio.gather(request_a(), request_b())
+
+
+class TestConcurrentProgressEvents:
+    """Progress events must stay attributable to the request that produced them."""
+
+    def test_neither_request_emits_a_step_number_twice(self):
+        """A number repeated within one research is dropped as a duplicate.
+
+        The orchestrator's _process_artifact keeps a `sent_research_steps` set for
+        the duration of one A2A stream and skips any number already in it, so a
+        repeat inside a single research silently loses that progress event.
+
+        Across researches the same number is fine: each runs as its own A2A task
+        on its own stream, with its own set.
+        """
+        artifacts = []
+        executor = main.MetadataAwareExecutor(agent_factory=lambda context_id, model_id=None: None)
+
+        asyncio.run(run_interleaved(executor, artifacts))
+
+        for label in ("A", "B"):
+            names = Counter(
+                a["name"] for a in artifacts
+                if a["request"] == label and a["name"].startswith("research_step_")
+            )
+            duplicated = {name: count for name, count in names.items() if count > 1}
+            assert not duplicated, (
+                f"request {label} reused step numbers {duplicated}, so the "
+                f"orchestrator would drop those progress events"
+            )
+
+    def test_each_request_numbers_its_own_steps_from_one(self):
+        """A request's steps must be numbered independently of other traffic.
+
+        The orchestrator derives display order from the suffix, so a request
+        whose first step arrives as research_step_3 renders out of order.
+        """
+        artifacts = []
+        executor = main.MetadataAwareExecutor(agent_factory=lambda context_id, model_id=None: None)
+
+        asyncio.run(run_interleaved(executor, artifacts))
+
+        for label in ("A", "B"):
+            steps = [
+                a["name"] for a in artifacts
+                if a["request"] == label and a["name"].startswith("research_step_")
+            ]
+            expected = [f"research_step_{i}" for i in range(1, len(steps) + 1)]
+            assert steps == expected, f"request {label} produced {steps}, expected {expected}"
+
+
+class TestConcurrentResultRouting:
+    """A request must return its own report, never another request's."""
+
+    def test_each_request_returns_its_own_report(self, workspaces):
+        """Guards against handing the user another research's report.
+
+        Runs both requests through the real streaming path and checks the
+        research_markdown artifact each one emitted.
+        """
+        for session, body in ((SESSION_A, "# Report for A"), (SESSION_B, "# Report for B")):
+            manager = workspaces(session, "u1")
+            os.makedirs(manager.workspace, exist_ok=True)
+            with open(os.path.join(manager.workspace, "research_report.md"), "w", encoding="utf-8") as handle:
+                handle.write(body)
+
+        reports = []
+
+        class ReportCapturingUpdater(RecordingUpdater):
+            async def add_artifact(self, parts, name=None):
+                await super().add_artifact(parts, name)
+                if name == "research_markdown":
+                    reports.append({"request": self.label, "text": parts[0].root.text})
+
+        async def scenario():
+            gate = asyncio.Event()
+            agents = {
+                "model-A": result_emitting_agent("A", gate=gate),
+                "model-B": result_emitting_agent("B"),
+            }
+            executor = main.MetadataAwareExecutor(
+                agent_factory=lambda context_id, model_id=None: agents[model_id]
+            )
+
+            async def request_a():
+                await executor._execute_streaming(
+                    make_context(SESSION_A, "A", "model-A"),
+                    ReportCapturingUpdater("A", []),
+                )
+
+            async def request_b():
+                await gate.wait()
+                await executor._execute_streaming(
+                    make_context(SESSION_B, "B", "model-B"),
+                    ReportCapturingUpdater("B", []),
+                )
+
+            await asyncio.gather(request_a(), request_b())
+
+        asyncio.run(scenario())
+
+        by_request = {r["request"]: r["text"] for r in reports}
+        assert "Report for A" in by_request.get("A", ""), (
+            f"request A returned {by_request.get('A')!r} — another request's research"
+        )
+        assert "Report for B" in by_request.get("B", ""), (
+            f"request B returned {by_request.get('B')!r} — another request's research"
+        )
+
+    def test_concurrent_research_does_not_delete_the_other_report(self, workspaces):
+        """Guards against one research destroying another's in-progress output.
+
+        Two researches started from one chat must not resolve to the same report
+        file, since starting a research used to clear that path.
+        """
+        chat_session = "chat-session" + "c" * 32
+
+        first = workspaces(chat_session + "-task1", "u1")
+        os.makedirs(first.workspace, exist_ok=True)
+        first_report = os.path.join(first.workspace, "research_report.md")
+        with open(first_report, "w", encoding="utf-8") as handle:
+            handle.write("# Research A, still being written")
+
+        # A second research from the same chat resolves its own report location.
+        second = workspaces(chat_session + "-task2", "u1")
+        second_report = os.path.join(second.workspace, "research_report.md")
+
+        assert second_report != first_report, (
+            "both researches in one chat resolve to the same report file "
+            f"({first_report}), so one would destroy the other's output"
+        )
+
+
+class TestAgentCardBuild:
+    """The card is built before any request exists."""
+
+    def test_executor_factory_works_with_no_request_in_flight(self):
+        """A LookupError here would stop the server from starting.
+
+        The base class builds a representative agent for the AgentCard outside
+        any request, so the factory must not require request state.
+        """
+        built = []
+        executor = main.MetadataAwareExecutor(
+            agent_factory=lambda context_id, model_id=None: built.append((context_id, model_id)) or "agent"
+        )
+
+        assert executor._build_context_agent("__agent_card__") == "agent"
+        assert built == [("__agent_card__", None)]

--- a/chatbot-app/agentcore/src/a2a_tools.py
+++ b/chatbot-app/agentcore/src/a2a_tools.py
@@ -162,8 +162,11 @@ async def send_a2a_message(
     try:
         # Check for local testing mode (per-agent env var)
         # e.g. LOCAL_RESEARCH_AGENT_URL, LOCAL_CODE_AGENT_URL, LOCAL_BROWSER_USE_AGENT_URL
+        # Only this agent's own variable: falling back to the research URL sent
+        # every other agent's traffic to the research runtime, which answers with
+        # a research report instead of failing.
         env_key = "LOCAL_" + agent_id.replace("agentcore_", "").replace("-", "_").upper() + "_URL"
-        local_runtime_url = os.environ.get(env_key) or os.environ.get('LOCAL_RESEARCH_AGENT_URL')
+        local_runtime_url = os.environ.get(env_key)
         if local_runtime_url:
             runtime_url = local_runtime_url
             logger.debug(f"Local test mode ({agent_id}): {runtime_url}")
@@ -511,9 +514,21 @@ def create_a2a_tool(agent_id: str):
         async def tool_impl(plan: str, tool_context: ToolContext = None) -> AsyncGenerator[Dict[str, Any], None]:
             session_id, user_id, model_id, _auth_token = extract_context(tool_context)
 
-            # Prepare metadata
+            # Scope the research agent's session to this call rather than reusing
+            # the chat's session. The research agent derives its report workspace
+            # and chart S3 prefix from this id, so two researches in one chat
+            # would otherwise share a workspace and overwrite each other's
+            # research_report.md. Derived from toolUseId so it is stable for
+            # retries of the same call.
+            tool_use_id = ""
+            if tool_context and getattr(tool_context, 'tool_use', None):
+                tool_use_id = tool_context.tool_use.get('toolUseId', '') or ""
+            research_session_id = f"{session_id}-{tool_use_id}" if tool_use_id else session_id
+
+            # Prepare metadata. session_id is the per-research one so the agent's
+            # workspace matches the session header below.
             metadata = {
-                "session_id": session_id,
+                "session_id": research_session_id,
                 "user_id": user_id,
                 "source": "main_agent",
                 "model_id": model_id,
@@ -525,7 +540,7 @@ def create_a2a_tool(agent_id: str):
             final_result_text = None
 
             # Stream events from A2A agent (including research_step events for real-time UI updates)
-            async for event in send_a2a_message(agent_id, plan, session_id, region, metadata=metadata, auth_token=_auth_token):
+            async for event in send_a2a_message(agent_id, plan, research_session_id, region, metadata=metadata, auth_token=_auth_token):
                 # Yield event FIRST to maintain proper stream order
                 yield event
 

--- a/chatbot-app/agentcore/src/agent/async_tasks.py
+++ b/chatbot-app/agentcore/src/agent/async_tasks.py
@@ -1,0 +1,85 @@
+"""Tracks in-flight background work so /ping can report it to AgentCore Runtime.
+
+AgentCore decides whether a runtime session is idle from the /ping status, not
+from open connections: a session reporting "Healthy" is idle-eligible and its
+microVM is terminated after idleRuntimeSessionTimeout (default 15 minutes),
+while "HealthyBusy" keeps it alive up to maxLifetime (default 8 hours). Work
+that outlives the request that started it therefore has to be registered here,
+or the platform reclaims the container from under it.
+
+Deliberately not bedrock_agentcore.runtime.BedrockAgentCoreApp: that class is a
+Starlette subclass meant to *be* the application, and adopting it would mean
+replacing the FastAPI app all the routers are mounted on. The behaviour we need
+from it is the one line that maps "any active task" to HealthyBusy.
+
+Threading, not asyncio: tools run in a ThreadPoolExecutor (see
+skill_tools._run_async), so registrations can arrive off the event loop.
+"""
+
+import itertools
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_active: Dict[int, Dict[str, Any]] = {}
+_ids = itertools.count(1)
+
+
+def begin(name: str, metadata: Optional[Dict[str, Any]] = None) -> int:
+    """Register background work and return the id used to end it."""
+    with _lock:
+        task_id = next(_ids)
+        _active[task_id] = {
+            "name": name,
+            "started_at": time.time(),
+            "metadata": metadata or {},
+        }
+        count = len(_active)
+    logger.info(f"[AsyncTask] Started {name} (id={task_id}, active={count})")
+    return task_id
+
+
+def end(task_id: int) -> bool:
+    """Mark work complete. Returns False if the id was unknown or already ended."""
+    with _lock:
+        task = _active.pop(task_id, None)
+        count = len(_active)
+    if task is None:
+        # Not an error worth raising: end() runs from finally blocks that may be
+        # reached twice, and losing the container matters more than a stray id.
+        logger.warning(f"[AsyncTask] Unknown task id {task_id}")
+        return False
+    elapsed = time.time() - task["started_at"]
+    logger.info(
+        f"[AsyncTask] Completed {task['name']} (id={task_id}, "
+        f"{elapsed:.1f}s, active={count})"
+    )
+    return True
+
+
+def ping_status() -> str:
+    """The status string AgentCore Runtime expects from /ping.
+
+    time_of_last_update is intentionally omitted: the platform tracks status
+    changes itself, and a timestamp that advances on every ping reads as a
+    continuous status change, which stops the idle timeout from ever firing and
+    keeps sessions alive until maxLifetime.
+    """
+    with _lock:
+        return "HealthyBusy" if _active else "Healthy"
+
+
+def active_tasks() -> Dict[int, Dict[str, Any]]:
+    """Snapshot of in-flight work. Used by tests to assert bookkeeping."""
+    with _lock:
+        return {task_id: dict(task) for task_id, task in _active.items()}
+
+
+def reset() -> None:
+    """Drop all registrations. For tests."""
+    with _lock:
+        _active.clear()

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -20,6 +20,7 @@ import os
 import time
 
 from models.schemas import FileContent
+from agent import async_tasks
 from agent.processor.multimodal_builder import build_prompt
 from agents.factory import create_agent
 from streaming.agui_event_processor import AGUIStreamEventProcessor
@@ -252,12 +253,6 @@ async def invocations(http_request: Request):
     return await _handle_agui_invocation(body, http_request)
 
 
-@router.get("/ping")
-async def ping():
-    """Health check endpoint required by AgentCore Runtime."""
-    return {"status": "healthy"}
-
-
 @router.get("/execution-status")
 async def get_execution_status(executionId: str):
     """Check execution status. Local-mode convenience endpoint."""
@@ -463,6 +458,11 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
 
         # Run agent as background task — events buffered in execution
         async def run_agui_to_buffer():
+            # Report the run to /ping. It deliberately outlives this request (the
+            # client can disconnect and resume from the buffer), so without this
+            # AgentCore Runtime treats the session as idle and can reclaim the
+            # microVM mid-run.
+            task_id = async_tasks.begin("agent_run", {"execution_id": execution.execution_id})
             try:
                 stream = agui_processor.process_stream(
                     agent.agent,
@@ -479,6 +479,7 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
                 error_event = f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
                 execution.append_event(error_event, "error")
             finally:
+                async_tasks.end(task_id)
                 agent.close()
                 if execution.status == ExecutionStatus.RUNNING:
                     execution.status = ExecutionStatus.COMPLETED

--- a/chatbot-app/agentcore/src/routers/health.py
+++ b/chatbot-app/agentcore/src/routers/health.py
@@ -2,6 +2,8 @@
 
 from fastapi import APIRouter
 
+from agent import async_tasks
+
 router = APIRouter(tags=["health"])
 
 @router.get("/health")
@@ -10,4 +12,12 @@ async def health_check():
 
 @router.get("/ping")
 async def ping():
-    return {"status": "pong"}
+    """Report liveness to AgentCore Runtime.
+
+    The status is the platform's only signal for whether this session is idle:
+    "Healthy" makes the microVM eligible for termination after
+    idleRuntimeSessionTimeout, "HealthyBusy" keeps it alive while background work
+    is in flight. Must stay non-blocking — a slow /ping reads as an unhealthy
+    session, and blocking here would let a busy event loop kill the container.
+    """
+    return {"status": async_tasks.ping_status()}

--- a/chatbot-app/agentcore/tests/unit/test_a2a_research_session.py
+++ b/chatbot-app/agentcore/tests/unit/test_a2a_research_session.py
@@ -1,0 +1,132 @@
+"""The research agent's session id must be scoped per research call.
+
+The research agent derives its report workspace and chart S3 prefix from the
+session id it is handed. Passing the chat's session id gave every research in a
+conversation the same workspace, so a second research overwrote the first's
+research_report.md. See the research agent's tests/test_concurrent_research.py
+for the other half of this.
+"""
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def research_tool(monkeypatch):
+    """Build the research A2A tool with its registry and transport stubbed out.
+
+    Returns (tool_impl, sent) where `sent` records the args of each A2A call.
+    """
+    import a2a_tools
+
+    skill = MagicMock()
+    skill.description = "Research agent"
+    registry_client = MagicMock()
+    registry_client.get_a2a_skill.return_value = skill
+    registry_module = MagicMock()
+    registry_module.get_registry_client.return_value = registry_client
+    monkeypatch.setitem(sys.modules, "registry.client", registry_module)
+
+    monkeypatch.setattr(a2a_tools, "get_cached_agent_url", lambda agent_id: "http://research.test/")
+
+    sent = []
+
+    async def fake_send(agent_id, message, session_id=None, region=None, metadata=None, auth_token=None):
+        sent.append({
+            "session_id": session_id,
+            "metadata": metadata or {},
+            "message": message,
+        })
+        yield {"status": "success", "content": [{"text": "# Findings"}]}
+
+    monkeypatch.setattr(a2a_tools, "send_a2a_message", fake_send)
+
+    tool = a2a_tools.create_a2a_tool("agentcore_research-agent")
+    assert tool is not None
+    return tool._tool_func, sent
+
+
+def make_tool_context(tool_use_id, session_id="chat-session-1"):
+    context = MagicMock()
+    context.tool_use = {"toolUseId": tool_use_id}
+    context.invocation_state = {
+        "session_id": session_id,
+        "user_id": "u1",
+        "model_id": "m1",
+        "auth_token": None,
+    }
+    # No artifact persistence in these tests: agent.state is exercised elsewhere.
+    context.agent = None
+    return context
+
+
+async def drain(agen):
+    return [event async for event in agen]
+
+
+class TestResearchSessionScoping:
+    @pytest.mark.asyncio
+    async def test_two_researches_in_one_chat_get_different_sessions(self, research_tool):
+        """Same workspace for both would let the second delete the first's report."""
+        tool_impl, sent = research_tool
+
+        await drain(tool_impl(plan="first", tool_context=make_tool_context("tool-use-1")))
+        await drain(tool_impl(plan="second", tool_context=make_tool_context("tool-use-2")))
+
+        assert len(sent) == 2
+        assert sent[0]["session_id"] != sent[1]["session_id"], (
+            "both researches were sent the same session id, so they share a "
+            f"report workspace ({sent[0]['session_id']})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_header_and_metadata_agree(self, research_tool):
+        """The agent resolves its workspace from metadata; the runtime routes on
+        the header. If they disagree, work lands in a different place than the
+        session it is billed to."""
+        tool_impl, sent = research_tool
+
+        await drain(tool_impl(plan="go", tool_context=make_tool_context("tool-use-1")))
+
+        assert sent[0]["metadata"]["session_id"] == sent[0]["session_id"]
+
+    @pytest.mark.asyncio
+    async def test_session_is_stable_for_the_same_call(self, research_tool):
+        """A retry of one tool call must resume the same workspace, not orphan it."""
+        tool_impl, sent = research_tool
+
+        await drain(tool_impl(plan="go", tool_context=make_tool_context("tool-use-1")))
+        await drain(tool_impl(plan="go", tool_context=make_tool_context("tool-use-1")))
+
+        assert sent[0]["session_id"] == sent[1]["session_id"]
+
+    @pytest.mark.asyncio
+    async def test_derived_session_keeps_the_chat_session_as_a_prefix(self, research_tool):
+        """Keeps researches traceable to their conversation in logs and S3."""
+        tool_impl, sent = research_tool
+
+        await drain(tool_impl(plan="go", tool_context=make_tool_context("tool-use-1", "chat-abc")))
+
+        assert sent[0]["session_id"].startswith("chat-abc")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_chat_session_without_a_tool_use_id(self, research_tool):
+        """Better one shared workspace than a session id of None."""
+        tool_impl, sent = research_tool
+
+        context = make_tool_context("", "chat-abc")
+        await drain(tool_impl(plan="go", tool_context=context))
+
+        assert sent[0]["session_id"] == "chat-abc"
+
+    @pytest.mark.asyncio
+    async def test_meets_the_runtime_minimum_session_length(self, research_tool):
+        """AgentCore requires >= 33 characters; send_a2a_message pads short ids,
+        but the derived id should already satisfy it for real sessions."""
+        tool_impl, sent = research_tool
+
+        session = "chat-" + "s" * 28  # a realistic 33-char chat session
+        await drain(tool_impl(plan="go", tool_context=make_tool_context("tool-use-1", session)))
+
+        assert len(sent[0]["session_id"]) >= 33

--- a/chatbot-app/agentcore/tests/unit/test_async_tasks.py
+++ b/chatbot-app/agentcore/tests/unit/test_async_tasks.py
@@ -1,0 +1,147 @@
+"""Tests for background task tracking and the /ping status it drives.
+
+The status is what stops AgentCore Runtime from reclaiming the microVM while
+work is still in flight, so the mapping and the bookkeeping around it are load
+bearing: a stuck "HealthyBusy" leaks sessions until maxLifetime, and a premature
+"Healthy" kills work mid-flight.
+"""
+import threading
+
+import pytest
+
+from agent import async_tasks
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    async_tasks.reset()
+    yield
+    async_tasks.reset()
+
+
+class TestPingStatus:
+    """The status string is the platform's only idle signal."""
+
+    def test_idle_when_nothing_is_registered(self):
+        assert async_tasks.ping_status() == "Healthy"
+
+    def test_busy_while_work_is_in_flight(self):
+        async_tasks.begin("research")
+        assert async_tasks.ping_status() == "HealthyBusy"
+
+    def test_idle_again_once_work_ends(self):
+        task_id = async_tasks.begin("research")
+        async_tasks.end(task_id)
+        assert async_tasks.ping_status() == "Healthy"
+
+    # The platform reads these two exact spellings; anything else is not a
+    # recognised status and the session's liveness stops being predictable.
+    def test_uses_the_exact_status_spellings_the_platform_expects(self):
+        assert async_tasks.ping_status() == "Healthy"
+        async_tasks.begin("research")
+        assert async_tasks.ping_status() == "HealthyBusy"
+
+    def test_stays_busy_until_the_last_task_ends(self):
+        """Concurrent researches must not let each other's container be reclaimed."""
+        first = async_tasks.begin("research-1")
+        second = async_tasks.begin("research-2")
+
+        async_tasks.end(first)
+        assert async_tasks.ping_status() == "HealthyBusy", (
+            "one research finishing marked the session idle while another ran"
+        )
+
+        async_tasks.end(second)
+        assert async_tasks.ping_status() == "Healthy"
+
+
+class TestTaskBookkeeping:
+    def test_ids_are_unique_across_tasks(self):
+        ids = {async_tasks.begin(f"task-{i}") for i in range(50)}
+        assert len(ids) == 50
+
+    def test_reused_id_does_not_end_another_task(self):
+        """end() runs from finally blocks that can be reached twice."""
+        first = async_tasks.begin("research-1")
+        async_tasks.end(first)
+        second = async_tasks.begin("research-2")
+
+        assert async_tasks.end(first) is False
+        assert async_tasks.ping_status() == "HealthyBusy", (
+            f"ending stale id {first} also ended the live task {second}"
+        )
+
+    def test_unknown_id_is_reported_not_raised(self):
+        # Raising here would propagate out of a finally block and mask the real error.
+        assert async_tasks.end(9999) is False
+
+    def test_active_tasks_reports_names(self):
+        async_tasks.begin("research", {"session": "s1"})
+        active = async_tasks.active_tasks()
+        assert len(active) == 1
+        task = next(iter(active.values()))
+        assert task["name"] == "research"
+        assert task["metadata"] == {"session": "s1"}
+
+    def test_active_tasks_snapshot_does_not_alias_internal_state(self):
+        task_id = async_tasks.begin("research")
+        snapshot = async_tasks.active_tasks()
+        snapshot[task_id]["name"] = "mutated"
+        assert async_tasks.active_tasks()[task_id]["name"] == "research"
+
+    def test_concurrent_registration_from_threads(self):
+        """Tools run in a ThreadPoolExecutor, so begin/end arrive off the loop."""
+        ids = []
+        ids_lock = threading.Lock()
+
+        def worker():
+            task_id = async_tasks.begin("threaded")
+            with ids_lock:
+                ids.append(task_id)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(set(ids)) == 20
+        assert len(async_tasks.active_tasks()) == 20
+
+        for task_id in ids:
+            assert async_tasks.end(task_id) is True
+        assert async_tasks.ping_status() == "Healthy"
+
+
+class TestPingEndpoint:
+    """The endpoint has to reflect the tracker and stay cheap."""
+
+    def _client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from routers import health
+
+        app = FastAPI()
+        app.include_router(health.router)
+        return TestClient(app)
+
+    def test_reports_healthy_when_idle(self):
+        response = self._client().get("/ping")
+        assert response.status_code == 200
+        assert response.json() == {"status": "Healthy"}
+
+    def test_reports_busy_while_work_is_in_flight(self):
+        async_tasks.begin("research")
+        response = self._client().get("/ping")
+        assert response.status_code == 200
+        assert response.json() == {"status": "HealthyBusy"}
+
+    # A timestamp that advances on every ping reads as a continuous status
+    # change, which prevents the idle timeout from ever firing and exhausts the
+    # session quota. The platform tracks changes itself, so the field is omitted.
+    def test_omits_time_of_last_update(self):
+        response = self._client().get("/ping")
+        assert "time_of_last_update" not in response.json()
+
+    def test_ping_is_get_only(self):
+        assert self._client().post("/ping").status_code == 405

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -41,34 +41,21 @@ def _agui_payload(
 # ============================================================
 
 class TestPingEndpoint:
-    """Tests for the /ping health check endpoint."""
+    """/ping is owned by routers.health — see test_health_router.py.
 
-    def test_ping_returns_healthy(self):
-        """Test that ping returns healthy status."""
+    The chat router used to declare a second /ping. It never served a request:
+    main.py registers health.router first and FastAPI keeps the first match, so
+    the duplicate shadowed nothing and drifted out of spec unnoticed.
+    """
+
+    def test_chat_router_does_not_declare_ping(self):
         from routers.chat import router
-        from fastapi import FastAPI
 
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
-
-        response = client.get("/ping")
-
-        assert response.status_code == 200
-        assert response.json() == {"status": "healthy"}
-
-    def test_ping_is_get_method(self):
-        """Test that ping only accepts GET requests."""
-        from routers.chat import router
-        from fastapi import FastAPI
-
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
-
-        # POST should fail
-        response = client.post("/ping")
-        assert response.status_code == 405
+        paths = {route.path for route in router.routes}
+        assert "/ping" not in paths, (
+            "/ping must be declared once, in routers.health; a second "
+            "declaration is dead code that silently diverges"
+        )
 
 
 # ============================================================

--- a/chatbot-app/agentcore/tests/unit/test_ping_reports_agent_runs.py
+++ b/chatbot-app/agentcore/tests/unit/test_ping_reports_agent_runs.py
@@ -1,0 +1,82 @@
+"""An agent run must be visible to /ping for its whole duration.
+
+The run is a background task that deliberately outlives its request: the client
+can disconnect and resume from the execution buffer. AgentCore Runtime decides
+whether to reclaim the microVM from the /ping status, so a run it cannot see can
+be killed part-way through.
+"""
+import asyncio
+
+import pytest
+
+from agent import async_tasks
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    async_tasks.reset()
+    yield
+    async_tasks.reset()
+
+
+class TestPingDuringAgentRun:
+    def test_run_is_registered_and_released(self):
+        """Mirrors run_agui_to_buffer: register, stream, release in finally."""
+        observed = []
+
+        async def scenario():
+            task_id = async_tasks.begin("agent_run", {"execution_id": "s:r"})
+            try:
+                observed.append(async_tasks.ping_status())
+            finally:
+                async_tasks.end(task_id)
+            observed.append(async_tasks.ping_status())
+
+        asyncio.run(scenario())
+        assert observed == ["HealthyBusy", "Healthy"]
+
+    def test_two_runs_keep_the_session_alive_until_both_finish(self):
+        """One run ending must not mark the container idle while another streams."""
+        first = async_tasks.begin("agent_run", {"execution_id": "s:r1"})
+        second = async_tasks.begin("agent_run", {"execution_id": "s:r2"})
+
+        async_tasks.end(first)
+        assert async_tasks.ping_status() == "HealthyBusy"
+
+        async_tasks.end(second)
+        assert async_tasks.ping_status() == "Healthy"
+
+
+class TestChatRouterWiring:
+    """The router has to be the thing that registers, not just the tracker."""
+
+    def test_run_to_buffer_registers_the_run(self):
+        """Guards the wiring: a tracker with no writer always reports Healthy."""
+        import inspect
+
+        from routers import chat
+
+        source = inspect.getsource(chat._handle_agui_invocation)
+        assert "async_tasks.begin(" in source, (
+            "the agent run is never registered, so /ping reports Healthy while "
+            "it streams and the platform can reclaim the container mid-run"
+        )
+        assert "async_tasks.end(" in source, (
+            "the run is never released, so /ping reports HealthyBusy forever and "
+            "pins the session until maxLifetime"
+        )
+
+    def test_release_happens_in_a_finally_block(self):
+        """Errors and cancellation must not leak a registration."""
+        import inspect
+        import re
+
+        from routers import chat
+
+        source = inspect.getsource(chat._handle_agui_invocation)
+        # The end() call must sit under a finally:, not only on the happy path.
+        finally_body = re.search(r"\n(\s+)finally:\n(.*?)(?=\n\1\S|\Z)", source, re.DOTALL)
+        assert finally_body and "async_tasks.end(" in finally_body.group(2), (
+            "async_tasks.end() is not in the finally block, so a failed or "
+            "cancelled run would keep the session pinned"
+        )

--- a/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
+++ b/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
@@ -1,0 +1,181 @@
+/**
+ * A past research must not be "completed" again after a page reload.
+ *
+ * researchData is derived from message history, so every research a session has
+ * ever run reappears as status 'complete' on each mount. The completion handler
+ * dedupes with a useRef Set, which starts empty on every mount — so after a
+ * reload the first render replays old completions. Each replay resets the
+ * research state and opens that research's artifact, which tears down the
+ * approval card for the research the user is starting right now.
+ *
+ * That is why the bug only showed up with artifacts already present, and only
+ * after a reload: without a reload the Set still holds the earlier ids.
+ *
+ * Canvas's own priority rule is covered in CanvasResearchApproval.test.tsx.
+ * This covers the guard that stops the state from being torn down before Canvas
+ * ever gets the chance to apply it.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+interface ResearchExecution {
+  status: string
+  result: string
+}
+
+/**
+ * The completion loop from ChatInterface, with the surrounding component state
+ * passed in. Kept as a function of its inputs so the ordering that produced the
+ * bug (interrupt arrives, then history replays) can be driven directly.
+ */
+function runCompletionPass(
+  researchData: Map<string, ResearchExecution>,
+  artifacts: Array<{ id: string }>,
+  processed: Set<string>,
+  researchArtifactId: string | null,
+  handlers: {
+    onComplete: (executionId: string) => void
+    onReset: () => void
+    onOpenArtifact: (id: string) => void
+  },
+) {
+  if (!researchArtifactId) return
+
+  for (const [executionId, data] of researchData) {
+    if (processed.has(executionId)) continue
+
+    // The guard: an artifact for this research already exists, so it finished
+    // before this mount and must not be completed again.
+    if (artifacts.some(a => a.id === `research-${executionId}`)) {
+      processed.add(executionId)
+      continue
+    }
+
+    if (data.status === 'complete' && data.result) {
+      processed.add(executionId)
+      handlers.onComplete(executionId)
+      handlers.onReset()
+      handlers.onOpenArtifact(`research-${executionId}`)
+    }
+  }
+}
+
+/** Reads the shipped component source; vitest runs with the frontend as cwd. */
+async function readChatInterfaceSource(): Promise<string> {
+  const { readFileSync } = await import('node:fs')
+  const { resolve } = await import('node:path')
+  return readFileSync(resolve(process.cwd(), 'src/components/ChatInterface.tsx'), 'utf8')
+}
+
+function setup() {
+  return {
+    onComplete: vi.fn(),
+    onReset: vi.fn(),
+    onOpenArtifact: vi.fn(),
+  }
+}
+
+describe('research completion replay after reload', () => {
+  it('does not re-complete a research that already has an artifact', () => {
+    const handlers = setup()
+    const researchData = new Map([
+      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
+    ])
+    const artifacts = [{ id: 'research-exec-old' }]
+
+    // Fresh mount: the dedupe set is empty, as it is after every reload.
+    runCompletionPass(researchData, artifacts, new Set(), 'in-progress', handlers)
+
+    expect(handlers.onReset).not.toHaveBeenCalled()
+    expect(handlers.onOpenArtifact).not.toHaveBeenCalled()
+  })
+
+  // The user-visible failure: the approval card is replaced by the old report.
+  it('leaves a pending approval intact when an old research replays', () => {
+    const handlers = setup()
+    const researchData = new Map([
+      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
+    ])
+    const artifacts = [{ id: 'research-exec-old' }]
+
+    // 'in-progress' is what the interrupt handler sets while awaiting approval.
+    runCompletionPass(researchData, artifacts, new Set(), 'in-progress', handlers)
+
+    expect(handlers.onReset).not.toHaveBeenCalled()
+  })
+
+  it('still completes a research that finished during this mount', () => {
+    const handlers = setup()
+    const researchData = new Map([
+      ['exec-new', { status: 'complete', result: '<research># New</research>' }],
+    ])
+
+    // No artifact yet — the backend saves it, but this pass is what adds it locally.
+    runCompletionPass(researchData, [], new Set(), 'in-progress', handlers)
+
+    expect(handlers.onComplete).toHaveBeenCalledWith('exec-new')
+    expect(handlers.onOpenArtifact).toHaveBeenCalledWith('research-exec-new')
+  })
+
+  it('completes only the new research when an old one is also present', () => {
+    const handlers = setup()
+    const researchData = new Map([
+      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
+      ['exec-new', { status: 'complete', result: '<research># New</research>' }],
+    ])
+    const artifacts = [{ id: 'research-exec-old' }]
+
+    runCompletionPass(researchData, artifacts, new Set(), 'in-progress', handlers)
+
+    expect(handlers.onComplete).toHaveBeenCalledTimes(1)
+    expect(handlers.onComplete).toHaveBeenCalledWith('exec-new')
+    expect(handlers.onOpenArtifact).toHaveBeenCalledWith('research-exec-new')
+  })
+
+  it('marks the replayed research processed so later passes skip it', () => {
+    const handlers = setup()
+    const researchData = new Map([
+      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
+    ])
+    const artifacts = [{ id: 'research-exec-old' }]
+    const processed = new Set<string>()
+
+    runCompletionPass(researchData, artifacts, processed, 'in-progress', handlers)
+
+    expect(processed.has('exec-old')).toBe(true)
+  })
+
+  // runCompletionPass above mirrors ChatInterface rather than importing it (the
+  // logic lives inside a useEffect in a component with ~40 hooks). That mirror
+  // can drift, so assert the guard is actually present in the shipped source.
+  it('the shipped completion effect guards on an existing artifact', async () => {
+    const source = await readChatInterfaceSource()
+
+    const effect = source.slice(source.indexOf('Clean up when research completes'))
+    const body = effect.slice(0, effect.indexOf('}, ['))
+
+    expect(body).toMatch(/artifacts\.some\(\s*a\s*=>\s*a\.id === `research-\$\{executionId\}`\s*\)/)
+    expect(body).toContain('processedResearchIdsRef.current.add(executionId)')
+  })
+
+  it('the shipped effect re-runs when artifacts change', async () => {
+    const source = await readChatInterfaceSource()
+
+    const effect = source.slice(source.indexOf('Clean up when research completes'))
+    const deps = effect.slice(effect.indexOf('}, ['), effect.indexOf('])', effect.indexOf('}, [')))
+
+    // Without artifacts in the dependency list the guard reads a stale list and
+    // the replay slips through on the render where it matters.
+    expect(deps).toContain('artifacts')
+  })
+
+  it('does nothing when no research is active', () => {
+    const handlers = setup()
+    const researchData = new Map([
+      ['exec-new', { status: 'complete', result: '<research># New</research>' }],
+    ])
+
+    runCompletionPass(researchData, [], new Set(), null, handlers)
+
+    expect(handlers.onComplete).not.toHaveBeenCalled()
+  })
+})

--- a/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
@@ -206,6 +206,41 @@ describe('useChat message queue wiring', () => {
     expect(result.current.queuedMessages.map(m => m.text)).toEqual(['b'])
   })
 
+  // Approving a research resumes the SAME turn. That resumed turn is what
+  // finishes the work the queue is waiting on, so it must settle the turn too —
+  // otherwise the queued message is held by a turn that never reports an outcome.
+  it('flushes the queue after an approved turn completes', async () => {
+    const { result } = await mount()
+    streamState.interrupt = { interrupts: [{ id: 'i1', name: 'approve', reason: { tool_name: 'research_agent' } }] }
+
+    act(() => { result.current.enqueueMessage('follow-up') })
+    await act(async () => { await result.current.sendMessage('research this') })
+    await waitFor(() => expect(result.current.queueHoldReason).toBe('interrupt'))
+
+    // User approves; the run resumes and this time finishes cleanly.
+    streamState.interrupt = null
+    await act(async () => { await result.current.respondToInterrupt('i1', 'yes') })
+
+    await waitFor(() => expect(sentTexts()).toContain('follow-up'))
+    expect(result.current.queuedMessages).toEqual([])
+  })
+
+  it('holds again when the resumed turn errors', async () => {
+    const { result } = await mount()
+    streamState.interrupt = { interrupts: [{ id: 'i1', name: 'approve', reason: { tool_name: 'research_agent' } }] }
+
+    act(() => { result.current.enqueueMessage('follow-up') })
+    await act(async () => { await result.current.sendMessage('research this') })
+    await waitFor(() => expect(result.current.queueHoldReason).toBe('interrupt'))
+
+    streamState.interrupt = null
+    failNextSend = true
+    await act(async () => { await result.current.respondToInterrupt('i1', 'yes') })
+
+    await waitFor(() => expect(result.current.queueHoldReason).toBe('error'))
+    expect(sentTexts()).not.toContain('follow-up')
+  })
+
   it('forwards the artifact context captured at enqueue time', async () => {
     const { result } = await mount()
 

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -594,6 +594,16 @@ export function ChatInterface() {
       // Skip already processed
       if (processedResearchIdsRef.current.has(executionId)) continue
 
+      // A research whose artifact already exists finished before this mount:
+      // researchData is derived from message history, so a page reload replays
+      // every past research as freshly "complete" against an empty processed
+      // set. Completing it again would reset the research state and open its
+      // artifact, replacing the approval card for the research starting now.
+      if (artifacts.some(a => a.id === `research-${executionId}`)) {
+        processedResearchIdsRef.current.add(executionId)
+        continue
+      }
+
       if (data.status === 'complete' && data.result) {
         processedResearchIdsRef.current.add(executionId)
 
@@ -632,7 +642,7 @@ export function ChatInterface() {
         }
       }
     }
-  }, [researchData, researchArtifactId, closeCanvas, addArtifact, sessionId, extractResearchContent, openArtifact])
+  }, [researchData, researchArtifactId, artifacts, closeCanvas, addArtifact, sessionId, extractResearchContent, openArtifact])
 
   // Export conversation to text file
   const exportConversation = useCallback(() => {

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -454,8 +454,8 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   }, [apiNewChat, stopPolling])
 
   // Answering an approval resumes the same turn, so the queue must keep waiting
-  // for that turn to finish rather than treating the hold as resolved. Clearing
-  // the hold here is enough: the resumed turn settles through the normal path.
+  // for that turn to finish rather than treating the hold as resolved: the hold
+  // is cleared here, and the resumed turn reports its own outcome below.
   const respondToInterrupt = useCallback(async (interruptId: string, response: string) => {
     if (!sessionState.interrupt) return
     releaseHoldRef.current()
@@ -473,11 +473,18 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
       await apiSendMessage(
         JSON.stringify([{ interruptResponse: { interruptId, response } }]),
         undefined,
-        undefined,
-        () => setUIState(prev => ({ ...prev, isTyping: false, agentStatus: 'idle' })),
+        // The resumed turn is the one that finishes the work the queue is waiting
+        // on, so it has to settle the turn like any other. Without this the queue
+        // keeps a message that nothing ever flushes.
+        () => { setTurnSettled({ outcome: 'finished' }) },
+        () => {
+          setTurnSettled({ outcome: 'error' })
+          setUIState(prev => ({ ...prev, isTyping: false, agentStatus: 'idle' }))
+        },
       )
     } catch (error) {
       console.error('[Interrupt] Failed to respond to interrupt:', error)
+      setTurnSettled({ outcome: 'error' })
       setUIState(prev => ({ ...prev, isTyping: false, agentStatus: 'idle' }))
     }
   }, [sessionState.interrupt, apiSendMessage])


### PR DESCRIPTION
## Summary

Fixes three defects around research, all reported from the UI, plus the runtime
liveness signal that a non-blocking research will depend on.

**The approval card vanished** once a session had artifacts and the page was
reloaded. `researchData` is derived from message history, so every past research
reappears as `status: 'complete'` on each mount, while the dedupe set guarding the
completion handler is a `useRef` that starts empty. The first render after a reload
replayed those completions, and each replay reset the research state and opened
that research's artifact — tearing down the card for the research being started.
That is exactly why it needed both prior artifacts and a reload to reproduce.

**Queued messages were stranded after an approval.** The resumed turn is the one
that finishes the work the queue waits on, but `respondToInterrupt` passed no
success callback, so it never reported a turn outcome and nothing flushed.

**Concurrent researches corrupted each other.** `MetadataAwareExecutor` kept its
streaming state on the instance, and the executor is a singleton. Driving two
interleaved requests through the real executor confirmed: step numbers were
shared; `_current_session_id` was overwritten, so a request returned *another
request's report*; and both resolved to one `research_report.md`, which the second
deleted on entry. The orchestrator compounded this by handing the research agent
the chat's session id, so both shared a workspace.

**`/ping` always reported `Healthy`.** AgentCore Runtime decides whether a session
is idle from that status alone and terminates idle sessions after
`idleRuntimeSessionTimeout` (15 min default). Both the orchestrator's agent run and
the research run outlive their request — the client can disconnect and resume from
the buffer, and the A2A SDK keeps consuming events after disconnect — so the
platform could reclaim a container mid-run.

## Approach

- **Per-request state via `ContextVar`.** Each A2A request runs as its own asyncio
  task, so a read resolves to the value that task set: no key to collide, nothing
  to clean up. Replaces an earlier attempt keyed on `id(updater)`, which is only
  unique among *live* objects (measured: 1983 collisions in 2000 short-lived
  objects).
- **Agent selection moves to the SDK's `agent_factory` mode**, which gives each A2A
  context its own agent and lock. Drops the hand-rolled agent cache and the
  deprecation warning.
- **Research sessions are scoped per call** (`{session_id}-{toolUseId}`), so
  workspaces and chart prefixes separate. Stable across a retry of the same call.
- **A small task counter drives `/ping`**, rather than `BedrockAgentCoreApp` — that
  class is a Starlette subclass meant to *be* the application, so adopting it would
  mean replacing the FastAPI app every router is mounted on to gain one line of
  behaviour. `time_of_last_update` is deliberately omitted: a timestamp that
  advances on every ping reads as a continuous status change and stops the idle
  timeout from ever firing.

## Cleanup

- Removed a second `/ping` on the chat router — `main.py` registers `health.router`
  first and FastAPI keeps the first match, so it never served a request and had
  drifted out of spec. A test now pins the single declaration.
- Removed the `LOCAL_RESEARCH_AGENT_URL` fallback, which sent every *other* agent's
  local traffic to the research runtime and returned a research report instead of
  failing.
- Removed the unused `POST /research` endpoint, which bypassed the executor and so
  would have missed all of the isolation above.
- Removed the pre-run clearing of `research_report.md`: with per-research sessions
  there is no stale file, and deleting by session is what destroyed a concurrent
  research's in-progress output.

## Testing

- 634 orchestrator, 61 research agent, 608 frontend — all green; ruff and tsc clean.
- Each of the three commits verified independently.
- Every new test mutation-checked. The frontend guard is verified against the
  *shipped source*, not a copy of the logic: the earlier Canvas-only test passed
  while the component was being handed cleared props, which is how this bug
  survived the first fix.
- Verified in dev against the deployed runtimes: real chat turn, Code and Research
  A2A paths (research through the approval flow), and the `HealthyBusy` lifecycle
  in CloudWatch (`active=1` → `active=0`, 79s research).
- Scenario A/B confirmed by hand in the browser: the plan renders, and a queued
  message is delivered once the research completes.

## Not covered

Research is still **blocking** — the orchestrator consumes the A2A stream to
completion, so a second research cannot start yet. Making it non-blocking is
follow-up work; the isolation and liveness fixes here are its prerequisites, which
is why they are pinned before the change that exposes them. Consequently the
concurrency fixes are backed by tests rather than production observation.

The 15-minute idle timeout itself is unverified: it needs a research long enough to
cross it while detached.