### PR TITLE
feat(research): deliver durable background results

### DIFF
--- a/chatbot-app/agentcore/skills/research-agent/SKILL.md
+++ b/chatbot-app/agentcore/skills/research-agent/SKILL.md
@@ -59,7 +59,10 @@ Structure:
 """)
 ```
 
-The agent streams `research_step` progress events as it works. The final result is a markdown report saved as a research artifact in the canvas.
+The tool returns immediately with a `started` receipt containing `job_id` and
+`artifact_id`. Research continues in the background and emits
+`research_step` progress events. When it finishes, the report is saved as a
+research artifact and delivered back into the conversation automatically.
 
 ## Output
 
@@ -70,6 +73,16 @@ The agent streams `research_step` progress events as it works. The final result 
 ## Guidelines for the orchestrator
 
 - Don't fabricate the plan — use the user's own words and just structure them into objectives/topics/structure. If the user only gave a one-line request, expand it into 2-3 objectives but stay true to intent.
-- One research_agent call per user request. Don't fan out multiple parallel calls.
+- Split a broad request into parallel jobs only when the objectives are
+  independent and each report is useful on its own (for example, separate
+  market, technical, and regulatory analyses). Prefer 2-3 well-scoped jobs over
+  many narrow searches.
+- Keep one job when the sections must share evidence, build on each other, or
+  form one coherent report. Use one call per distinct objective and do not
+  create duplicate jobs for the same objective.
 - If the user asks a follow-up ("add a section on X", "dig deeper into Y"), call `research_agent` again with an updated plan — the agent itself does not have persistent memory across calls.
-- After the tool returns, do NOT restate the whole report in chat. The report is already rendered as an artifact; a 1-2 sentence summary pointing the user to the canvas is enough.
+- Treat a `started` receipt as accepted background work, not a completed report.
+  Tell the user it has started and continue with any other useful work.
+- When the completion is delivered, do NOT restate the whole report in chat.
+  The report is already rendered as an artifact; a 1-2 sentence summary
+  pointing the user to the canvas is enough.

--- a/chatbot-app/agentcore/src/a2a_tools.py
+++ b/chatbot-app/agentcore/src/a2a_tools.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 _cache = {
     'agent_urls': {},
     'agent_cards': {},
-    'http_client': None
 }
 
 
@@ -96,27 +95,16 @@ def get_cached_agent_url(agent_id: str) -> Optional[str]:
 
 
 def get_http_client(region: str = "us-west-2", auth_token: Optional[str] = None):
-    """Create HTTP client with JWT Bearer authentication.
-
-    A new client is created per call when auth_token is provided,
-    since each user session has a different JWT.
-    """
+    """Create an isolated HTTP client for one A2A call."""
+    client_kwargs = {
+        "timeout": httpx.Timeout(DEFAULT_TIMEOUT, connect=30.0),
+        "limits": httpx.Limits(max_keepalive_connections=5, max_connections=10),
+    }
     if auth_token:
-        auth = BearerAuth(
+        client_kwargs["auth"] = BearerAuth(
             auth_token.replace("Bearer ", "") if auth_token.startswith("Bearer ") else auth_token
         )
-        return httpx.AsyncClient(
-            timeout=httpx.Timeout(DEFAULT_TIMEOUT, connect=30.0),
-            limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
-            auth=auth,
-        )
-
-    if not _cache['http_client']:
-        _cache['http_client'] = httpx.AsyncClient(
-            timeout=httpx.Timeout(DEFAULT_TIMEOUT, connect=30.0),
-            limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
-        )
-    return _cache['http_client']
+    return httpx.AsyncClient(**client_kwargs)
 
 
 async def send_a2a_message(
@@ -182,7 +170,7 @@ async def send_a2a_message(
         logger.debug(f"Invoking A2A agent {agent_id}")
 
         httpx_client = get_http_client(region, auth_token=auth_token)
-        owns_httpx_client = bool(auth_token)
+        owns_httpx_client = True
 
         # Add session ID header (must be >= 33 characters)
         if not session_id:
@@ -509,9 +497,9 @@ def create_a2a_tool(agent_id: str):
         agent_tool._skill_name = skill_name
 
     else:
-        # Research Agent (default) - plan parameter
-        # Uses async generator to stream research_step events for real-time status updates
-        async def tool_impl(plan: str, tool_context: ToolContext = None) -> AsyncGenerator[Dict[str, Any], None]:
+        # Research Agent (default) - return immediately while a durable job owns
+        # the A2A stream, persistence, and eventual delivery to the supervisor.
+        async def tool_impl(plan: str, tool_context: ToolContext = None) -> str:
             session_id, user_id, model_id, _auth_token = extract_context(tool_context)
 
             # Scope the research agent's session to this call rather than reusing
@@ -536,74 +524,29 @@ def create_a2a_tool(agent_id: str):
             }
 
 
-            # Track final result for artifact saving
-            final_result_text = None
+            artifact_id = f"research-{tool_use_id}" if tool_use_id else f"research-{uuid4().hex}"
 
-            # Stream events from A2A agent (including research_step events for real-time UI updates)
-            async for event in send_a2a_message(agent_id, plan, research_session_id, region, metadata=metadata, auth_token=_auth_token):
-                # Yield event FIRST to maintain proper stream order
-                yield event
+            from agent.research_jobs import start_research_job
 
-                # After yielding, check if this was the final success event and save artifact
-                # This happens after the event is sent to agent, so won't interfere with interrupt
-                if isinstance(event, dict) and event.get("status") == "success":
-                    content = event.get("content", [])
-                    if content and len(content) > 0:
-                        final_result_text = content[0].get("text", "")
+            def event_factory():
+                return send_a2a_message(
+                    agent_id,
+                    plan,
+                    research_session_id,
+                    region,
+                    metadata=metadata,
+                    auth_token=_auth_token,
+                )
 
-                        # Save research result to agent.state (after yielding final event)
-                        if final_result_text and tool_context and tool_context.agent:
-                            try:
-                                from datetime import datetime, timezone
-
-                                # Extract title from research content (first H1 heading)
-                                import re
-                                title_match = re.search(r'^#\s+(.+)$', final_result_text, re.MULTILINE)
-                                title = title_match.group(1).strip() if title_match else "Research Results"
-
-                                # Generate artifact ID using toolUseId for frontend mapping
-                                tool_use_id = tool_context.tool_use.get('toolUseId', '')
-                                artifact_id = f"research-{tool_use_id}" if tool_use_id else f"research-{session_id}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
-
-                                # Get current artifacts from agent.state
-                                artifacts = tool_context.agent.state.get("artifacts") or {}
-
-                                # Calculate word count
-                                word_count = len(final_result_text.split())
-
-                                # Add new artifact
-                                artifacts[artifact_id] = {
-                                    "id": artifact_id,
-                                    "type": "research",
-                                    "title": title,
-                                    "content": final_result_text,
-                                    "tool_name": "research_agent",
-                                    "metadata": {
-                                        "word_count": word_count,
-                                        "description": f"Research report: {title}"
-                                    },
-                                    "created_at": datetime.now(timezone.utc).isoformat(),
-                                    "updated_at": datetime.now(timezone.utc).isoformat()
-                                }
-
-                                # Save to agent.state
-                                tool_context.agent.state.set("artifacts", artifacts)
-
-                                # Sync agent state to file system / AgentCore Memory
-                                # Try session_manager from invocation_state first (set by ChatAgent)
-                                session_manager = tool_context.invocation_state.get("session_manager")
-
-                                if not session_manager and hasattr(tool_context.agent, 'session_manager'):
-                                    session_manager = tool_context.agent.session_manager
-
-                                if session_manager:
-                                    session_manager.sync_agent(tool_context.agent)
-                                    logger.debug(f"Saved research artifact: {artifact_id}")
-                                else:
-                                    logger.warning("No session_manager found, artifact not persisted")
-
-                            except Exception as e:
-                                logger.error(f"Failed to save research artifact: {e}")
+            receipt = start_research_job(
+                session_id=session_id or research_session_id,
+                user_id=user_id or "anonymous",
+                plan=plan,
+                artifact_id=artifact_id,
+                event_factory=event_factory,
+                model_id=model_id,
+            )
+            return __import__("json").dumps(receipt)
 
         # Set correct function name and docstring BEFORE decorating
         tool_impl.__name__ = correct_name
@@ -619,5 +562,4 @@ def create_a2a_tool(agent_id: str):
 
 # Cleanup on shutdown
 async def cleanup():
-    if _cache['http_client']:
-        await _cache['http_client'].aclose()
+    return None

--- a/chatbot-app/agentcore/src/agent/research_jobs.py
+++ b/chatbot-app/agentcore/src/agent/research_jobs.py
@@ -1,0 +1,378 @@
+"""Durable background jobs for non-blocking research.
+
+Research runs in its own thread and event loop because skill tools may execute
+inside a ThreadPoolExecutor. Job metadata is persisted before the worker starts,
+and the report is persisted before completion is announced or delivered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
+from urllib.parse import quote
+from uuid import uuid4
+
+import boto3
+
+from agent import async_tasks
+from agent.factory.session_manager_factory import get_sessions_dir
+
+logger = logging.getLogger(__name__)
+
+EventFactory = Callable[[], AsyncIterator[Dict[str, Any]]]
+DeliveryHandler = Callable[[Dict[str, Any], Dict[str, Any]], Awaitable[None]]
+
+_delivery_loop: Optional[asyncio.AbstractEventLoop] = None
+_delivery_handler: Optional[DeliveryHandler] = None
+_delivery_lock = threading.Lock()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_component(value: str) -> str:
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", value)
+    return cleaned or "unknown"
+
+
+def _job_sk(session_id: str, job_id: str) -> str:
+    return f"RESEARCH_JOB#{session_id}#{job_id}"
+
+
+def _local_job_dir(session_id: str) -> Path:
+    path = get_sessions_dir() / f"session_{_safe_component(session_id)}" / "research_jobs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+
+
+def _is_cloud_storage() -> bool:
+    return bool(os.environ.get("DYNAMODB_USERS_TABLE"))
+
+
+def _save_job(record: Dict[str, Any]) -> None:
+    if _is_cloud_storage():
+        table_name = os.environ["DYNAMODB_USERS_TABLE"]
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        item = {
+            **record,
+            "userId": record["userId"],
+            "sk": _job_sk(record["sessionId"], record["jobId"]),
+            "recordType": "RESEARCH_JOB",
+        }
+        boto3.resource("dynamodb", region_name=region).Table(table_name).put_item(Item=item)
+        return
+
+    path = _local_job_dir(record["sessionId"]) / f"{_safe_component(record['jobId'])}.json"
+    _atomic_write(path, json.dumps(record, ensure_ascii=False, indent=2))
+
+
+def _save_report(record: Dict[str, Any], report: str) -> Dict[str, str]:
+    if _is_cloud_storage():
+        from workspace.config import get_workspace_bucket
+
+        bucket = get_workspace_bucket()
+        key = (
+            "research-artifacts/"
+            f"{quote(record['userId'], safe='')}/"
+            f"{quote(record['sessionId'], safe='')}/"
+            f"{record['jobId']}.md"
+        )
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        boto3.client("s3", region_name=region).put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=report.encode("utf-8"),
+            ContentType="text/markdown; charset=utf-8",
+        )
+        return {"artifactBucket": bucket, "artifactS3Key": key}
+
+    path = _local_job_dir(record["sessionId"]) / f"{_safe_component(record['jobId'])}.md"
+    _atomic_write(path, report)
+    return {"artifactPath": str(path)}
+
+
+def _load_report(record: Dict[str, Any]) -> str:
+    if record.get("artifactBucket") and record.get("artifactS3Key"):
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        response = boto3.client("s3", region_name=region).get_object(
+            Bucket=record["artifactBucket"],
+            Key=record["artifactS3Key"],
+        )
+        return response["Body"].read().decode("utf-8")
+
+    path = _local_job_dir(record["sessionId"]) / f"{_safe_component(record['jobId'])}.md"
+    return path.read_text(encoding="utf-8")
+
+
+def _list_jobs(user_id: str, session_id: str) -> list[Dict[str, Any]]:
+    if _is_cloud_storage():
+        table_name = os.environ["DYNAMODB_USERS_TABLE"]
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        table = boto3.resource("dynamodb", region_name=region).Table(table_name)
+        items = []
+        start_key = None
+        while True:
+            query_kwargs = {
+                "KeyConditionExpression": "userId = :user_id AND begins_with(sk, :prefix)",
+                "ExpressionAttributeValues": {
+                    ":user_id": user_id,
+                    ":prefix": f"RESEARCH_JOB#{session_id}#",
+                },
+            }
+            if start_key:
+                query_kwargs["ExclusiveStartKey"] = start_key
+            response = table.query(**query_kwargs)
+            items.extend(response.get("Items", []))
+            start_key = response.get("LastEvaluatedKey")
+            if not start_key:
+                return items
+
+    jobs = []
+    for path in _local_job_dir(session_id).glob("*.json"):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if record.get("userId") == user_id and record.get("sessionId") == session_id:
+                jobs.append(record)
+        except (OSError, ValueError):
+            logger.warning("[ResearchJob] Ignoring unreadable job file %s", path)
+    return jobs
+
+
+def _build_artifact(record: Dict[str, Any], report: str) -> Dict[str, Any]:
+    title_match = re.search(r"^#\s+(.+)$", report, re.MULTILINE)
+    title = title_match.group(1).strip() if title_match else "Research Results"
+    timestamp = record.get("completedAt") or _now()
+    return {
+        "id": record["artifactId"],
+        "type": "research",
+        "title": title,
+        "content": report,
+        "tool_name": "research_agent",
+        "metadata": {
+            "word_count": len(report.split()),
+            "description": f"Research report: {title}",
+            "job_id": record["jobId"],
+        },
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+
+
+def load_pending_results(user_id: str, session_id: str) -> list[Dict[str, Any]]:
+    """Load reports that are durable but were not delivered to the agent."""
+    pending = []
+    try:
+        for record in _list_jobs(user_id, session_id):
+            status = record.get("status")
+            if status not in ("completed", "delivering"):
+                continue
+            try:
+                updated_at = datetime.fromisoformat(record["updatedAt"])
+                stale = (datetime.now(timezone.utc) - updated_at).total_seconds() >= 10
+            except (KeyError, TypeError, ValueError):
+                stale = True
+            # A live worker briefly writes completed before switching to
+            # delivering. Only recover immediately after an explicit delivery
+            # failure; otherwise wait for the lease to become stale.
+            if not record.get("deliveryError") and not stale:
+                continue
+            report = _load_report(record)
+            pending.append({
+                "record": record,
+                "artifact": _build_artifact(record, report),
+            })
+    except Exception:
+        logger.exception(
+            "[ResearchJob] Failed to load pending results for %s",
+            session_id,
+        )
+    return pending
+
+
+def mark_delivered(record: Dict[str, Any]) -> None:
+    record.update(status="delivered", deliveredAt=_now(), updatedAt=_now())
+    record.pop("deliveryError", None)
+    _save_job(record)
+
+
+def register_delivery_handler(
+    loop: asyncio.AbstractEventLoop,
+    handler: DeliveryHandler,
+) -> None:
+    """Register the main FastAPI loop used for safe agent continuations."""
+    global _delivery_loop, _delivery_handler
+    with _delivery_lock:
+        _delivery_loop = loop
+        _delivery_handler = handler
+
+
+def clear_delivery_handler() -> None:
+    global _delivery_loop, _delivery_handler
+    with _delivery_lock:
+        _delivery_loop = None
+        _delivery_handler = None
+
+
+async def _deliver(record: Dict[str, Any], artifact: Dict[str, Any]) -> None:
+    with _delivery_lock:
+        loop = _delivery_loop
+        handler = _delivery_handler
+    if not loop or not handler or loop.is_closed():
+        raise RuntimeError("Research delivery handler is not available")
+
+    future = asyncio.run_coroutine_threadsafe(handler(dict(record), artifact), loop)
+    await asyncio.wrap_future(future)
+
+
+def _publish_progress(record: Dict[str, Any], event: Dict[str, Any]) -> None:
+    from streaming import skill_event_bus
+
+    enriched = {
+        **event,
+        "jobId": record["jobId"],
+        "artifactId": record["artifactId"],
+    }
+    queue = skill_event_bus.get_queue(record["sessionId"])
+    if queue is not None:
+        queue.put_nowait(enriched)
+
+
+async def _run_job(record: Dict[str, Any], event_factory: EventFactory) -> None:
+    task_id = async_tasks.begin(
+        "research",
+        {"job_id": record["jobId"], "session_id": record["sessionId"]},
+    )
+    try:
+        record.update(status="running", startedAt=_now(), updatedAt=_now())
+        _save_job(record)
+
+        report = ""
+        error = ""
+        async for event in event_factory():
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") in ("research_step", "research_progress"):
+                record["progress"] = {
+                    "stepNumber": event.get("stepNumber", 0),
+                    "content": event.get("content", ""),
+                }
+                record["updatedAt"] = _now()
+                _save_job(record)
+                _publish_progress(record, event)
+
+            status = event.get("status")
+            if status in ("success", "error"):
+                content = event.get("content") or []
+                text = content[0].get("text", "") if content and isinstance(content[0], dict) else ""
+                if status == "success":
+                    report = text
+                else:
+                    error = text or "Research agent failed"
+
+        if error or not report:
+            raise RuntimeError(error or "Research agent returned an empty report")
+
+        completed_at = _now()
+        record.update(
+            status="completed",
+            completedAt=completed_at,
+            updatedAt=completed_at,
+        )
+        record.update(_save_report(record, report))
+        artifact = _build_artifact(record, report)
+        record["artifact"] = {key: value for key, value in artifact.items() if key != "content"}
+        _save_job(record)
+
+        try:
+            record.update(status="delivering", updatedAt=_now())
+            _save_job(record)
+            await _deliver(record, artifact)
+        except Exception as exc:
+            record.update(
+                status="completed",
+                deliveryError=str(exc),
+                updatedAt=_now(),
+            )
+            _save_job(record)
+            logger.exception("[ResearchJob] Delivery failed for %s", record["jobId"])
+            return
+
+        record.update(
+            status="delivered",
+            deliveredAt=_now(),
+            updatedAt=_now(),
+        )
+        record.pop("deliveryError", None)
+        _save_job(record)
+    except Exception as exc:
+        record.update(status="error", error=str(exc), updatedAt=_now())
+        try:
+            _save_job(record)
+        except Exception:
+            logger.exception("[ResearchJob] Failed to persist terminal error")
+        logger.exception("[ResearchJob] Job %s failed", record["jobId"])
+    finally:
+        async_tasks.end(task_id)
+
+
+def start_research_job(
+    *,
+    session_id: str,
+    user_id: str,
+    plan: str,
+    artifact_id: str,
+    event_factory: EventFactory,
+    model_id: Optional[str] = None,
+    request_type: str = "skill",
+) -> Dict[str, Any]:
+    """Persist and start one research job, returning its public start receipt."""
+    job_id = uuid4().hex
+    created_at = _now()
+    record: Dict[str, Any] = {
+        "jobId": job_id,
+        "sessionId": session_id,
+        "userId": user_id,
+        "artifactId": artifact_id,
+        "plan": plan,
+        "status": "queued",
+        "createdAt": created_at,
+        "updatedAt": created_at,
+        "modelId": model_id or "",
+        "requestType": request_type,
+    }
+    _save_job(record)
+
+    thread = threading.Thread(
+        target=lambda: asyncio.run(_run_job(record, event_factory)),
+        name=f"research-{job_id[:8]}",
+        daemon=True,
+    )
+    thread.start()
+    return {
+        "status": "started",
+        "job_id": job_id,
+        "artifact_id": artifact_id,
+    }

--- a/chatbot-app/agentcore/src/agents/chat_agent.py
+++ b/chatbot-app/agentcore/src/agents/chat_agent.py
@@ -11,7 +11,7 @@ from strands import Agent
 from strands.tools.executors import SequentialToolExecutor
 from agents.base import BaseAgent
 from agents.model_factory import build_model
-from agent.hooks import ResearchApprovalHook, EmailApprovalHook, GitHubApprovalHook
+from agent.hooks import EmailApprovalHook, GitHubApprovalHook
 from agent.config.prompt_builder import (
     build_text_system_prompt,
     system_prompt_to_string,
@@ -127,11 +127,6 @@ class ChatAgent(BaseAgent):
 
             # Create hooks
             hooks = []
-
-            # Add research approval hook (always enabled)
-            research_approval_hook = ResearchApprovalHook(app_name="chatbot")
-            hooks.append(research_approval_hook)
-            logger.debug("Research approval hook enabled (BeforeToolCallEvent)")
 
             # Add email approval hook for bulk email operations
             email_approval_hook = EmailApprovalHook(app_name="chatbot")

--- a/chatbot-app/agentcore/src/agents/skill_chat_agent.py
+++ b/chatbot-app/agentcore/src/agents/skill_chat_agent.py
@@ -180,11 +180,6 @@ class SkillChatAgent(ChatAgent):
 
         self.tools = [skill_dispatcher, skill_executor] + non_skill_tools
 
-        _SEQUENTIAL_SKILLS = {'web-search'}
-        if _SEQUENTIAL_SKILLS & set(registry.skill_names):
-            self._force_sequential = True
-            logger.info(f"[SkillChatAgent] SequentialToolExecutor forced — skills require it: {_SEQUENTIAL_SKILLS & set(registry.skill_names)}")
-
         super().create_agent()
 
         logger.info(

--- a/chatbot-app/agentcore/src/main.py
+++ b/chatbot-app/agentcore/src/main.py
@@ -21,6 +21,7 @@ from fastapi import FastAPI  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 import logging  # noqa: E402
+import asyncio  # noqa: E402
 
 # Set up logging
 logging.basicConfig(
@@ -72,9 +73,15 @@ async def lifespan(app: FastAPI):
     os.makedirs(sessions_dir, exist_ok=True)
     logger.info("Sessions directory ready")
 
+    from agent.research_jobs import register_delivery_handler, clear_delivery_handler
+    from routers.chat import deliver_research_job
+
+    register_delivery_handler(asyncio.get_running_loop(), deliver_research_job)
+
     yield  # Application is running
 
     # Shutdown
+    clear_delivery_handler()
     logger.info("=== Agent Core Service Shutting Down ===")
     # TODO: Cleanup agent pool, MCP clients, etc.
 

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 registry = ExecutionRegistry()
 
+_BACKGROUND_RESEARCH_TAG = "background-research-result"
 
 router = APIRouter(tags=["chat"])
 
@@ -388,6 +389,32 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
         f"disabled_skills={disabled_skills}"
     )
 
+    # Recover reports that were durably completed but whose idle continuation
+    # failed (for example because the process restarted). The next foreground
+    # turn becomes the retry boundary.
+    from agent.research_jobs import load_pending_results
+    pending_research = load_pending_results(user_id, session_id)
+    if pending_research:
+        reports = "\n\n".join(
+            (
+                f"<completed-background-research artifact_id=\"{item['artifact']['id']}\">\n"
+                f"{item['artifact']['content']}\n"
+                "</completed-background-research>"
+            )
+            for item in pending_research
+        )
+        recovery_prompt = (
+            "Background research completed before this turn but was not yet "
+            "delivered. Use the reports below when answering the user. Do not "
+            "start duplicate research jobs.\n\n"
+            f"{reports}"
+        )
+        system_prompt = (
+            f"{system_prompt}\n\n{recovery_prompt}"
+            if system_prompt
+            else recovery_prompt
+        )
+
     try:
         agent = create_agent(
             request_type=request_type,
@@ -403,6 +430,14 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
             allow_user_federation=allow_user_federation,
             concise_mode=concise_mode,
         )
+
+        if pending_research:
+            recovered_artifacts = dict(agent.agent.state.get("artifacts") or {})
+            for item in pending_research:
+                artifact = item["artifact"]
+                recovered_artifacts[artifact["id"]] = artifact
+            agent.agent.state.set("artifacts", recovered_artifacts)
+            agent.session_manager.sync_agent(agent.agent)
 
         agui_processor = AGUIStreamEventProcessor(thread_id=thread_id, run_id=run_id)
 
@@ -474,6 +509,17 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
                 async for sse_chunk in stream:
                     event_type = _extract_event_type(sse_chunk)
                     execution.append_event(sse_chunk, event_type)
+
+                if pending_research:
+                    from agent.research_jobs import mark_delivered
+                    for item in pending_research:
+                        try:
+                            mark_delivered(item["record"])
+                        except Exception:
+                            logger.exception(
+                                "[ResearchDelivery] Failed to mark recovered job %s delivered",
+                                item["record"]["jobId"],
+                            )
             except Exception as e:
                 logger.error(f"[Execution] AG-UI agent error for {execution.execution_id}: {e}", exc_info=True)
                 error_event = f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
@@ -512,6 +558,108 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
             status_code=500,
             detail="Agent processing failed. Please check logs for details."
         )
+
+
+async def deliver_research_job(record: dict, artifact: dict) -> None:
+    """Persist a completed report and wake the supervisor at a safe boundary."""
+    session_id = record["sessionId"]
+    user_id = record["userId"]
+    run_id = f"research-delivery-{record['jobId']}"
+
+    while True:
+        execution = await registry.create_execution(
+            session_id,
+            user_id,
+            run_id,
+            supersede_running=False,
+        )
+        if execution is None:
+            await asyncio.sleep(0.25)
+            continue
+
+        async def run_continuation():
+            agent = None
+            task_id = async_tasks.begin(
+                "research_delivery",
+                {"execution_id": execution.execution_id, "job_id": record["jobId"]},
+            )
+            try:
+                agent = create_agent(
+                    request_type=record.get("requestType") or "skill",
+                    session_id=session_id,
+                    user_id=user_id,
+                    model_id=record.get("modelId") or None,
+                )
+
+                artifacts = dict(agent.agent.state.get("artifacts") or {})
+                artifacts[artifact["id"]] = artifact
+                agent.agent.state.set("artifacts", artifacts)
+                # Delivery is not successful unless the canonical agent state is
+                # durable. Let sync failures propagate so the job remains ready
+                # for retry instead of being falsely marked delivered.
+                agent.session_manager.sync_agent(agent.agent)
+
+                report = artifact.get("content", "")
+                hidden_message = (
+                    f"<{_BACKGROUND_RESEARCH_TAG} "
+                    f"job_id=\"{record['jobId']}\" artifact_id=\"{artifact['id']}\">\n"
+                    "Background research requested earlier has completed. "
+                    "The full report is now stored as an artifact. Incorporate "
+                    "the result into the ongoing conversation and tell the user "
+                    "the report is ready. Do not start another research job.\n\n"
+                    f"{report}\n"
+                    f"</{_BACKGROUND_RESEARCH_TAG}>"
+                )
+                processor = AGUIStreamEventProcessor(
+                    thread_id=session_id,
+                    run_id=run_id,
+                )
+                invocation_state = {
+                    "session_id": session_id,
+                    "user_id": user_id,
+                    "run_id": run_id,
+                    "model_id": agent.model_id,
+                    "session_manager": agent.session_manager,
+                    "background_research_job_id": record["jobId"],
+                }
+                stream = processor.process_stream(
+                    agent.agent,
+                    hidden_message,
+                    session_id=session_id,
+                    invocation_state=invocation_state,
+                    elicitation_bridge=getattr(agent, "elicitation_bridge", None),
+                )
+                async for sse_chunk in stream:
+                    execution.append_event(
+                        sse_chunk,
+                        _extract_event_type(sse_chunk),
+                    )
+                execution.status = ExecutionStatus.COMPLETED
+            except asyncio.CancelledError:
+                execution.status = ExecutionStatus.STOPPED
+                raise
+            except Exception:
+                execution.status = ExecutionStatus.ERROR
+                raise
+            finally:
+                async_tasks.end(task_id)
+                if agent:
+                    agent.close()
+                execution.completed_at = time.time()
+                execution._new_event.set()
+
+        execution.task = asyncio.create_task(run_continuation())
+        try:
+            await execution.task
+            return
+        except asyncio.CancelledError:
+            # A real user turn superseded this background continuation. Wait for
+            # the next safe boundary and retry the idempotent artifact delivery.
+            logger.info(
+                "[ResearchDelivery] User turn superseded job %s; retrying",
+                record["jobId"],
+            )
+            await asyncio.sleep(0)
 
 
 _cleanup_task: Optional[asyncio.Task] = None

--- a/chatbot-app/agentcore/src/streaming/execution_registry.py
+++ b/chatbot-app/agentcore/src/streaming/execution_registry.py
@@ -107,12 +107,21 @@ class ExecutionRegistry:
         """Reset singleton (for testing)."""
         cls._instance = None
 
-    async def create_execution(self, session_id: str, user_id: str, run_id: str) -> Execution:
+    async def create_execution(
+        self,
+        session_id: str,
+        user_id: str,
+        run_id: str,
+        *,
+        supersede_running: bool = True,
+    ) -> Optional[Execution]:
         async with self._lock:
             latest_id = self._session_latest.get(session_id)
             if latest_id:
                 latest = self._executions.get(latest_id)
                 if latest and latest.status == ExecutionStatus.RUNNING:
+                    if not supersede_running:
+                        return None
                     # Force-complete the stale execution (stop was already requested)
                     logger.warning(
                         f"[ExecutionRegistry] Superseding stale execution {latest_id} "

--- a/chatbot-app/agentcore/tests/unit/test_a2a_research_session.py
+++ b/chatbot-app/agentcore/tests/unit/test_a2a_research_session.py
@@ -7,6 +7,7 @@ research_report.md. See the research agent's tests/test_concurrent_research.py
 for the other half of this.
 """
 import sys
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,6 +43,25 @@ def research_tool(monkeypatch):
 
     monkeypatch.setattr(a2a_tools, "send_a2a_message", fake_send)
 
+    def fake_start_research_job(**kwargs):
+        async def consume():
+            async for _ in kwargs["event_factory"]():
+                pass
+
+        asyncio.get_running_loop().create_task(consume())
+        return {
+            "status": "started",
+            "job_id": "job-id",
+            "artifact_id": kwargs["artifact_id"],
+        }
+
+    import agent.research_jobs
+    monkeypatch.setattr(
+        agent.research_jobs,
+        "start_research_job",
+        fake_start_research_job,
+    )
+
     tool = a2a_tools.create_a2a_tool("agentcore_research-agent")
     assert tool is not None
     return tool._tool_func, sent
@@ -62,7 +82,11 @@ def make_tool_context(tool_use_id, session_id="chat-session-1"):
 
 
 async def drain(agen):
-    return [event async for event in agen]
+    if hasattr(agen, "__aiter__"):
+        return [event async for event in agen]
+    result = await agen
+    await asyncio.sleep(0)
+    return [result]
 
 
 class TestResearchSessionScoping:

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -116,6 +116,24 @@ class TestExecutionRegistry:
         assert latest is execution
 
     @pytest.mark.asyncio
+    async def test_background_execution_does_not_supersede_busy_session(self):
+        from streaming.execution_registry import ExecutionRegistry, ExecutionStatus
+        ExecutionRegistry.reset()
+        registry = ExecutionRegistry()
+        foreground = await registry.create_execution("sess-busy", "user1", "run1")
+
+        background = await registry.create_execution(
+            "sess-busy",
+            "user1",
+            "background",
+            supersede_running=False,
+        )
+
+        assert background is None
+        assert foreground.status == ExecutionStatus.RUNNING
+        assert registry.get_latest_execution("sess-busy") is foreground
+
+    @pytest.mark.asyncio
     async def test_append_and_get_events(self):
         """Test appending events and cursor-based retrieval."""
         from streaming.execution_registry import ExecutionRegistry

--- a/chatbot-app/agentcore/tests/unit/test_research_jobs.py
+++ b/chatbot-app/agentcore/tests/unit/test_research_jobs.py
@@ -1,0 +1,159 @@
+import asyncio
+from copy import deepcopy
+
+import pytest
+
+from agent import research_jobs
+
+
+@pytest.fixture(autouse=True)
+def clear_handler():
+    research_jobs.clear_delivery_handler()
+    yield
+    research_jobs.clear_delivery_handler()
+
+
+@pytest.mark.asyncio
+async def test_report_is_durable_before_delivery(monkeypatch):
+    writes = []
+    deliveries = []
+
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_job",
+        lambda record: writes.append(("job", deepcopy(record))),
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_report",
+        lambda record, report: writes.append(("report", report)) or {
+            "artifactPath": "/tmp/report.md",
+        },
+    )
+    monkeypatch.setattr(
+        research_jobs.async_tasks,
+        "begin",
+        lambda *args, **kwargs: 1,
+    )
+    monkeypatch.setattr(research_jobs.async_tasks, "end", lambda task_id: True)
+
+    async def deliver(record, artifact):
+        deliveries.append((deepcopy(record), deepcopy(artifact)))
+
+    monkeypatch.setattr(research_jobs, "_deliver", deliver)
+
+    async def events():
+        yield {"type": "research_step", "stepNumber": 1, "content": "Searching"}
+        yield {"status": "success", "content": [{"text": "# Report\n\nDone."}]}
+
+    record = {
+        "jobId": "a" * 32,
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "artifactId": "research-tool-1",
+        "plan": "plan",
+        "status": "queued",
+        "createdAt": "now",
+        "updatedAt": "now",
+    }
+    await research_jobs._run_job(record, events)
+
+    report_index = next(i for i, item in enumerate(writes) if item[0] == "report")
+    completed_index = next(
+        i for i, item in enumerate(writes)
+        if item[0] == "job" and item[1]["status"] == "completed"
+    )
+    assert report_index < completed_index
+    assert deliveries[0][1]["id"] == "research-tool-1"
+    assert writes[-1][1]["status"] == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_keeps_completed_job_retryable(monkeypatch):
+    writes = []
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_job",
+        lambda record: writes.append(deepcopy(record)),
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_report",
+        lambda record, report: {"artifactPath": "/tmp/report.md"},
+    )
+    monkeypatch.setattr(research_jobs.async_tasks, "begin", lambda *args, **kwargs: 1)
+    monkeypatch.setattr(research_jobs.async_tasks, "end", lambda task_id: True)
+
+    async def fail_delivery(record, artifact):
+        raise RuntimeError("delivery unavailable")
+
+    monkeypatch.setattr(research_jobs, "_deliver", fail_delivery)
+
+    async def events():
+        yield {"status": "success", "content": [{"text": "# Report"}]}
+
+    record = {
+        "jobId": "b" * 32,
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "artifactId": "research-tool-2",
+        "plan": "plan",
+        "status": "queued",
+        "createdAt": "now",
+        "updatedAt": "now",
+    }
+    await research_jobs._run_job(record, events)
+
+    assert writes[-1]["status"] == "completed"
+    assert writes[-1]["deliveryError"] == "delivery unavailable"
+
+
+def test_start_returns_without_running_worker_inline(monkeypatch):
+    saved = []
+    started = []
+
+    class FakeThread:
+        def __init__(self, *, target, name, daemon):
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            started.append(self)
+
+    monkeypatch.setattr(research_jobs, "_save_job", lambda record: saved.append(record))
+    monkeypatch.setattr(research_jobs.threading, "Thread", FakeThread)
+
+    async def events():
+        yield {"status": "success", "content": [{"text": "# Report"}]}
+
+    receipt = research_jobs.start_research_job(
+        session_id="session-1",
+        user_id="user-1",
+        plan="plan",
+        artifact_id="research-tool-3",
+        event_factory=events,
+    )
+
+    assert receipt["status"] == "started"
+    assert receipt["artifact_id"] == "research-tool-3"
+    assert saved[0]["status"] == "queued"
+    assert len(started) == 1
+    assert started[0].daemon is True
+
+
+@pytest.mark.asyncio
+async def test_delivery_handler_runs_on_registered_loop(monkeypatch):
+    observed = []
+
+    async def handler(record, artifact):
+        observed.append((record["jobId"], artifact["id"]))
+
+    loop = asyncio.get_running_loop()
+    research_jobs.register_delivery_handler(loop, handler)
+    await research_jobs._deliver(
+        {"jobId": "job-1"},
+        {"id": "artifact-1"},
+    )
+
+    assert observed == [("job-1", "artifact-1")]

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -25,6 +25,7 @@ const mockUseChat: {
   showProgressPanel: boolean
   toggleProgressPanel: ReturnType<typeof vi.fn>
   sendMessage: ReturnType<typeof vi.fn>
+  replayExecution: ReturnType<typeof vi.fn>
   stopGeneration: ReturnType<typeof vi.fn>
   queuedMessages: any[]
   queueHoldReason: string | null
@@ -54,6 +55,7 @@ const mockUseChat: {
   showProgressPanel: false,
   toggleProgressPanel: vi.fn(),
   sendMessage: vi.fn(),
+  replayExecution: vi.fn().mockResolvedValue(true),
   stopGeneration: vi.fn(),
   queuedMessages: [],
   queueHoldReason: null,
@@ -321,14 +323,14 @@ describe('ChatInterface', () => {
       expect(screen.queryByTestId('interrupt-modal')).not.toBeInTheDocument()
     })
 
-    it('should not show interrupt modal for research-approval interrupts', () => {
+    it('should allow a legacy research approval interrupt to be resolved', () => {
       mockUseChat.currentInterrupt = {
         interrupts: [{ id: 'int1', name: 'chatbot-research-approval', reason: {} }]
       }
 
       render(<ChatInterface />)
 
-      expect(screen.queryByTestId('interrupt-modal')).not.toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-modal')).toBeInTheDocument()
     })
   })
 

--- a/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
+++ b/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
@@ -1,181 +1,76 @@
 /**
- * A past research must not be "completed" again after a page reload.
- *
- * researchData is derived from message history, so every research a session has
- * ever run reappears as status 'complete' on each mount. The completion handler
- * dedupes with a useRef Set, which starts empty on every mount — so after a
- * reload the first render replays old completions. Each replay resets the
- * research state and opens that research's artifact, which tears down the
- * approval card for the research the user is starting right now.
- *
- * That is why the bug only showed up with artifacts already present, and only
- * after a reload: without a reload the Set still holds the earlier ids.
- *
- * Canvas's own priority rule is covered in CanvasResearchApproval.test.tsx.
- * This covers the guard that stops the state from being torn down before Canvas
- * ever gets the chance to apply it.
+ * Research completion is now driven by durable jobs rather than replaying tool
+ * results from message history. These source-level contract tests guard the
+ * dedupe that prevents a polling tick or page reload from reopening an artifact.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-interface ResearchExecution {
-  status: string
-  result: string
-}
-
-/**
- * The completion loop from ChatInterface, with the surrounding component state
- * passed in. Kept as a function of its inputs so the ordering that produced the
- * bug (interrupt arrives, then history replays) can be driven directly.
- */
-function runCompletionPass(
-  researchData: Map<string, ResearchExecution>,
-  artifacts: Array<{ id: string }>,
-  processed: Set<string>,
-  researchArtifactId: string | null,
-  handlers: {
-    onComplete: (executionId: string) => void
-    onReset: () => void
-    onOpenArtifact: (id: string) => void
-  },
-) {
-  if (!researchArtifactId) return
-
-  for (const [executionId, data] of researchData) {
-    if (processed.has(executionId)) continue
-
-    // The guard: an artifact for this research already exists, so it finished
-    // before this mount and must not be completed again.
-    if (artifacts.some(a => a.id === `research-${executionId}`)) {
-      processed.add(executionId)
-      continue
-    }
-
-    if (data.status === 'complete' && data.result) {
-      processed.add(executionId)
-      handlers.onComplete(executionId)
-      handlers.onReset()
-      handlers.onOpenArtifact(`research-${executionId}`)
-    }
-  }
-}
-
-/** Reads the shipped component source; vitest runs with the frontend as cwd. */
 async function readChatInterfaceSource(): Promise<string> {
   const { readFileSync } = await import('node:fs')
   const { resolve } = await import('node:path')
   return readFileSync(resolve(process.cwd(), 'src/components/ChatInterface.tsx'), 'utf8')
 }
 
-function setup() {
-  return {
-    onComplete: vi.fn(),
-    onReset: vi.fn(),
-    onOpenArtifact: vi.fn(),
-  }
-}
-
-describe('research completion replay after reload', () => {
-  it('does not re-complete a research that already has an artifact', () => {
-    const handlers = setup()
-    const researchData = new Map([
-      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
-    ])
-    const artifacts = [{ id: 'research-exec-old' }]
-
-    // Fresh mount: the dedupe set is empty, as it is after every reload.
-    runCompletionPass(researchData, artifacts, new Set(), 'in-progress', handlers)
-
-    expect(handlers.onReset).not.toHaveBeenCalled()
-    expect(handlers.onOpenArtifact).not.toHaveBeenCalled()
-  })
-
-  // The user-visible failure: the approval card is replaced by the old report.
-  it('leaves a pending approval intact when an old research replays', () => {
-    const handlers = setup()
-    const researchData = new Map([
-      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
-    ])
-    const artifacts = [{ id: 'research-exec-old' }]
-
-    // 'in-progress' is what the interrupt handler sets while awaiting approval.
-    runCompletionPass(researchData, artifacts, new Set(), 'in-progress', handlers)
-
-    expect(handlers.onReset).not.toHaveBeenCalled()
-  })
-
-  it('still completes a research that finished during this mount', () => {
-    const handlers = setup()
-    const researchData = new Map([
-      ['exec-new', { status: 'complete', result: '<research># New</research>' }],
-    ])
-
-    // No artifact yet — the backend saves it, but this pass is what adds it locally.
-    runCompletionPass(researchData, [], new Set(), 'in-progress', handlers)
-
-    expect(handlers.onComplete).toHaveBeenCalledWith('exec-new')
-    expect(handlers.onOpenArtifact).toHaveBeenCalledWith('research-exec-new')
-  })
-
-  it('completes only the new research when an old one is also present', () => {
-    const handlers = setup()
-    const researchData = new Map([
-      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
-      ['exec-new', { status: 'complete', result: '<research># New</research>' }],
-    ])
-    const artifacts = [{ id: 'research-exec-old' }]
-
-    runCompletionPass(researchData, artifacts, new Set(), 'in-progress', handlers)
-
-    expect(handlers.onComplete).toHaveBeenCalledTimes(1)
-    expect(handlers.onComplete).toHaveBeenCalledWith('exec-new')
-    expect(handlers.onOpenArtifact).toHaveBeenCalledWith('research-exec-new')
-  })
-
-  it('marks the replayed research processed so later passes skip it', () => {
-    const handlers = setup()
-    const researchData = new Map([
-      ['exec-old', { status: 'complete', result: '<research># Old</research>' }],
-    ])
-    const artifacts = [{ id: 'research-exec-old' }]
-    const processed = new Set<string>()
-
-    runCompletionPass(researchData, artifacts, processed, 'in-progress', handlers)
-
-    expect(processed.has('exec-old')).toBe(true)
-  })
-
-  // runCompletionPass above mirrors ChatInterface rather than importing it (the
-  // logic lives inside a useEffect in a component with ~40 hooks). That mirror
-  // can drift, so assert the guard is actually present in the shipped source.
-  it('the shipped completion effect guards on an existing artifact', async () => {
+describe('durable research completion replay', () => {
+  it('uses the durable research job hook as the completion source', async () => {
     const source = await readChatInterfaceSource()
 
-    const effect = source.slice(source.indexOf('Clean up when research completes'))
-    const body = effect.slice(0, effect.indexOf('}, ['))
-
-    expect(body).toMatch(/artifacts\.some\(\s*a\s*=>\s*a\.id === `research-\$\{executionId\}`\s*\)/)
-    expect(body).toContain('processedResearchIdsRef.current.add(executionId)')
+    expect(source).toContain('useResearchJobs(')
+    expect(source).toContain("tool.toolName === 'research_agent'")
+    expect(source).toContain('invocationIds.add(tool.id)')
+    expect(source).not.toContain('Clean up when research completes')
   })
 
-  it('the shipped effect re-runs when artifacts change', async () => {
+  it('deduplicates unchanged artifact versions before updating Canvas', async () => {
     const source = await readChatInterfaceSource()
+    const effect = source.slice(
+      source.indexOf('A completed report is readable'),
+      source.indexOf('Background continuations have their own buffered'),
+    )
 
-    const effect = source.slice(source.indexOf('Clean up when research completes'))
-    const deps = effect.slice(effect.indexOf('}, ['), effect.indexOf('])', effect.indexOf('}, [')))
-
-    // Without artifacts in the dependency list the guard reads a stale list and
-    // the replay slips through on the render where it matters.
-    expect(deps).toContain('artifacts')
+    expect(effect).toContain('researchArtifactVersionsRef')
+    expect(effect).toContain(
+      'researchArtifactVersionsRef.current.get(artifact.id) === version',
+    )
+    expect(effect.indexOf('researchArtifactVersionsRef.current.get(artifact.id) === version'))
+      .toBeLessThan(effect.indexOf('addArtifact({'))
   })
 
-  it('does nothing when no research is active', () => {
-    const handlers = setup()
-    const researchData = new Map([
-      ['exec-new', { status: 'complete', result: '<research># New</research>' }],
-    ])
+  it('clears artifact replay state when the session changes', async () => {
+    const source = await readChatInterfaceSource()
+    const reset = source.slice(
+      source.indexOf('reloadedDeliveriesRef.current.clear()'),
+      source.indexOf('}, [sessionId])'),
+    )
 
-    runCompletionPass(researchData, [], new Set(), null, handlers)
+    expect(reset).toContain('researchArtifactVersionsRef.current.clear()')
+  })
 
-    expect(handlers.onComplete).not.toHaveBeenCalled()
+  it('replays the background delivery execution instead of replacing history', async () => {
+    const source = await readChatInterfaceSource()
+    const effect = source.slice(
+      source.indexOf('Background continuations have their own buffered'),
+      source.indexOf('// Keep reloadFromStorage ref'),
+    )
+
+    expect(effect).toContain('research-delivery-${jobId}')
+    expect(effect).toContain('await replayExecution(executionId)')
+    expect(effect).toContain('for (const jobId of unseen)')
+    expect(effect).toContain('queuedMessages.length > 0')
+    expect(effect).toContain("agentStatus !== 'idle'")
+    expect(effect).not.toContain('await loadSession(sessionId)')
+  })
+
+  it('marks the first visible event of each run as a new assistant turn', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/hooks/useStreamEvents.ts'),
+      'utf8',
+    )
+
+    expect(source).toContain('pendingAssistantTurnBoundaryRef.current = true')
+    expect(source).toContain('consumeAssistantTurnBoundary()')
+    expect(source).toContain('startsNewAssistantTurn: true')
   })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
@@ -51,6 +51,7 @@ const apiSendMessage = vi.fn(async (...args: SendArgs) => {
 })
 
 const sendStopSignal = vi.fn().mockResolvedValue(true)
+const apiReplayExecution = vi.fn().mockResolvedValue(true)
 
 vi.mock('@/hooks/useChatAPI', () => ({
   useChatAPI: vi.fn(() => ({
@@ -60,6 +61,7 @@ vi.mock('@/hooks/useChatAPI', () => ({
     summarizeForCompact: vi.fn(),
     listSessionEvents: vi.fn(),
     sendMessage: apiSendMessage,
+    replayExecution: apiReplayExecution,
     cleanup: vi.fn(),
     sendStopSignal,
     loadSession: vi.fn().mockResolvedValue({ preferences: null, messages: [] }),
@@ -122,6 +124,21 @@ describe('useChat message queue wiring', () => {
     await act(async () => { await result.current.sendMessage('first') })
 
     await waitFor(() => expect(sentTexts()).toEqual(['first', 'follow-up']))
+    expect(result.current.queuedMessages).toEqual([])
+  })
+
+  it('flushes a user turn queued while a research delivery renders', async () => {
+    const { result } = await mount()
+
+    act(() => { result.current.enqueueMessage('question during delivery') })
+    await act(async () => {
+      await result.current.replayExecution('session-1:research-delivery-job-1')
+    })
+
+    expect(apiReplayExecution).toHaveBeenCalledWith(
+      'session-1:research-delivery-job-1',
+    )
+    expect(sentTexts()).toEqual(['question during delivery'])
     expect(result.current.queuedMessages).toEqual([])
   })
 

--- a/chatbot-app/frontend/__tests__/hooks/useChat.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/hooks/useChatAPI', () => ({
   useChatAPI: vi.fn(() => ({
     newChat: vi.fn().mockResolvedValue(true),
     sendMessage: vi.fn().mockResolvedValue(undefined),
+    replayExecution: vi.fn().mockResolvedValue(true),
     cleanup: vi.fn(),
     sendStopSignal: vi.fn(),
     loadSession: vi.fn().mockResolvedValue(null)

--- a/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
@@ -48,6 +48,7 @@ function sseResponse(events: Array<Record<string, unknown>>) {
             return { done: false, value: new TextEncoder().encode(payload) }
           },
           cancel: async () => {},
+          releaseLock: () => {},
         }
       },
     },
@@ -65,14 +66,14 @@ const INTERRUPT = {
   },
 }
 
-function setup() {
+function setup(handleStreamEvent = vi.fn()) {
   const stopFetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '' })
   const hook = renderHook(() =>
     useChatAPI({
       backendUrl: 'http://localhost:8000',
       setUIState: vi.fn(),
       setMessages: vi.fn(),
-      handleStreamEvent: vi.fn(),
+      handleStreamEvent,
       resetStreamingState: vi.fn(),
       sessionId: 'session-1',
       setSessionId: vi.fn(),
@@ -80,7 +81,7 @@ function setup() {
       currentTemperature: 0.5,
     } as any),
   )
-  return { hook, stopFetch }
+  return { hook, stopFetch, handleStreamEvent }
 }
 
 /** Runs one turn whose stream ends with the given events. */
@@ -160,5 +161,72 @@ describe('useChatAPI — stopping a turn that parked at an interrupt', () => {
     const { requested } = await tryStop(hook)
 
     expect(requested).toBe(false)
+  })
+})
+
+describe('useChatAPI — background execution replay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionStorage.clear()
+    vi.mocked(sessionStorage.getItem).mockImplementation(key =>
+      key === 'chat-session-id' ? 'session-1' : null,
+    )
+  })
+
+  it('replays a buffered completion with auth through the normal event handler', async () => {
+    let finishCleanup: (() => void) | undefined
+    const cleanup = new Promise<void>(resolve => {
+      finishCleanup = resolve
+    })
+    const handleStreamEvent = vi.fn().mockImplementation(async event => {
+      if (event.type === 'RUN_FINISHED') await cleanup
+    })
+    const { hook } = setup(handleStreamEvent)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const activeSessionId = sessionStorage.getItem('chat-session-id')
+    expect(activeSessionId).toBeTruthy()
+
+    const events = [
+      { type: 'RUN_STARTED', threadId: activeSessionId, runId: 'delivery-1' },
+      { type: 'TEXT_MESSAGE_START', messageId: 'completion-1', role: 'assistant' },
+      { type: 'TEXT_MESSAGE_CONTENT', messageId: 'completion-1', delta: 'Research is ready.' },
+      { type: 'TEXT_MESSAGE_END', messageId: 'completion-1' },
+      { type: 'RUN_FINISHED', threadId: activeSessionId, runId: 'delivery-1' },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse(events))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const executionId = `${activeSessionId}:research-delivery-job-1`
+    let replayed = false
+    let replayPromise: Promise<boolean> | undefined
+    await act(async () => {
+      replayPromise = hook.result.current.replayExecution(executionId)
+      await Promise.resolve()
+    })
+    expect(replayed).toBe(false)
+
+    await act(async () => {
+      finishCleanup?.()
+      replayed = await replayPromise!
+    })
+
+    expect(replayed).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `executionId=${encodeURIComponent(executionId)}`,
+      ),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          Accept: 'text/event-stream',
+        }),
+      }),
+    )
+    expect(handleStreamEvent.mock.calls.map(([event]) => event.type)).toEqual(
+      events.map(event => event.type),
+    )
   })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useMessageQueue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useMessageQueue.test.ts
@@ -169,16 +169,16 @@ describe('useMessageQueue', () => {
     expect(send).toHaveBeenCalledTimes(1)
   })
 
-  it('does not replay a message whose send failed', async () => {
+  it('retains and holds a message whose send failed', async () => {
     const send = vi.fn().mockRejectedValue(new Error('network'))
     const { hook } = setup(send)
     enqueue(hook, 'doomed')
 
-    await act(async () => {
-      await expect(hook.result.current.flushNext(SESSION, CLEAR)).rejects.toThrow('network')
-    })
+    const sent = await act(async () => hook.result.current.flushNext(SESSION, CLEAR))
 
-    expect(hook.result.current.queue).toHaveLength(0)
+    expect(sent).toBe(false)
+    expect(hook.result.current.queue.map(m => m.text)).toEqual(['doomed'])
+    expect(hook.result.current.holdReason).toBe('error')
   })
 
   it('never sends a message into a different session', async () => {

--- a/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
@@ -1,0 +1,137 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useResearchJobs } from '@/hooks/useResearchJobs'
+
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: vi.fn().mockResolvedValue({
+    tokens: {
+      accessToken: {
+        toString: () => 'research-access-token',
+      },
+    },
+  }),
+}))
+
+function response(jobs: unknown[]) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ jobs }),
+  } as Response)
+}
+
+async function flushAsyncWork() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+const runningJob = {
+  jobId: 'job-1',
+  sessionId: 'session-1',
+  userId: 'user-1',
+  artifactId: 'research-tool-1',
+  plan: 'Research',
+  status: 'running',
+  createdAt: '2026-08-06T00:00:00Z',
+  updatedAt: '2026-08-06T00:00:01Z',
+}
+
+const deliveredJob = {
+  ...runningJob,
+  status: 'delivered',
+  updatedAt: '2026-08-06T00:00:02Z',
+  artifact: {
+    id: 'research-tool-1',
+    type: 'research',
+    title: 'Report',
+  },
+}
+
+describe('useResearchJobs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('discovers a job after its tool invocation and hydrates its completion', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response([runningJob]))
+      .mockImplementationOnce(() => response([deliveredJob]))
+      .mockImplementationOnce(() => response([{
+        ...deliveredJob,
+        artifact: {
+          ...deliveredJob.artifact,
+          content: '# Finished report',
+        },
+      }]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ invocationCount }) => useResearchJobs('session-1', invocationCount),
+      { initialProps: { invocationCount: 0 } },
+    )
+
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    hook.rerender({ invocationCount: 1 })
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(hook.result.current.jobs[0]?.status).toBe('running')
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/research/jobs?session_id=session-1',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer research-access-token',
+        }),
+      }),
+    )
+    expect(hook.result.current.jobs[0]?.artifact?.content).toBe('# Finished report')
+    expect(hook.result.current.deliveredJobIds).toEqual(['job-1'])
+  })
+
+  it('keeps polling during invocation discovery when the first lookup is empty', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response([runningJob]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ invocationCount }) => useResearchJobs('session-1', invocationCount),
+      { initialProps: { invocationCount: 0 } },
+    )
+
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    hook.rerender({ invocationCount: 1 })
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(hook.result.current.jobs[0]?.status).toBe('running')
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/chat-message-groups.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/chat-message-groups.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { groupChatMessages } from '@/lib/chat-message-groups'
+import type { Message } from '@/types/chat'
+
+function bot(id: string, startsNewAssistantTurn = false): Message {
+  return {
+    id,
+    text: id,
+    sender: 'bot',
+    timestamp: 'now',
+    startsNewAssistantTurn,
+  }
+}
+
+describe('groupChatMessages', () => {
+  it('keeps consecutive assistant messages in one turn by default', () => {
+    const groups = groupChatMessages([bot('started'), bot('follow-up')])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].messages.map(message => message.id)).toEqual([
+      'started',
+      'follow-up',
+    ])
+  })
+
+  it('starts a separate assistant turn for background delivery', () => {
+    const groups = groupChatMessages([
+      bot('research-started'),
+      bot('research-complete', true),
+    ])
+
+    expect(groups).toHaveLength(2)
+    expect(groups.map(group => group.messages[0].id)).toEqual([
+      'research-started',
+      'research-complete',
+    ])
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/research-jobs.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/research-jobs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  hideBackgroundResearchInputs,
+  parseResearchStartReceipt,
+} from '@/lib/research-start-receipt'
+
+describe('parseResearchStartReceipt', () => {
+  it('accepts a durable background research receipt', () => {
+    expect(parseResearchStartReceipt(JSON.stringify({
+      status: 'started',
+      job_id: 'job-1',
+      artifact_id: 'research-tool-1',
+    }))).toEqual({
+      status: 'started',
+      job_id: 'job-1',
+      artifact_id: 'research-tool-1',
+    })
+  })
+
+  it('ignores tool use before the background job receipt exists', () => {
+    expect(parseResearchStartReceipt(undefined)).toBeNull()
+    expect(parseResearchStartReceipt('legacy report body')).toBeNull()
+  })
+})
+
+describe('hideBackgroundResearchInputs', () => {
+  it('moves the hidden wake-up boundary to the delivery response', () => {
+    const messages = hideBackgroundResearchInputs([
+      { role: 'assistant', content: [{ text: 'Research started.' }] },
+      {
+        role: 'user',
+        content: [{ text: '<background-research-result job_id="job-1">' }],
+      },
+      { role: 'assistant', content: [{ text: 'Research complete.' }] },
+    ])
+
+    expect(messages).toHaveLength(2)
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      startsNewAssistantTurn: true,
+    })
+  })
+})

--- a/chatbot-app/frontend/src/app/api/conversation/history/route.ts
+++ b/chatbot-app/frontend/src/app/api/conversation/history/route.ts
@@ -3,6 +3,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { extractUserFromRequest } from '@/lib/auth-utils'
+import { hideBackgroundResearchInputs } from '@/lib/research-start-receipt'
 
 // Check if running in local development mode
 const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
@@ -318,6 +319,24 @@ export async function GET(request: NextRequest) {
       })
       console.log(`[API] Merged metadata for ${Object.keys(sessionMetadata.messages).length} message(s)`)
     }
+
+    // Synthetic background-research inputs wake the supervisor but are an
+    // internal mailbox protocol, not user-authored chat messages. Preserve
+    // their turn boundary on the generated assistant response.
+    messages = hideBackgroundResearchInputs(messages)
+
+    // Completed reports are independently durable from AgentCore Memory state.
+    // Merge them so a delivery/sync retry never makes a finished report vanish
+    // from history or Canvas.
+    const { listResearchJobs, completedResearchArtifacts } = await import('@/lib/research-jobs')
+    const researchArtifacts = completedResearchArtifacts(
+      await listResearchJobs(userId, sessionId, { includeContent: true }),
+    )
+    const artifactsById = new Map(artifacts.map(item => [item.id, item]))
+    for (const artifact of researchArtifacts) {
+      artifactsById.set(artifact.id, artifact)
+    }
+    artifacts = Array.from(artifactsById.values())
 
     // Return messages with merged toolResults from blobs and metadata
     // Also include session preferences (model, tools) for restoration

--- a/chatbot-app/frontend/src/app/api/research/jobs/route.ts
+++ b/chatbot-app/frontend/src/app/api/research/jobs/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { extractUserFromRequest } from '@/lib/auth-utils'
+import { listResearchJobs } from '@/lib/research-jobs'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionId = request.nextUrl.searchParams.get('session_id')
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Missing session_id parameter' }, { status: 400 })
+    }
+
+    const user = await extractUserFromRequest(request)
+    const includeContent = request.nextUrl.searchParams.get('include_content') === 'true'
+    const jobs = await listResearchJobs(user.userId, sessionId, { includeContent })
+    return NextResponse.json({ jobs })
+  } catch (error) {
+    console.error('[ResearchJobs] Failed to list jobs:', error)
+    return NextResponse.json({ error: 'Failed to list research jobs' }, { status: 500 })
+  }
+}

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -5,7 +5,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from "react"
 import { useChat } from "@/hooks/useChat"
 import { useArtifacts } from "@/hooks/useArtifacts"
 import { useCanvasHandlers } from "@/hooks/useCanvasHandlers"
-import { useAgentExecutions } from "@/hooks/useAgentExecutions"
+import { useResearchJobs } from "@/hooks/useResearchJobs"
 import { ArtifactType } from "@/types/artifact"
 import { ChatMessage } from "@/components/chat/ChatMessage"
 import { AssistantTurn } from "@/components/chat/AssistantTurn"
@@ -17,7 +17,6 @@ import { SwarmProgress } from "@/components/SwarmProgress"
 import { Canvas } from "@/components/canvas"
 import { ChatInputArea } from "@/components/chat/ChatInputArea"
 import { QueuedMessages } from "@/components/chat/QueuedMessages"
-import { useResearch } from "@/hooks/useResearch"
 import { Button } from "@/components/ui/button"
 import { SidebarTrigger, SidebarInset, useSidebar } from "@/components/ui/sidebar"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
@@ -154,6 +153,7 @@ export function ChatInterface() {
     agentStatus,
     currentReasoning,
     sendMessage,
+    replayExecution,
     stopGeneration,
     queuedMessages,
     queueHoldReason,
@@ -206,9 +206,6 @@ export function ChatInterface() {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([])
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
-  // Agent executions (research)
-  const { researchData } = useAgentExecutions(groupedMessages)
-
   // Greeting prompt prefill
   const [prefillMessage, setPrefillMessage] = useState<string | undefined>(undefined)
 
@@ -221,7 +218,6 @@ export function ChatInterface() {
     openCanvas: openCanvasBase,
     openArtifact: openArtifactBase,
     closeCanvas: closeCanvasBase,
-    setSelectedArtifactId,
     addArtifact,
     removeArtifact,
     updateArtifact,
@@ -229,6 +225,76 @@ export function ChatInterface() {
     reloadFromStorage,
     justUpdated: artifactJustUpdated,
   } = useArtifacts(sessionId)
+
+  const researchInvocationCount = useMemo(() => {
+    const invocationIds = new Set<string>()
+    for (const group of groupedMessages) {
+      for (const message of group.messages) {
+        for (const tool of message.toolExecutions || []) {
+          if (tool.toolName === 'research_agent') invocationIds.add(tool.id)
+        }
+      }
+    }
+    return invocationIds.size
+  }, [groupedMessages])
+  const { jobs: researchJobs, deliveredJobIds } = useResearchJobs(
+    sessionId,
+    researchInvocationCount,
+  )
+  const reloadedDeliveriesRef = useRef<Set<string>>(new Set())
+  const researchArtifactVersionsRef = useRef<Map<string, string>>(new Map())
+
+  useEffect(() => {
+    reloadedDeliveriesRef.current.clear()
+    researchArtifactVersionsRef.current.clear()
+  }, [sessionId])
+
+  // A completed report is readable from the durable job store even before the
+  // supervisor continuation finishes. Add it to Canvas as soon as it appears.
+  useEffect(() => {
+    for (const job of researchJobs) {
+      const artifact = job.artifact
+      if (!artifact?.content) continue
+      const version = `${job.updatedAt}:${artifact.content.length}`
+      if (researchArtifactVersionsRef.current.get(artifact.id) === version) continue
+      researchArtifactVersionsRef.current.set(artifact.id, version)
+      addArtifact({
+        id: artifact.id,
+        type: artifact.type,
+        title: artifact.title,
+        content: artifact.content,
+        description: artifact.metadata?.description || '',
+        toolName: artifact.tool_name,
+        timestamp: artifact.created_at || job.completedAt || job.updatedAt,
+        sessionId,
+        metadata: artifact.metadata,
+      })
+    }
+  }, [researchJobs, addArtifact, sessionId])
+
+  // Background continuations have their own buffered AG-UI execution. Replay
+  // each one through the normal stream handler so its assistant turn appears
+  // live, while the durable job continues to own the tool card and artifact.
+  useEffect(() => {
+    const userTurnWaiting = queuedMessages.length > 0 && queueHoldReason === null
+    if (agentStatus !== 'idle' || userTurnWaiting || deliveredJobIds.length === 0) return
+    const unseen = deliveredJobIds.filter(id => !reloadedDeliveriesRef.current.has(id))
+    if (unseen.length === 0) return
+    unseen.forEach(id => reloadedDeliveriesRef.current.add(id))
+    void (async () => {
+      for (const jobId of unseen) {
+        const executionId = `${sessionId}:research-delivery-${jobId}`
+        await replayExecution(executionId)
+      }
+    })()
+  }, [
+    agentStatus,
+    deliveredJobIds,
+    queueHoldReason,
+    queuedMessages.length,
+    replayExecution,
+    sessionId,
+  ])
 
   // Keep reloadFromStorage ref in sync for the onSessionLoaded callback
   useEffect(() => {
@@ -254,9 +320,6 @@ export function ChatInterface() {
     })
   }, [artifacts, refreshArtifacts, addArtifact, updateArtifact, openArtifact, setArtifactMethods])
 
-  // Research artifact ID tracking
-  const [researchArtifactId, setResearchArtifactId] = useState<string | null>(null)
-
   // Browser artifact ID tracking (for Live View in Canvas)
   const [browserArtifactId, setBrowserArtifactId] = useState<string | null>(null)
 
@@ -272,12 +335,6 @@ export function ChatInterface() {
   useEffect(() => {
     setBrowserArtifactIdRef.current = setBrowserArtifactId
   }, [setBrowserArtifactId])
-
-  // Research management
-  const research = useResearch({
-    sessionId,
-    respondToInterrupt,
-  })
 
   // Wrapper functions to ensure mutual exclusivity between left sidebar and canvas
   const toggleCanvas = useCallback(() => {
@@ -299,30 +356,6 @@ export function ChatInterface() {
     setOpenMobile(false)
     openCanvasBase()
   }, [openCanvasBase, setOpen, setOpenMobile])
-
-  // Research Canvas callbacks - use refs for stable references
-  const researchRef = useRef(research)
-  researchRef.current = research
-
-  const handleResearchConfirmPlan = useCallback((approved: boolean) => {
-    researchRef.current.confirmPlanResponse(approved)
-    if (!approved) {
-      researchRef.current.reset()
-      setResearchArtifactId(null)
-      processedInterruptRef.current = null
-      closeCanvas()
-    }
-  }, [closeCanvas])
-
-  const handleResearchCancel = useCallback(() => {
-    if (researchRef.current.showPlanConfirm) {
-      researchRef.current.confirmPlanResponse(false)
-    }
-    researchRef.current.reset()
-    setResearchArtifactId(null)
-    processedInterruptRef.current = null
-    closeCanvas()
-  }, [closeCanvas])
 
   // Remove a browser artifact from both state and sessionStorage
   const removeBrowserArtifact = useCallback((artifactId: string) => {
@@ -460,190 +493,6 @@ export function ChatInterface() {
   })
 
 
-  // Reset research state when a new research starts
-  // This allows the second research in the same session to show the HITL modal
-  const prevAgentStatusRef = useRef<string | null>(null)
-  useEffect(() => {
-    // When transitioning to 'researching' from another status, reset the research artifact
-    if (agentStatus === 'researching' && prevAgentStatusRef.current !== 'researching') {
-      if (researchArtifactId && researchArtifactId !== 'in-progress') {
-        // Previous research was completed, reset for new research
-        setResearchArtifactId(null)
-        researchRef.current.reset()
-      }
-    }
-    prevAgentStatusRef.current = agentStatus
-  }, [agentStatus, researchArtifactId])
-
-  // Connect research_progress events to useResearch hook
-  useEffect(() => {
-    if (researchProgress && researchArtifactId) {
-      researchRef.current.handleProgressEvent(researchProgress)
-    }
-  }, [researchProgress, researchArtifactId])
-
-  // Track processed interrupt IDs to prevent duplicate handling
-  const processedInterruptRef = useRef<string | null>(null)
-
-  // Auto-open Canvas when research interrupt is received
-  useEffect(() => {
-    if (currentInterrupt && currentInterrupt.interrupts.length > 0) {
-      const interrupt = currentInterrupt.interrupts[0]
-
-      if (interrupt.name === "chatbot-research-approval" &&
-          processedInterruptRef.current !== interrupt.id) {
-
-        // Mark as processed
-        processedInterruptRef.current = interrupt.id
-
-        // Reset research state for new interrupt (clears any previous run)
-        setResearchArtifactId('in-progress')
-
-        // Deselect any currently viewed artifact so ResearchArtifact renders
-        setSelectedArtifactId(null)
-
-        // Open canvas and pass interrupt to research hook
-        openCanvas()
-        researchRef.current.handleInterrupt(interrupt)
-      }
-    } else {
-      // Clear processed ref when no interrupt
-      processedInterruptRef.current = null
-    }
-  }, [currentInterrupt, researchArtifactId, openCanvas])
-
-  // Track which research executions we've already processed
-  const processedResearchIdsRef = useRef<Set<string>>(new Set())
-
-  // Extract clean research content using <research> XML tags (same as ResearchModal)
-  const extractResearchContent = useCallback((result: string): { title: string; content: string } => {
-    if (!result) return { title: 'Research Results', content: '' }
-
-    // Helper function to unescape JSON-escaped strings
-    const unescapeJsonString = (str: string): string => {
-      if (str.includes('\\n') || str.includes('\\u') || str.includes('\\t')) {
-        try {
-          const escaped = str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-          return JSON.parse(`"${escaped}"`)
-        } catch (e) {
-          return str
-            .replace(/\\n/g, '\n')
-            .replace(/\\t/g, '\t')
-            .replace(/\\r/g, '\r')
-            .replace(/\\u([0-9a-fA-F]{4})/g, (_, code) => String.fromCharCode(parseInt(code, 16)))
-        }
-      }
-      return str
-    }
-
-    // Helper to extract title from content
-    const extractTitle = (content: string): string => {
-      const h1Match = content.match(/^#\s+(.+)$/m)
-      if (h1Match) return h1Match[1].trim()
-      const h2Match = content.match(/^##\s+(.+)$/m)
-      if (h2Match) return h2Match[1].trim()
-      return 'Research Results'
-    }
-
-    // 1. Check for <research> XML tag (primary method)
-    const researchMatch = result.match(/<research>([\s\S]*?)<\/research>/)
-    if (researchMatch && researchMatch[1]) {
-      const content = unescapeJsonString(researchMatch[1].trim())
-      return { title: extractTitle(content), content }
-    }
-
-    // 2. Try to parse as JSON (legacy format)
-    try {
-      const parsed = JSON.parse(result)
-      if (parsed.content && typeof parsed.content === 'string') {
-        const content = unescapeJsonString(parsed.content)
-        return { title: extractTitle(content), content }
-      }
-      if (parsed.text && typeof parsed.text === 'string') {
-        const innerMatch = parsed.text.match(/<research>([\s\S]*?)<\/research>/)
-        if (innerMatch && innerMatch[1]) {
-          const content = unescapeJsonString(innerMatch[1].trim())
-          return { title: extractTitle(content), content }
-        }
-        const content = unescapeJsonString(parsed.text)
-        return { title: extractTitle(content), content }
-      }
-    } catch (e) {
-      // Not JSON, continue with other methods
-    }
-
-    // 3. Fallback: Look for first H1 heading (skip progress lines before it)
-    const h1Match = result.match(/^#\s+.+$/m)
-    if (h1Match && h1Match.index !== undefined) {
-      const content = unescapeJsonString(result.substring(h1Match.index))
-      return { title: extractTitle(content), content }
-    }
-
-    // 4. Last resort: return as is
-    return { title: 'Research Results', content: unescapeJsonString(result) }
-  }, [])
-
-
-  // Clean up when research completes - detect via researchData status changes
-  useEffect(() => {
-    // Only process if we have an active research in progress
-    if (!researchArtifactId) return
-
-    // Check if any research execution has completed
-    for (const [executionId, data] of researchData) {
-      // Skip already processed
-      if (processedResearchIdsRef.current.has(executionId)) continue
-
-      // A research whose artifact already exists finished before this mount:
-      // researchData is derived from message history, so a page reload replays
-      // every past research as freshly "complete" against an empty processed
-      // set. Completing it again would reset the research state and open its
-      // artifact, replacing the approval card for the research starting now.
-      if (artifacts.some(a => a.id === `research-${executionId}`)) {
-        processedResearchIdsRef.current.add(executionId)
-        continue
-      }
-
-      if (data.status === 'complete' && data.result) {
-        processedResearchIdsRef.current.add(executionId)
-
-        // Extract clean content from research result
-        const { title, content } = extractResearchContent(data.result)
-
-        // Call research.handleComplete to update ResearchArtifact UI
-        researchRef.current.handleComplete({ title, content })
-
-        // Artifact ID is research-{toolUseId} where toolUseId = executionId
-        const targetArtifactId = `research-${executionId}`
-
-        // Add artifact directly to state (backend also saves it)
-        // No need to call refreshArtifacts which triggers unnecessary API calls
-        addArtifact({
-          id: targetArtifactId,
-          type: 'research',
-          title: title,
-          content: content,
-          description: '',
-          timestamp: new Date().toISOString(),
-          sessionId: sessionId || undefined,
-        })
-
-        // Open the artifact in Canvas and clean up research state
-        setResearchArtifactId(null)
-        researchRef.current.reset()
-        openArtifact(targetArtifactId)
-      } else if (data.status === 'error' || data.status === 'declined') {
-        processedResearchIdsRef.current.add(executionId)
-        // Only cleanup if this is the active research (not 'in-progress' waiting for new one)
-        if (researchArtifactId && researchArtifactId !== 'in-progress') {
-          setResearchArtifactId(null)
-          researchRef.current.reset()
-          closeCanvas()
-        }
-      }
-    }
-  }, [researchData, researchArtifactId, artifacts, closeCanvas, addArtifact, sessionId, extractResearchContent, openArtifact])
-
   // Export conversation to text file
   const exportConversation = useCallback(() => {
     if (groupedMessages.length === 0) return
@@ -755,7 +604,7 @@ export function ChatInterface() {
     enqueueMessage(text, files, buildCurrentArtifactContext(), selectedArtifactId)
   }, [enqueueMessage, buildCurrentArtifactContext, selectedArtifactId])
 
-  // Interrupt approval handlers (for browser interrupts - research is handled via useEffect/Canvas)
+  // Interrupt approval handlers for destructive/write operations.
   const handleApproveInterrupt = useCallback(() => {
     if (currentInterrupt && currentInterrupt.interrupts.length > 0) {
       const interrupt = currentInterrupt.interrupts[0]
@@ -1031,6 +880,7 @@ export function ChatInterface() {
                         onOpenExtractedDataArtifact={handleOpenExtractedDataArtifact}
                         onOpenExcalidrawArtifact={handleOpenExcalidrawArtifact}
                         researchProgress={researchProgress}
+                        researchJobs={researchJobs}
                         codeProgress={codeProgress}
                         hideAvatar={isSwarmFinalResponse || hasHistorySwarm}
                       />
@@ -1156,9 +1006,8 @@ export function ChatInterface() {
         </DialogContent>
       </Dialog>
 
-      {/* Interrupt Approval Modal - for destructive/write operations (research handled via Canvas) */}
+      {/* Interrupt Approval Modal - for destructive/write operations */}
       {currentInterrupt && currentInterrupt.interrupts.length > 0 &&
-       !currentInterrupt.interrupts[0].name.includes("research-approval") &&
        (
         <InterruptApprovalModal
           isOpen={true}
@@ -1184,17 +1033,6 @@ export function ChatInterface() {
         onSelectArtifact={openArtifact}
         onUpdateArtifact={updateArtifact}
         justUpdated={artifactJustUpdated}
-        researchState={researchArtifactId ? {
-          isResearching: research.isResearching,
-          progress: research.progress,
-          plan: research.plan,
-          showPlanConfirm: research.showPlanConfirm,
-          resultParts: research.resultParts,
-          completedResult: research.completedResult,
-          onConfirmPlan: handleResearchConfirmPlan,
-          onCancel: handleResearchCancel,
-          sessionId: sessionId || undefined,
-        } : undefined}
         browserState={(() => {
           const bArtifact = browserArtifactId ? artifacts.find(a => a.id === browserArtifactId) : null
           const bSessionId = bArtifact?.metadata?.browserSessionId

--- a/chatbot-app/frontend/src/components/chat/AssistantTurn.tsx
+++ b/chatbot-app/frontend/src/components/chat/AssistantTurn.tsx
@@ -10,9 +10,9 @@ import { Markdown } from '@/components/ui/Markdown'
 import { StreamingText } from './StreamingText'
 import { ToolExecutionContainer } from './ToolExecutionContainer'
 import { CodeAgentTerminal, isCodeAgentExecution } from './CodeAgentUI'
-import { ResearchContainer } from '@/components/ResearchContainer'
 import { LazyImage } from '@/components/ui/LazyImage'
 import { fetchAuthSession } from 'aws-amplify/auth'
+import type { ResearchJob } from '@/lib/research-jobs'
 
 // Parse artifact creation message pattern
 const parseArtifactMessage = (text: string): { title: string; wordCount: number } | null => {
@@ -61,6 +61,7 @@ interface AssistantTurnProps {
     stepNumber: number
     content: string
   }
+  researchJobs?: ResearchJob[]
   codeProgress?: Array<{
     stepNumber: number
     content: string
@@ -68,7 +69,7 @@ interface AssistantTurnProps {
   hideAvatar?: boolean
 }
 
-export const AssistantTurn = React.memo<AssistantTurnProps>(({ messages, currentReasoning, sessionId, onOpenResearchArtifact, onOpenWordArtifact, onOpenExcelArtifact, onOpenPptArtifact, onOpenExtractedDataArtifact, onOpenExcalidrawArtifact, researchProgress, codeProgress, hideAvatar = false }) => {
+export const AssistantTurn = React.memo<AssistantTurnProps>(({ messages, currentReasoning, sessionId, onOpenResearchArtifact, onOpenWordArtifact, onOpenExcelArtifact, onOpenPptArtifact, onOpenExtractedDataArtifact, onOpenExcalidrawArtifact, researchProgress, researchJobs, codeProgress, hideAvatar = false }) => {
   // Get initial feedback state from first message
   const initialFeedback = messages[0]?.feedback || null
 
@@ -299,6 +300,7 @@ if (!messages || messages.length === 0) {
                       onOpenPptArtifact={onOpenPptArtifact}
                       onOpenExtractedDataArtifact={onOpenExtractedDataArtifact}
                       onOpenExcalidrawArtifact={onOpenExcalidrawArtifact}
+                      researchJobs={researchJobs}
                     />
                   )}
                 </div>

--- a/chatbot-app/frontend/src/components/chat/ToolExecutionContainer.tsx
+++ b/chatbot-app/frontend/src/components/chat/ToolExecutionContainer.tsx
@@ -15,6 +15,7 @@ import { getApiUrl } from '@/config/environment'
 import { isCodeAgentExecution, CodeAgentDetails, CodeAgentResult, CodeAgentDownloadButton } from './CodeAgentUI'
 
 import type { ImageData } from '@/utils/imageExtractor'
+import type { ResearchJob } from '@/lib/research-jobs'
 
 // Word document tool names
 const WORD_DOCUMENT_TOOLS = ['create_word_document', 'modify_word_document']
@@ -37,6 +38,7 @@ interface ToolExecutionContainerProps {
   onOpenPptArtifact?: (filename: string) => void  // Open PowerPoint presentation in Canvas
   onOpenExtractedDataArtifact?: (artifactId: string) => void  // Open extracted data in Canvas
   onOpenExcalidrawArtifact?: (artifactId: string) => void  // Open Excalidraw diagram in Canvas
+  researchJobs?: ResearchJob[]
 }
 
 // Collapsible Markdown component for tool results
@@ -94,7 +96,7 @@ const CollapsibleMarkdown = React.memo<{
          prevProps.sessionId === nextProps.sessionId
 })
 
-export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({ toolExecutions, compact = false, sessionId, onOpenResearchArtifact, onOpenWordArtifact, onOpenExcelArtifact, onOpenPptArtifact, onOpenExtractedDataArtifact, onOpenExcalidrawArtifact }) => {
+export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({ toolExecutions, compact = false, sessionId, onOpenResearchArtifact, onOpenWordArtifact, onOpenExcelArtifact, onOpenPptArtifact, onOpenExtractedDataArtifact, onOpenExcalidrawArtifact, researchJobs = [] }) => {
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set())
   const [selectedImage, setSelectedImage] = useState<{ src: string; alt: string } | null>(null)
   const [downloadingFiles, setDownloadingFiles] = useState<Set<string>>(new Set())
@@ -180,15 +182,39 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
     return expandedTools.has(toolId)
   }
 
+  const resolvedToolExecutions = useMemo(() => toolExecutions.map(execution => {
+    if (execution.toolName !== 'research_agent' || !execution.toolResult) return execution
+    try {
+      const receipt = JSON.parse(execution.toolResult)
+      if (receipt?.status !== 'started' || !receipt.job_id) return execution
+      const job = researchJobs.find(item => item.jobId === receipt.job_id)
+      const complete = !!job && ['completed', 'delivering', 'delivered'].includes(job.status)
+      const failed = job?.status === 'error'
+      return {
+        ...execution,
+        isComplete: complete || failed,
+        isCancelled: failed,
+        streamingResponse: job?.progress?.content || execution.streamingResponse,
+        toolResult: complete && job?.artifact?.content
+          ? job.artifact.content
+          : failed
+            ? `Error: ${job.error || 'Research failed'}`
+            : execution.toolResult,
+      }
+    } catch {
+      return execution
+    }
+  }), [toolExecutions, researchJobs])
+
   // Memoize parsed chart data (hooks must be called unconditionally)
   const toolExecutionsDeps = useMemo(() => {
-    return toolExecutions.map(t => ({
+    return resolvedToolExecutions.map(t => ({
       id: t.id,
       isComplete: t.isComplete,
       toolResult: t.toolResult,
       toolName: t.toolName
     }))
-  }, [toolExecutions])
+  }, [resolvedToolExecutions])
 
   const chartDataCache = useMemo(() => {
     const cache = new Map<string, { parsed: ChartToolResult, resultString: string }>();
@@ -753,7 +779,7 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
   const renderItems: RenderItem[] = []
   const groupMap = new Map<string, ToolGroup>()
 
-  for (const exec of toolExecutions) {
+  for (const exec of resolvedToolExecutions) {
     // Skip skill_dispatcher — the executor calls show the actual work
     if (exec.toolName === 'skill_dispatcher') continue
 
@@ -805,6 +831,9 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
           const allDone = completedCount === executions.length
           const count = executions.length
           const isExpanded = isToolExpanded(key)
+          const liveProgress = count === 1 && !allDone
+            ? executions[0].streamingResponse
+            : undefined
 
           // Find the last completed execution for action buttons (Canvas, Download)
           const lastCompleteExec = [...executions].reverse().find(e => e.isComplete)
@@ -828,6 +857,11 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
                   <span className="text-label text-foreground">
                     {allDone ? displayName.complete : displayName.running}
                   </span>
+                  {liveProgress && (
+                    <span className="text-caption text-muted-foreground truncate">
+                      {liveProgress}
+                    </span>
+                  )}
 
                   {/* Count badge — only when count > 1 */}
                   {count > 1 && (
@@ -897,6 +931,10 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
   }
 
   if (prevProps.compact !== nextProps.compact || prevProps.sessionId !== nextProps.sessionId) {
+    return false
+  }
+
+  if (prevProps.researchJobs !== nextProps.researchJobs) {
     return false
   }
 

--- a/chatbot-app/frontend/src/config/tool-icons.tsx
+++ b/chatbot-app/frontend/src/config/tool-icons.tsx
@@ -12,6 +12,7 @@ import {
   TbPresentation,
   TbChartLine,
   TbCode,
+  TbTelescope,
 } from 'react-icons/tb';
 import {
   SiDuckduckgo,
@@ -74,7 +75,8 @@ export const toolIconMap: Record<string, IconType> = {
   mcp_github: SiGithub,
 
   // Research Agent
-  'agentcore_research-agent': TbSearch,
+  'agentcore_research-agent': TbTelescope,
+  research_agent: TbTelescope,
 };
 
 /**

--- a/chatbot-app/frontend/src/hooks/useAgentExecutions.ts
+++ b/chatbot-app/frontend/src/hooks/useAgentExecutions.ts
@@ -1,4 +1,6 @@
 import { useState, useMemo, useEffect } from 'react'
+import type { ResearchJob } from '@/lib/research-jobs'
+import { parseResearchStartReceipt } from '@/lib/research-start-receipt'
 
 export interface ResearchExecutionData {
   query: string
@@ -22,7 +24,10 @@ interface MessageGroup {
   }>
 }
 
-export function useAgentExecutions(groupedMessages: MessageGroup[]) {
+export function useAgentExecutions(
+  groupedMessages: MessageGroup[],
+  researchJobs: ResearchJob[] = [],
+) {
   const [researchData, setResearchData] = useState<Map<string, ResearchExecutionData>>(new Map())
 
   const computedResearchData = useMemo(() => {
@@ -38,12 +43,21 @@ export function useAgentExecutions(groupedMessages: MessageGroup[]) {
             if (execution.toolName === 'research_agent') {
               const executionId = execution.id
               const query = execution.toolInput?.plan || "Research Task"
+              const started = parseResearchStartReceipt(execution.toolResult)
+              const job = started
+                ? researchJobs.find(item => item.jobId === started.job_id)
+                : researchJobs.find(item => item.artifactId === `research-${executionId}`)
 
-              if (!execution.isComplete) {
+              if (!execution.isComplete || started) {
+                const isError = job?.status === 'error'
+                const isComplete = job && ['completed', 'delivering', 'delivered'].includes(job.status)
+                const result = typeof job?.artifact?.content === 'string'
+                  ? job.artifact.content
+                  : execution.streamingResponse || ''
                 newResearchData.set(executionId, {
                   query,
-                  result: execution.streamingResponse || '',
-                  status: execution.streamingResponse ? 'generating' : 'searching',
+                  result,
+                  status: isError ? 'error' : isComplete ? 'complete' : result ? 'generating' : 'searching',
                   agentName: 'Research Agent'
                 })
               } else if (execution.toolResult) {
@@ -70,7 +84,7 @@ export function useAgentExecutions(groupedMessages: MessageGroup[]) {
     }
 
     return newResearchData
-  }, [groupedMessages])
+  }, [groupedMessages, researchJobs])
 
   useEffect(() => {
     setResearchData(prev => {

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -9,6 +9,7 @@ import { useMessageQueue, QueuedMessage, QueueHoldReason } from './useMessageQue
 import { getApiUrl } from '@/config/environment'
 import { generateSessionId } from '@/config/session'
 import { apiGet, apiPost } from '@/lib/api-client'
+import { groupChatMessages, type GroupedChatMessage } from '@/lib/chat-message-groups'
 
 import { WorkspaceDocument } from './useStreamEvents'
 import { ExtractedDataInfo } from './useCanvasHandlers'
@@ -29,11 +30,7 @@ interface UseChatProps {
 
 interface UseChatReturn {
   messages: Message[]
-  groupedMessages: Array<{
-    type: 'user' | 'assistant_turn'
-    messages: Message[]
-    id: string
-  }>
+  groupedMessages: GroupedChatMessage[]
   isConnected: boolean
   isTyping: boolean
   agentStatus: AgentStatus
@@ -42,6 +39,7 @@ interface UseChatReturn {
   showProgressPanel: boolean
   toggleProgressPanel: () => void
   sendMessage: (text: string, files?: File[], systemPrompt?: string, selectedArtifactId?: string | null) => Promise<void>
+  replayExecution: (executionId: string) => Promise<boolean>
   stopGeneration: () => Promise<void>
   // Queue for turns composed while the agent is busy
   queuedMessages: QueuedMessage[]
@@ -247,6 +245,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     summarizeForCompact: apiSummarizeForCompact,
     listSessionEvents: apiListSessionEvents,
     sendMessage: apiSendMessage,
+    replayExecution: apiReplayExecution,
     cleanup,
     sendStopSignal,
     loadSession: apiLoadSession,
@@ -629,6 +628,30 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     })
   }, [enqueue, sessionId])
 
+  const replayExecution = useCallback(async (executionId: string) => {
+    const replayed = await apiReplayExecution(executionId)
+    if (!replayed) {
+      // Runtime buffers expire; history contains the same durable assistant
+      // response and preserves its synthetic turn boundary.
+      await loadSessionWithPreferences(sessionId)
+    }
+
+    // A message composed while the delivery was rendering is a normal queued
+    // user turn. Dispatch it only after replay or history fallback completes.
+    await flushNext(sessionId, {
+      hasInterrupt: sessionState.interrupt !== null,
+      hasPendingOAuth: !!sessionState.pendingOAuth,
+    })
+    return replayed
+  }, [
+    apiReplayExecution,
+    flushNext,
+    loadSessionWithPreferences,
+    sessionId,
+    sessionState.interrupt,
+    sessionState.pendingOAuth,
+  ])
+
   useEffect(() => {
     if (!turnSettled) return
     setTurnSettled(null)
@@ -828,45 +851,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   }, [stopGeneration])
 
   // ==================== DERIVED STATE ====================
-  const groupedMessages = useMemo(() => {
-    const grouped: Array<{
-      type: 'user' | 'assistant_turn'
-      messages: Message[]
-      id: string
-    }> = []
-
-    let currentAssistantTurn: Message[] = []
-
-    for (const message of messages) {
-      if (message.sender === 'user') {
-        if (currentAssistantTurn.length > 0) {
-          grouped.push({
-            type: 'assistant_turn',
-            messages: currentAssistantTurn,
-            id: `turn_${currentAssistantTurn[0].id}`
-          })
-          currentAssistantTurn = []
-        }
-        grouped.push({
-          type: 'user',
-          messages: [message],
-          id: `user_${message.id}`
-        })
-      } else {
-        currentAssistantTurn.push(message)
-      }
-    }
-
-    if (currentAssistantTurn.length > 0) {
-      grouped.push({
-        type: 'assistant_turn',
-        messages: currentAssistantTurn,
-        id: `turn_${currentAssistantTurn[0].id}`
-      })
-    }
-
-    return grouped
-  }, [messages])
+  const groupedMessages = useMemo(() => groupChatMessages(messages), [messages])
 
   // Update per-session model config (React state + global default via API)
   const updateModelConfig = useCallback((modelId: string, temperature?: number) => {
@@ -1095,6 +1080,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     showProgressPanel: uiState.showProgressPanel,
     toggleProgressPanel,
     sendMessage,
+    replayExecution,
     stopGeneration,
     queuedMessages,
     queueHoldReason,

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -158,7 +158,7 @@ interface UseChatAPIProps {
   backendUrl: string
   setUIState: React.Dispatch<React.SetStateAction<ChatUIState>>
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>
-  handleStreamEvent: (event: AGUIStreamEvent) => void
+  handleStreamEvent: (event: AGUIStreamEvent) => void | Promise<void>
   resetStreamingState: () => void
   onSessionCreated?: () => void
   sessionId: string
@@ -180,6 +180,7 @@ export interface SessionPreferences {
 interface UseChatAPIReturn {
   newChat: () => Promise<boolean>
   sendMessage: (messageToSend: string, files?: File[], onSuccess?: () => void, onError?: (error: string) => void) => Promise<void>
+  replayExecution: (executionId: string) => Promise<boolean>
   cleanup: () => void
   sendStopSignal: () => Promise<boolean>
   loadSession: (sessionId: string) => Promise<{ preferences: SessionPreferences | null; messages: Message[] }>
@@ -1098,6 +1099,9 @@ export const useChatAPI = ({
             ...(msg.isVoiceMessage && {
               isVoiceMessage: true
             }),
+            ...(msg.startsNewAssistantTurn && {
+              startsNewAssistantTurn: true
+            }),
             // Preserve swarm context from parsed message
             ...(swarmContext && {
               swarmContext: swarmContext
@@ -1214,6 +1218,106 @@ export const useChatAPI = ({
     }
   }, [setMessages, getAuthHeaders, reconnect, handleStreamEvent, setUIState])
 
+  const replayExecution = useCallback(async (executionId: string): Promise<boolean> => {
+    const separator = executionId.lastIndexOf(':')
+    const executionSessionId = separator >= 0
+      ? executionId.substring(0, separator)
+      : executionId
+    if (sessionIdRef.current !== executionSessionId) return false
+
+    const failReplay = () => {
+      if (sessionIdRef.current === executionSessionId) {
+        setUIState(prev => ({
+          ...prev,
+          isTyping: false,
+          agentStatus: 'idle',
+        }))
+      }
+      return false
+    }
+
+    // Close the idle window before the resume request. Messages submitted while
+    // the delivery renders enter the normal queue and are flushed afterward.
+    setUIState(prev => prev.agentStatus === 'idle'
+      ? { ...prev, isTyping: true, agentStatus: 'thinking' }
+      : prev)
+
+    try {
+      const authHeaders = await getAuthHeaders()
+      const response = await fetch(
+        `${getApiUrl('stream/resume')}?executionId=${encodeURIComponent(executionId)}&cursor=0`,
+        {
+          headers: {
+            ...authHeaders,
+            Accept: 'text/event-stream',
+          },
+        },
+      )
+      if (!response.ok || !response.body) return failReplay()
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let currentEventId: number | null = null
+      let terminalEventSeen = false
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          if (sessionIdRef.current !== executionSessionId) {
+            await reader.cancel()
+            return false
+          }
+
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() || ''
+
+          for (const line of lines) {
+            if (line.startsWith('id: ')) {
+              currentEventId = parseInt(line.substring(4), 10)
+              continue
+            }
+            if (!line.startsWith('data: ')) continue
+
+            try {
+              const eventData = JSON.parse(line.substring(6))
+              if (eventData.type === 'CUSTOM' && eventData.name === 'execution_meta') {
+                currentEventId = null
+                continue
+              }
+              if (currentEventId !== null && currentEventId > 0) {
+                eventData._eventId = currentEventId
+              }
+              currentEventId = null
+              if (
+                eventData.type &&
+                (AGUI_EVENT_TYPES as readonly string[]).includes(eventData.type)
+              ) {
+                if (
+                  eventData.type === 'RUN_FINISHED' ||
+                  eventData.type === 'RUN_ERROR'
+                ) {
+                  terminalEventSeen = true
+                }
+                await handleStreamEvent(eventData as AGUIStreamEvent)
+              }
+            } catch {
+              // Ignore malformed SSE payloads and continue replaying the buffer.
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock()
+      }
+      return terminalEventSeen || failReplay()
+    } catch (error) {
+      logger.warn(`[useChatAPI] Failed to replay ${executionId}:`, error)
+      return failReplay()
+    }
+  }, [getAuthHeaders, handleStreamEvent, setUIState])
+
   const cleanup = useCallback(() => {
     abortRef.current?.unsubscribe()
   }, [])
@@ -1266,6 +1370,7 @@ export const useChatAPI = ({
     summarizeForCompact,
     listSessionEvents,
     sendMessage,
+    replayExecution,
     cleanup,
     sendStopSignal,
     loadSession,

--- a/chatbot-app/frontend/src/hooks/useMessageQueue.ts
+++ b/chatbot-app/frontend/src/hooks/useMessageQueue.ts
@@ -166,12 +166,16 @@ export function useMessageQueue({ send }: UseMessageQueueProps): UseMessageQueue
     const next = queueRef.current.find(m => m.sessionId === sessionId)!
 
     isFlushingRef.current = true
-    // Dequeue before sending: the send path echoes the text into the transcript
-    // immediately, so leaving it queued on failure would offer a duplicate.
-    updateQueue(prev => prev.filter(m => m.id !== next.id))
     try {
       await send(next.text, next.files, next.systemPrompt, next.selectedArtifactId)
+      // A transport failure is not proof that the backend accepted the turn.
+      // Keep the item until success so a transient error cannot silently lose
+      // user input. The error hold requires an explicit retry/discard decision.
+      updateQueue(prev => prev.filter(m => m.id !== next.id))
       return true
+    } catch {
+      hold('error')
+      return false
     } finally {
       isFlushingRef.current = false
     }

--- a/chatbot-app/frontend/src/hooks/useResearchJobs.ts
+++ b/chatbot-app/frontend/src/hooks/useResearchJobs.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from '@/lib/api-client'
+import type { ResearchJob } from '@/lib/research-jobs'
+
+const POLL_INTERVAL_MS = 2000
+const DISCOVERY_WINDOW_MS = 15000
+
+export function useResearchJobs(sessionId: string, refreshToken = 0) {
+  const [jobs, setJobs] = useState<ResearchJob[]>([])
+  const [deliveredJobIds, setDeliveredJobIds] = useState<string[]>([])
+  const statusesRef = useRef<Map<string, string> | null>(null)
+  const jobsRef = useRef<ResearchJob[]>([])
+  const refreshingRef = useRef(false)
+  const pendingRefreshRef = useRef(false)
+  const activeRef = useRef(false)
+  const discoveryUntilRef = useRef(0)
+  const invocationCountRef = useRef(0)
+  const sessionRef = useRef(sessionId)
+  sessionRef.current = sessionId
+
+  const refresh = useCallback(async () => {
+    if (!sessionId) return
+    if (refreshingRef.current) {
+      pendingRefreshRef.current = true
+      return
+    }
+    const requestedSessionId = sessionId
+    refreshingRef.current = true
+    try {
+      const response = await apiFetch(`research/jobs?session_id=${encodeURIComponent(sessionId)}`, {
+        cache: 'no-store',
+      })
+      if (!response.ok) return
+      const data = await response.json()
+      if (sessionRef.current !== requestedSessionId) return
+      let nextJobs: ResearchJob[] = Array.isArray(data.jobs) ? data.jobs : []
+      const existingById = new Map(jobsRef.current.map(job => [job.jobId, job]))
+      nextJobs = nextJobs.map(job => {
+        const existing = existingById.get(job.jobId)
+        return existing?.artifact?.content
+          ? { ...job, artifact: existing.artifact }
+          : job
+      })
+
+      const needsContent = nextJobs.some(job =>
+        ['completed', 'delivering', 'delivered'].includes(job.status) &&
+        !job.artifact?.content,
+      )
+      if (needsContent) {
+        const contentResponse = await apiFetch(
+          `research/jobs?session_id=${encodeURIComponent(sessionId)}&include_content=true`,
+          { cache: 'no-store' },
+        )
+        if (contentResponse.ok) {
+          const contentData = await contentResponse.json()
+          if (sessionRef.current !== requestedSessionId) return
+          const hydrated: ResearchJob[] = Array.isArray(contentData.jobs) ? contentData.jobs : []
+          const hydratedById = new Map(hydrated.map(job => [job.jobId, job]))
+          nextJobs = nextJobs.map(job => hydratedById.get(job.jobId) || job)
+        }
+      }
+
+      const previous = statusesRef.current
+      if (previous) {
+        const transitions = nextJobs
+          .filter(job => job.status === 'delivered' && previous.get(job.jobId) !== 'delivered')
+          .map(job => job.jobId)
+        if (transitions.length > 0) setDeliveredJobIds(transitions)
+      }
+      statusesRef.current = new Map(nextJobs.map(job => [job.jobId, job.status]))
+      const hasActiveJobs = nextJobs.some(job =>
+        ['queued', 'running', 'delivering'].includes(job.status),
+      )
+      const expectedJobs = invocationCountRef.current
+      if (nextJobs.length >= expectedJobs) {
+        discoveryUntilRef.current = 0
+      }
+      const waitingForReceipt =
+        nextJobs.length < expectedJobs &&
+        Date.now() < discoveryUntilRef.current
+      activeRef.current = hasActiveJobs || waitingForReceipt
+      const changed = nextJobs.length !== jobsRef.current.length || nextJobs.some((job, index) => {
+        const current = jobsRef.current[index]
+        return !current ||
+          current.jobId !== job.jobId ||
+          current.status !== job.status ||
+          current.updatedAt !== job.updatedAt ||
+          current.artifact?.content !== job.artifact?.content
+      })
+      jobsRef.current = nextJobs
+      if (changed) setJobs(nextJobs)
+    } finally {
+      refreshingRef.current = false
+      if (pendingRefreshRef.current && sessionRef.current === requestedSessionId) {
+        pendingRefreshRef.current = false
+        void refresh()
+      }
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    statusesRef.current = null
+    jobsRef.current = []
+    activeRef.current = false
+    discoveryUntilRef.current = 0
+    invocationCountRef.current = 0
+    refreshingRef.current = false
+    pendingRefreshRef.current = false
+    setJobs([])
+    setDeliveredJobIds([])
+    void refresh()
+    const timer = window.setInterval(() => {
+      if (activeRef.current) void refresh()
+    }, POLL_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  useEffect(() => {
+    if (refreshToken <= invocationCountRef.current) return
+    invocationCountRef.current = refreshToken
+    discoveryUntilRef.current = Date.now() + DISCOVERY_WINDOW_MS
+    activeRef.current = true
+    void refresh()
+  }, [refresh, refreshToken])
+
+  return { jobs, deliveredJobIds, refresh }
+}

--- a/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
+++ b/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
@@ -138,12 +138,16 @@ export function useSSEReconnect() {
 
       try {
         // 1. Check execution status via BFF buffer
+        const headers = await getAuthHeaders()
         const statusController = new AbortController()
         const statusTimeout = setTimeout(() => statusController.abort(), FETCH_TIMEOUT_MS)
         let statusData: { status: string }
         try {
           const statusUrl = `${getApiUrl('stream/execution-status')}?executionId=${encodeURIComponent(executionId)}`
-          const statusRes = await fetch(statusUrl, { signal: statusController.signal })
+          const statusRes = await fetch(statusUrl, {
+            headers,
+            signal: statusController.signal,
+          })
           statusData = await statusRes.json()
         } finally {
           clearTimeout(statusTimeout)
@@ -158,7 +162,6 @@ export function useSSEReconnect() {
         const resumeController = new AbortController()
         const resumeTimeout = setTimeout(() => resumeController.abort(), FETCH_TIMEOUT_MS)
         const resumeUrl = `${getApiUrl('stream/resume')}?executionId=${encodeURIComponent(executionId)}&cursor=0`
-        const headers = await getAuthHeaders()
         let response: Response
         try {
           response = await fetch(resumeUrl, {

--- a/chatbot-app/frontend/src/hooks/useStreamEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useStreamEvents.ts
@@ -68,6 +68,7 @@ export const useStreamEvents = ({
   const streamingIdRef = useRef<string | null>(null)
   const completeProcessedRef = useRef(false)
   const tokenUsageRef = useRef<TokenUsage | null>(null)
+  const pendingAssistantTurnBoundaryRef = useRef(false)
 
   // Accumulates TOOL_CALL_ARGS deltas keyed by toolCallId
   const toolInputAccumulatorRef = useRef<Record<string, string>>({})
@@ -89,6 +90,12 @@ export const useStreamEvents = ({
   // Note: onFlush callback is passed to startFlushing() when streaming starts,
   // not at initialization, to avoid stale closure issues with streamingIdRef
   const textBuffer = useTextBuffer({ flushInterval: 50 })
+
+  const consumeAssistantTurnBoundary = useCallback(() => {
+    if (!pendingAssistantTurnBoundaryRef.current) return {}
+    pendingAssistantTurnBoundaryRef.current = false
+    return { startsNewAssistantTurn: true as const }
+  }, [])
 
   const handleReasoningEvent = useCallback((data: CustomEvent) => {
     const ev = (data as any).value
@@ -140,6 +147,7 @@ export const useStreamEvents = ({
     // Create new streaming message
     streamingStartedRef.current = true
     streamingIdRef.current = event.messageId
+    const turnBoundary = consumeAssistantTurnBoundary()
 
     // Create message with empty text - buffer will populate it
     setMessages(prevMsgs => [...prevMsgs, {
@@ -148,7 +156,8 @@ export const useStreamEvents = ({
       sender: 'bot',
       timestamp: new Date().toISOString(),
       isStreaming: true,
-      images: []
+      images: [],
+      ...turnBoundary,
     }])
 
     setSessionState(prev => ({
@@ -190,7 +199,7 @@ export const useStreamEvents = ({
         latencyMetrics: { ...prevUI.latencyMetrics, timeToFirstToken: ttft ?? prevUI.latencyMetrics.timeToFirstToken ?? null }
       }
     })
-  }, [sessionState, setSessionState, setMessages, setUIState, streamingStartedRef, streamingIdRef, metadataTracking, textBuffer])
+  }, [sessionState, setSessionState, setMessages, setUIState, streamingStartedRef, streamingIdRef, metadataTracking, textBuffer, consumeAssistantTurnBoundary])
 
   const handleTextMessageContentEvent = useCallback((event: TextMessageContentEvent) => {
     // Swarm mode: non-responder captures in agentSteps
@@ -379,6 +388,7 @@ export const useStreamEvents = ({
       // Create new tool message immediately (not in startTransition)
       // Tool container should appear right away with "Loading parameters..." state
       const toolMessageId = String(Date.now())
+      const turnBoundary = consumeAssistantTurnBoundary()
       setMessages(prevMessages => [...prevMessages, {
         id: toolMessageId,
         text: '',
@@ -386,10 +396,11 @@ export const useStreamEvents = ({
         timestamp: new Date().toISOString(),
         toolExecutions: [newToolExecution],
         isToolMessage: true,
-        turnId: currentTurnIdRef.current || undefined
+        turnId: currentTurnIdRef.current || undefined,
+        ...turnBoundary,
       }])
     }
-  }, [currentToolExecutionsRef, currentTurnIdRef, setSessionState, setMessages, setUIState, uiState, textBuffer])
+  }, [currentToolExecutionsRef, currentTurnIdRef, setSessionState, setMessages, setUIState, uiState, textBuffer, consumeAssistantTurnBoundary])
 
   const handleToolCallArgsEvent = useCallback((event: ToolCallArgsEvent) => {
     const current = toolInputAccumulatorRef.current[event.toolCallId] || ''
@@ -858,6 +869,7 @@ export const useStreamEvents = ({
     streamingIdRef.current = null
     completeProcessedRef.current = false
     tokenUsageRef.current = null
+    pendingAssistantTurnBoundaryRef.current = false
     metadataTracking.reset()
   }, [setSessionState, setMessages, setUIState, streamingStartedRef, streamingIdRef, completeProcessedRef, metadataTracking, currentToolExecutionsRef, textBuffer, stopPollingRef])
 
@@ -865,6 +877,7 @@ export const useStreamEvents = ({
     // Clear dedup set at the start of each new run so that events from the new
     // execution (which restart eventId from 1) are not mistakenly dropped.
     processedEventIdsRef.current.clear()
+    pendingAssistantTurnBoundaryRef.current = true
 
     setUIState(prev => {
       if (prev.latencyMetrics.requestStartTime) {
@@ -887,12 +900,14 @@ export const useStreamEvents = ({
 
     // Reset buffer on error
     textBuffer.reset()
+    const turnBoundary = consumeAssistantTurnBoundary()
 
     setMessages(prev => [...prev, {
       id: String(Date.now()),
       text: event.message,
       sender: 'bot',
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      ...turnBoundary,
     }])
 
     setUIState(prev => {
@@ -934,7 +949,7 @@ export const useStreamEvents = ({
       console.log('[Swarm] Reset due to error')
       swarmModeRef.current = { isActive: false, nodeHistory: [], agentSteps: [] }
     }
-  }, [uiState, setMessages, setUIState, setSessionState, streamingStartedRef, streamingIdRef, completeProcessedRef, metadataTracking, textBuffer, stopPollingRef])
+  }, [uiState, setMessages, setUIState, setSessionState, streamingStartedRef, streamingIdRef, completeProcessedRef, metadataTracking, textBuffer, stopPollingRef, consumeAssistantTurnBoundary])
 
   const handleInterruptEvent = useCallback((data: CustomEvent) => {
     const ev = (data as any).value
@@ -1482,11 +1497,11 @@ export const useStreamEvents = ({
           handleToolCallResultEvent(event)
           break
         case EventType.RUN_FINISHED:
-          // handleCompleteEvent is async - catch rejections to prevent app crash
-          handleCompleteEvent(event).catch(err => {
+          // Return the cleanup promise so buffered background executions can
+          // serialize complete runs. Live stream callers may ignore it.
+          return handleCompleteEvent(event).catch(err => {
             console.error('[useStreamEvents] Error in complete event handler:', err)
           })
-          break
         case EventType.RUN_ERROR:
           handleErrorEvent(event)
           break
@@ -1499,15 +1514,18 @@ export const useStreamEvents = ({
             case 'interrupt':
               handleInterruptEvent(customEvent)
               break
-            case 'warning':
+            case 'warning': {
               // Show warning as a bot message without stopping the stream
+              const turnBoundary = consumeAssistantTurnBoundary()
               setMessages(prev => [...prev, {
                 id: `warning_${Date.now()}`,
                 text: `⚠️ ${(customEvent as any).value?.message}`,
                 sender: 'bot',
-                timestamp: new Date().toISOString()
+                timestamp: new Date().toISOString(),
+                ...turnBoundary,
               }])
               break
+            }
             case 'browser_progress':
               handleBrowserProgressEvent(customEvent)
               break
@@ -1608,6 +1626,7 @@ export const useStreamEvents = ({
     handleSwarmHandoffEvent,
     handleSwarmCompleteEvent,
     handleStreamStoppedEvent,
+    consumeAssistantTurnBoundary,
     setSessionState,
     setMessages,
     onBrowserSessionDetected
@@ -1622,6 +1641,7 @@ export const useStreamEvents = ({
     streamingIdRef.current = null
     completeProcessedRef.current = false
     tokenUsageRef.current = null
+    pendingAssistantTurnBoundaryRef.current = false
     processedEventIdsRef.current.clear()
     metadataTracking.reset()
 

--- a/chatbot-app/frontend/src/lib/chat-message-groups.ts
+++ b/chatbot-app/frontend/src/lib/chat-message-groups.ts
@@ -1,0 +1,40 @@
+import type { Message } from '@/types/chat'
+
+export interface GroupedChatMessage {
+  type: 'user' | 'assistant_turn'
+  messages: Message[]
+  id: string
+}
+
+export function groupChatMessages(messages: Message[]): GroupedChatMessage[] {
+  const grouped: GroupedChatMessage[] = []
+  let currentAssistantTurn: Message[] = []
+
+  const flushAssistantTurn = () => {
+    if (currentAssistantTurn.length === 0) return
+    grouped.push({
+      type: 'assistant_turn',
+      messages: currentAssistantTurn,
+      id: `turn_${currentAssistantTurn[0].id}`,
+    })
+    currentAssistantTurn = []
+  }
+
+  for (const message of messages) {
+    if (message.sender === 'user') {
+      flushAssistantTurn()
+      grouped.push({
+        type: 'user',
+        messages: [message],
+        id: `user_${message.id}`,
+      })
+      continue
+    }
+
+    if (message.startsNewAssistantTurn) flushAssistantTurn()
+    currentAssistantTurn.push(message)
+  }
+
+  flushAssistantTurn()
+  return grouped
+}

--- a/chatbot-app/frontend/src/lib/research-jobs.ts
+++ b/chatbot-app/frontend/src/lib/research-jobs.ts
@@ -1,0 +1,167 @@
+import fs from 'fs'
+import path from 'path'
+import {
+  DynamoDBClient,
+  QueryCommand,
+} from '@aws-sdk/client-dynamodb'
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
+import { unmarshall } from '@aws-sdk/util-dynamodb'
+
+const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
+const AWS_REGION = process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
+const TABLE_NAME = process.env.DYNAMODB_USERS_TABLE || 'strands-agent-chatbot-users-v2'
+
+export type ResearchJobStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'delivering'
+  | 'delivered'
+  | 'error'
+
+export interface ResearchJob {
+  jobId: string
+  sessionId: string
+  userId: string
+  artifactId: string
+  plan: string
+  status: ResearchJobStatus
+  createdAt: string
+  updatedAt: string
+  startedAt?: string
+  completedAt?: string
+  deliveredAt?: string
+  error?: string
+  deliveryError?: string
+  progress?: {
+    stepNumber: number
+    content: string
+  }
+  artifact?: Record<string, any>
+  artifactBucket?: string
+  artifactS3Key?: string
+  artifactPath?: string
+}
+
+function validSessionId(sessionId: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(sessionId)
+}
+
+async function bodyToString(body: any): Promise<string> {
+  if (!body) return ''
+  if (typeof body.transformToString === 'function') {
+    return body.transformToString()
+  }
+  const chunks: Buffer[] = []
+  for await (const chunk of body) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString('utf-8')
+}
+
+async function hydrateArtifact(job: ResearchJob): Promise<ResearchJob> {
+  if (!job.artifact) return job
+
+  let content = ''
+  if (IS_LOCAL || job.userId === 'anonymous' || !!job.artifactPath) {
+    if (!validSessionId(job.sessionId) || !/^[a-f0-9]+$/i.test(job.jobId)) return job
+    const sessionsDir = path.resolve(process.cwd(), '..', 'agentcore', 'sessions')
+    const reportPath = path.resolve(
+      sessionsDir,
+      `session_${job.sessionId}`,
+      'research_jobs',
+      `${job.jobId}.md`,
+    )
+    if (reportPath.startsWith(sessionsDir + path.sep) && fs.existsSync(reportPath)) {
+      content = fs.readFileSync(reportPath, 'utf-8')
+    }
+  } else if (job.artifactBucket && job.artifactS3Key) {
+    const response = await new S3Client({ region: AWS_REGION }).send(
+      new GetObjectCommand({
+        Bucket: job.artifactBucket,
+        Key: job.artifactS3Key,
+      }),
+    )
+    content = await bodyToString(response.Body)
+  }
+
+  return {
+    ...job,
+    artifact: {
+      ...job.artifact,
+      content,
+    },
+  }
+}
+
+function readLocalJobs(sessionId: string, userId: string): ResearchJob[] {
+  if (!validSessionId(sessionId)) return []
+  const sessionsDir = path.resolve(process.cwd(), '..', 'agentcore', 'sessions')
+  const jobsDir = path.resolve(sessionsDir, `session_${sessionId}`, 'research_jobs')
+  if (!jobsDir.startsWith(sessionsDir + path.sep) || !fs.existsSync(jobsDir)) return []
+
+  return fs.readdirSync(jobsDir)
+    .filter(name => /^[a-f0-9]+\.json$/i.test(name))
+    .flatMap(name => {
+      try {
+        const job = JSON.parse(fs.readFileSync(path.join(jobsDir, name), 'utf-8'))
+        if (job.sessionId !== sessionId) return []
+        if (userId !== 'anonymous' && job.userId !== userId) return []
+        return [job as ResearchJob]
+      } catch {
+        return []
+      }
+    })
+}
+
+async function readCloudJobs(sessionId: string, userId: string): Promise<ResearchJob[]> {
+  const client = new DynamoDBClient({ region: AWS_REGION })
+  const jobs: ResearchJob[] = []
+  let exclusiveStartKey: Record<string, any> | undefined
+  do {
+    const response = await client.send(new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression: 'userId = :userId AND begins_with(sk, :prefix)',
+      ExpressionAttributeValues: {
+        ':userId': { S: userId },
+        ':prefix': { S: `RESEARCH_JOB#${sessionId}#` },
+      },
+      ConsistentRead: true,
+      ExclusiveStartKey: exclusiveStartKey,
+    }))
+    jobs.push(...(response.Items || []).map(item => unmarshall(item) as ResearchJob))
+    exclusiveStartKey = response.LastEvaluatedKey
+  } while (exclusiveStartKey)
+  return jobs
+}
+
+export async function listResearchJobs(
+  userId: string,
+  sessionId: string,
+  options: { includeContent?: boolean } = {},
+): Promise<ResearchJob[]> {
+  const jobs = (IS_LOCAL || userId === 'anonymous')
+    ? readLocalJobs(sessionId, userId)
+    : await readCloudJobs(sessionId, userId)
+
+  if (!options.includeContent) {
+    return jobs.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+  }
+
+  const hydrated = await Promise.all(jobs.map(async job => {
+    try {
+      return await hydrateArtifact(job)
+    } catch (error) {
+      console.error(`[ResearchJobs] Failed to hydrate ${job.jobId}:`, error)
+      return job
+    }
+  }))
+  return hydrated.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+}
+
+export function completedResearchArtifacts(jobs: ResearchJob[]): any[] {
+  return jobs
+    .filter(job => ['completed', 'delivering', 'delivered'].includes(job.status))
+    .map(job => job.artifact)
+    .filter(artifact => artifact && typeof artifact.content === 'string' && artifact.content.length > 0)
+}

--- a/chatbot-app/frontend/src/lib/research-start-receipt.ts
+++ b/chatbot-app/frontend/src/lib/research-start-receipt.ts
@@ -1,0 +1,59 @@
+export interface ResearchStartReceipt {
+  status: 'started'
+  job_id: string
+  artifact_id: string
+}
+
+export function parseResearchStartReceipt(result: unknown): ResearchStartReceipt | null {
+  if (typeof result !== 'string' || !result) return null
+  try {
+    const parsed = JSON.parse(result)
+    if (
+      parsed?.status === 'started' &&
+      typeof parsed.job_id === 'string' &&
+      parsed.job_id &&
+      typeof parsed.artifact_id === 'string' &&
+      parsed.artifact_id
+    ) {
+      return parsed as ResearchStartReceipt
+    }
+  } catch {
+    // Tool results from older research flows are not start receipts.
+  }
+  return null
+}
+
+export function hideBackgroundResearchInputs<T extends {
+  role?: string
+  content?: Array<{ text?: string }>
+  startsNewAssistantTurn?: boolean
+}>(messages: T[]): T[] {
+  let pendingDeliveryBoundary = false
+  const visible: T[] = []
+
+  for (const message of messages) {
+    const isBackgroundInput =
+      message.role === 'user' &&
+      Array.isArray(message.content) &&
+      message.content.some(part =>
+        typeof part?.text === 'string' &&
+        part.text.includes('<background-research-result '),
+      )
+
+    if (isBackgroundInput) {
+      pendingDeliveryBoundary = true
+      continue
+    }
+
+    if (pendingDeliveryBoundary && message.role === 'assistant') {
+      visible.push({ ...message, startsNewAssistantTurn: true })
+      pendingDeliveryBoundary = false
+      continue
+    }
+
+    if (message.role === 'user') pendingDeliveryBoundary = false
+    visible.push(message)
+  }
+
+  return visible
+}

--- a/chatbot-app/frontend/src/types/chat.ts
+++ b/chatbot-app/frontend/src/types/chat.ts
@@ -37,6 +37,7 @@ export interface Message {
   }>
   isToolMessage?: boolean // Mark messages that are purely for tool execution display
   turnId?: string // Turn ID for grouping messages by conversation turn
+  startsNewAssistantTurn?: boolean // Internal boundary for synthetic/background turns
   toolUseId?: string // Tool use ID for session-based image paths
   uploadedFiles?: Array<{
     name: string
@@ -88,4 +89,3 @@ export interface Tool {
   tool_type?: "local" | "builtin" | "gateway" | "runtime-a2a"
   connection_status?: "connected" | "disconnected" | "invalid" | "unknown"
 }
-


### PR DESCRIPTION
## Summary
- run research jobs asynchronously without blocking the supervisor turn
- persist research job state and report artifacts before delivery
- wake the supervisor through a buffered background continuation and render it as a separate assistant turn
- hydrate Canvas from durable research jobs and serialize foreground messages with delivery replay
- allow concurrent web-search/research execution and add a dedicated research agent icon

## Verification
- `npm test -- --run` (614 tests)
- `npm run build`
- `/home/ec2-user/.cache/bevenv/bin/pytest -q tests/unit/test_research_jobs.py tests/unit/test_a2a_research_session.py tests/unit/test_chat_router.py` (40 tests)
- `git diff --check`

## Follow-up
A durable per-session mailbox/state machine will be handled separately to strengthen ordering across HITL, process restarts, and multiple clients.