### PR TITLE
feat(chat): add durable session mailbox

### DIFF
--- a/chatbot-app/agentcore/requirements.txt
+++ b/chatbot-app/agentcore/requirements.txt
@@ -6,7 +6,7 @@ fastapi==0.141.1
 uvicorn[standard]==0.52.0
 
 # Strands Agent Framework
-strands-agents[a2a,otel]>=1.50.2,<2.0.0
+strands-agents[a2a,otel]==1.50.2
 strands-agents-tools[a2a_client]>=0.8.5
 mcp>=1.28.1,<2.0.0
 
@@ -39,7 +39,7 @@ pymupdf>=1.28.0  # PDF text extraction for large files exceeding Bedrock's 4.5MB
 openpyxl>=3.1.5  # Excel sheet name extraction for preview
 defusedxml>=0.7.1  # Safe XML parsing for PPTX engine
 
-bedrock-agentcore>=1.14.1
+bedrock-agentcore==1.18.1
 
 # Nova Act SDK (for natural language browser automation via AgentCore Browser)
 # NOTE: nova-act requires --no-deps due to strands-agents version conflict

--- a/chatbot-app/agentcore/src/agent/mailbox.py
+++ b/chatbot-app/agentcore/src/agent/mailbox.py
@@ -1,0 +1,1241 @@
+"""Durable per-session mailbox primitives.
+
+Background workers may enqueue concurrently. Only a coordinator holding the
+session lease may claim and acknowledge events that can mutate conversation
+state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+import boto3
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+
+
+SCHEMA_VERSION = 1
+PENDING = "pending"
+PROCESSING = "processing"
+PROCESSED = "processed"
+DEAD = "dead"
+TERMINAL_TTL_DAYS = 30
+SESSION_EVENT_TTL_DAYS = 7
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _session_key(user_id: str, session_id: str) -> str:
+    return f"USER#{user_id}#SESSION#{session_id}"
+
+
+def _event_key(event_id: str) -> str:
+    return f"INBOX#{event_id}"
+
+
+def _session_event_key(event_id: str) -> str:
+    return f"OUTBOX#{event_id}"
+
+
+def _error_code(error: Exception) -> str:
+    response = getattr(error, "response", {})
+    return response.get("Error", {}).get("Code", "")
+
+
+def _is_condition_failure(error: Exception) -> bool:
+    code = _error_code(error)
+    if code == "ConditionalCheckFailedException":
+        return True
+    if code != "TransactionCanceledException":
+        return False
+    reasons = getattr(error, "response", {}).get("CancellationReasons", [])
+    return any(reason.get("Code") == "ConditionalCheckFailed" for reason in reasons)
+
+
+@dataclass(frozen=True)
+class MailboxLease:
+    owner: str
+    epoch: int
+    expires_at: int
+
+
+class SessionDeletedError(RuntimeError):
+    """Mailbox work cannot be added to a tombstoned session."""
+
+
+@dataclass
+class MailboxEvent:
+    event_id: str
+    event_type: str
+    session_id: str
+    user_id: str
+    created_at: str
+    available_at: str
+    source: Dict[str, str]
+    correlation: Dict[str, str] = field(default_factory=dict)
+    payload: Dict[str, Any] = field(default_factory=dict)
+    payload_ref: Optional[Dict[str, str]] = None
+    visibility: str = "internal"
+    schema_version: int = SCHEMA_VERSION
+    status: str = PENDING
+    attempts: int = 0
+    lease_owner: Optional[str] = None
+    lease_epoch: Optional[int] = None
+    event_lease_until: Optional[int] = None
+    last_error: Optional[str] = None
+    processed_at: Optional[str] = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        event_id: str,
+        event_type: str,
+        session_id: str,
+        user_id: str,
+        source_type: str,
+        source_id: str,
+        correlation: Optional[Dict[str, str]] = None,
+        payload: Optional[Dict[str, Any]] = None,
+        payload_ref: Optional[Dict[str, str]] = None,
+        visibility: str = "internal",
+        now: Optional[datetime] = None,
+    ) -> "MailboxEvent":
+        timestamp = _iso(now or utc_now())
+        return cls(
+            event_id=event_id,
+            event_type=event_type,
+            session_id=session_id,
+            user_id=user_id,
+            created_at=timestamp,
+            available_at=timestamp,
+            source={"type": source_type, "id": source_id},
+            correlation=dict(correlation or {}),
+            payload=dict(payload or {}),
+            payload_ref=dict(payload_ref) if payload_ref else None,
+            visibility=visibility,
+        )
+
+    def to_record(self) -> Dict[str, Any]:
+        record = {
+            "sessionKey": _session_key(self.user_id, self.session_id),
+            "recordKey": _event_key(self.event_id),
+            "recordType": "INBOX",
+            "schemaVersion": self.schema_version,
+            "eventId": self.event_id,
+            "eventType": self.event_type,
+            "sessionId": self.session_id,
+            "userId": self.user_id,
+            "createdAt": self.created_at,
+            "availableAt": self.available_at,
+            "source": self.source,
+            "correlation": self.correlation,
+            "payload": self.payload,
+            "payloadRef": self.payload_ref,
+            "visibility": self.visibility,
+            "status": self.status,
+            "attempts": self.attempts,
+            "leaseOwner": self.lease_owner,
+            "leaseEpoch": self.lease_epoch,
+            "eventLeaseUntil": self.event_lease_until,
+            "lastError": self.last_error,
+            "processedAt": self.processed_at,
+        }
+        return {key: value for key, value in record.items() if value is not None}
+
+    @classmethod
+    def from_record(cls, record: Dict[str, Any]) -> "MailboxEvent":
+        return cls(
+            schema_version=int(record.get("schemaVersion", SCHEMA_VERSION)),
+            event_id=record["eventId"],
+            event_type=record["eventType"],
+            session_id=record["sessionId"],
+            user_id=record["userId"],
+            created_at=record["createdAt"],
+            available_at=record["availableAt"],
+            source=record["source"],
+            correlation=record.get("correlation", {}),
+            payload=record.get("payload", {}),
+            payload_ref=record.get("payloadRef"),
+            visibility=record.get("visibility", "internal"),
+            status=record.get("status", PENDING),
+            attempts=int(record.get("attempts", 0)),
+            lease_owner=record.get("leaseOwner"),
+            lease_epoch=(
+                int(record["leaseEpoch"]) if record.get("leaseEpoch") is not None else None
+            ),
+            event_lease_until=(
+                int(record["eventLeaseUntil"])
+                if record.get("eventLeaseUntil") is not None
+                else None
+            ),
+            last_error=record.get("lastError"),
+            processed_at=record.get("processedAt"),
+        )
+
+
+@dataclass(frozen=True)
+class SessionEvent:
+    event_id: str
+    event_type: str
+    session_id: str
+    user_id: str
+    created_at: str
+    origin_event_id: str
+    correlation: Dict[str, str] = field(default_factory=dict)
+    payload: Dict[str, Any] = field(default_factory=dict)
+    schema_version: int = SCHEMA_VERSION
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        event_id: str,
+        event_type: str,
+        session_id: str,
+        user_id: str,
+        origin_event_id: str,
+        correlation: Optional[Dict[str, str]] = None,
+        payload: Optional[Dict[str, Any]] = None,
+        now: Optional[datetime] = None,
+    ) -> "SessionEvent":
+        return cls(
+            event_id=event_id,
+            event_type=event_type,
+            session_id=session_id,
+            user_id=user_id,
+            created_at=_iso(now or utc_now()),
+            origin_event_id=origin_event_id,
+            correlation=dict(correlation or {}),
+            payload=dict(payload or {}),
+        )
+
+    def to_record(self, *, ttl: Optional[int] = None) -> Dict[str, Any]:
+        record = {
+            "sessionKey": _session_key(self.user_id, self.session_id),
+            "recordKey": _session_event_key(self.event_id),
+            "recordType": "OUTBOX",
+            "schemaVersion": self.schema_version,
+            "eventId": self.event_id,
+            "eventType": self.event_type,
+            "sessionId": self.session_id,
+            "userId": self.user_id,
+            "createdAt": self.created_at,
+            "originEventId": self.origin_event_id,
+            "correlation": self.correlation,
+            "payload": self.payload,
+            "ttl": ttl,
+        }
+        return {key: value for key, value in record.items() if value is not None}
+
+    @classmethod
+    def from_record(cls, record: Dict[str, Any]) -> "SessionEvent":
+        return cls(
+            schema_version=int(record.get("schemaVersion", SCHEMA_VERSION)),
+            event_id=record["eventId"],
+            event_type=record["eventType"],
+            session_id=record["sessionId"],
+            user_id=record["userId"],
+            created_at=record["createdAt"],
+            origin_event_id=record["originEventId"],
+            correlation=record.get("correlation", {}),
+            payload=record.get("payload", {}),
+        )
+
+
+class MailboxRepository(ABC):
+    @abstractmethod
+    def enqueue(self, event: MailboxEvent) -> bool:
+        """Insert once. Return False when the event already exists."""
+
+    @abstractmethod
+    def tombstone_session(
+        self,
+        user_id: str,
+        session_id: str,
+        *,
+        now: Optional[datetime] = None,
+    ) -> None:
+        """Block new work and fence any active coordinator."""
+
+    @abstractmethod
+    def is_session_deleted(self, user_id: str, session_id: str) -> bool:
+        """Return whether the orchestration state has a delete tombstone."""
+
+    @abstractmethod
+    def acquire_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        owner: str,
+        *,
+        lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxLease]:
+        """Acquire the session writer lease, or return None when held elsewhere."""
+
+    @abstractmethod
+    def release_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+    ) -> bool:
+        """Release only when owner and fencing epoch still match."""
+
+    @abstractmethod
+    def renew_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+        *,
+        lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxLease]:
+        """Extend a live lease without changing its fencing epoch."""
+
+    @abstractmethod
+    def claim_next(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+        *,
+        event_lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxEvent]:
+        """Claim the oldest eligible event under the current session lease."""
+
+    @abstractmethod
+    def acknowledge(
+        self,
+        event: MailboxEvent,
+        lease: MailboxLease,
+        *,
+        session_events: Sequence[SessionEvent] = (),
+        now: Optional[datetime] = None,
+    ) -> bool:
+        """Atomically mark processed and publish deterministic UI projections."""
+
+    @abstractmethod
+    def retry(
+        self,
+        event: MailboxEvent,
+        lease: MailboxLease,
+        error: str,
+        *,
+        delay_seconds: int,
+        max_attempts: int,
+        now: Optional[datetime] = None,
+    ) -> str:
+        """Release for retry or move to dead-letter. Return the new status."""
+
+    @abstractmethod
+    def list_events(self, user_id: str, session_id: str) -> list[MailboxEvent]:
+        """List mailbox events in deterministic creation order."""
+
+    @abstractmethod
+    def list_session_events(
+        self,
+        user_id: str,
+        session_id: str,
+    ) -> list[SessionEvent]:
+        """List durable frontend projections in deterministic creation order."""
+
+
+class DynamoDBMailboxRepository(MailboxRepository):
+    def __init__(
+        self,
+        table_name: str,
+        *,
+        region_name: str = "us-west-2",
+        client: Any = None,
+    ):
+        self.table_name = table_name
+        self.client = client or boto3.client("dynamodb", region_name=region_name)
+        self._serializer = TypeSerializer()
+        self._deserializer = TypeDeserializer()
+
+    def _serialize(self, value: Dict[str, Any]) -> Dict[str, Any]:
+        # DynamoDB rejects Python floats. A JSON round trip converts them to
+        # Decimal while also proving the envelope is JSON-compatible.
+        normalized = json.loads(json.dumps(value), parse_float=Decimal)
+        return {key: self._serializer.serialize(item) for key, item in normalized.items()}
+
+    def _deserialize(self, value: Dict[str, Any]) -> Dict[str, Any]:
+        raw = {key: self._deserializer.deserialize(item) for key, item in value.items()}
+
+        def normalize(item: Any) -> Any:
+            if isinstance(item, Decimal):
+                return int(item) if item == item.to_integral_value() else float(item)
+            if isinstance(item, dict):
+                return {key: normalize(child) for key, child in item.items()}
+            if isinstance(item, list):
+                return [normalize(child) for child in item]
+            return item
+
+        return normalize(raw)
+
+    def _key(self, user_id: str, session_id: str, record_key: str) -> Dict[str, Any]:
+        return self._serialize({
+            "sessionKey": _session_key(user_id, session_id),
+            "recordKey": record_key,
+        })
+
+    def enqueue(self, event: MailboxEvent) -> bool:
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "ConditionCheck": {
+                            "TableName": self.table_name,
+                            "Key": self._key(
+                                event.user_id,
+                                event.session_id,
+                                "STATE",
+                            ),
+                            "ConditionExpression": "attribute_not_exists(deletedAt)",
+                        }
+                    },
+                    {
+                        "Put": {
+                            "TableName": self.table_name,
+                            "Item": self._serialize(event.to_record()),
+                            "ConditionExpression": "attribute_not_exists(recordKey)",
+                        }
+                    },
+                ]
+            )
+            return True
+        except Exception as error:
+            if _is_condition_failure(error):
+                if self.is_session_deleted(event.user_id, event.session_id):
+                    raise SessionDeletedError(
+                        f"Session {event.session_id} has been deleted"
+                    ) from error
+                return False
+            raise
+
+    def tombstone_session(
+        self,
+        user_id: str,
+        session_id: str,
+        *,
+        now: Optional[datetime] = None,
+    ) -> None:
+        current = now or utc_now()
+        self.client.update_item(
+            TableName=self.table_name,
+            Key=self._key(user_id, session_id, "STATE"),
+            UpdateExpression=(
+                "SET deletedAt = :deleted, updatedAt = :deleted, "
+                "#status = :status "
+                "REMOVE leaseOwner, leaseUntil"
+            ),
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues=self._serialize({
+                ":deleted": _iso(current),
+                ":status": "deleted",
+            }),
+        )
+
+    def is_session_deleted(self, user_id: str, session_id: str) -> bool:
+        response = self.client.get_item(
+            TableName=self.table_name,
+            Key=self._key(user_id, session_id, "STATE"),
+            ConsistentRead=True,
+            ProjectionExpression="deletedAt",
+        )
+        return bool(response.get("Item"))
+
+    def acquire_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        owner: str,
+        *,
+        lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxLease]:
+        current = now or utc_now()
+        now_epoch = int(current.timestamp())
+        expires_at = now_epoch + lease_seconds
+        try:
+            response = self.client.update_item(
+                TableName=self.table_name,
+                Key=self._key(user_id, session_id, "STATE"),
+                UpdateExpression=(
+                    "SET leaseOwner = :owner, leaseUntil = :until, "
+                    "leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, "
+                    "#version = if_not_exists(#version, :zero) + :one, "
+                    "updatedAt = :updated"
+                ),
+                ConditionExpression=(
+                    "attribute_not_exists(deletedAt) AND ("
+                    "attribute_not_exists(leaseUntil) OR leaseUntil < :now "
+                    "OR leaseOwner = :owner)"
+                ),
+                ExpressionAttributeNames={"#version": "version"},
+                ExpressionAttributeValues=self._serialize({
+                    ":owner": owner,
+                    ":until": expires_at,
+                    ":zero": 0,
+                    ":one": 1,
+                    ":now": now_epoch,
+                    ":updated": _iso(current),
+                }),
+                ReturnValues="ALL_NEW",
+            )
+        except Exception as error:
+            if _error_code(error) == "ConditionalCheckFailedException":
+                return None
+            raise
+        attributes = self._deserialize(response["Attributes"])
+        return MailboxLease(
+            owner=owner,
+            epoch=int(attributes["leaseEpoch"]),
+            expires_at=expires_at,
+        )
+
+    def release_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+    ) -> bool:
+        try:
+            self.client.update_item(
+                TableName=self.table_name,
+                Key=self._key(user_id, session_id, "STATE"),
+                UpdateExpression="REMOVE leaseOwner, leaseUntil",
+                ConditionExpression="leaseOwner = :owner AND leaseEpoch = :epoch",
+                ExpressionAttributeValues=self._serialize({
+                    ":owner": lease.owner,
+                    ":epoch": lease.epoch,
+                }),
+            )
+            return True
+        except Exception as error:
+            if _error_code(error) == "ConditionalCheckFailedException":
+                return False
+            raise
+
+    def renew_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+        *,
+        lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxLease]:
+        current = now or utc_now()
+        now_epoch = int(current.timestamp())
+        expires_at = now_epoch + lease_seconds
+        try:
+            self.client.update_item(
+                TableName=self.table_name,
+                Key=self._key(user_id, session_id, "STATE"),
+                UpdateExpression="SET leaseUntil = :until, updatedAt = :updated",
+                ConditionExpression=(
+                    "leaseOwner = :owner AND leaseEpoch = :epoch "
+                    "AND leaseUntil >= :now"
+                ),
+                ExpressionAttributeValues=self._serialize({
+                    ":owner": lease.owner,
+                    ":epoch": lease.epoch,
+                    ":now": now_epoch,
+                    ":until": expires_at,
+                    ":updated": _iso(current),
+                }),
+            )
+            return MailboxLease(
+                owner=lease.owner,
+                epoch=lease.epoch,
+                expires_at=expires_at,
+            )
+        except Exception as error:
+            if _is_condition_failure(error):
+                return None
+            raise
+
+    def list_events(self, user_id: str, session_id: str) -> list[MailboxEvent]:
+        items: list[Dict[str, Any]] = []
+        start_key = None
+        while True:
+            kwargs: Dict[str, Any] = {
+                "TableName": self.table_name,
+                "KeyConditionExpression": (
+                    "sessionKey = :session AND begins_with(recordKey, :prefix)"
+                ),
+                "ExpressionAttributeValues": self._serialize({
+                    ":session": _session_key(user_id, session_id),
+                    ":prefix": "INBOX#",
+                }),
+                "ConsistentRead": True,
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            response = self.client.query(**kwargs)
+            items.extend(self._deserialize(item) for item in response.get("Items", []))
+            start_key = response.get("LastEvaluatedKey")
+            if not start_key:
+                break
+        events = [MailboxEvent.from_record(item) for item in items]
+        return sorted(events, key=lambda item: (item.created_at, item.event_id))
+
+    def list_session_events(
+        self,
+        user_id: str,
+        session_id: str,
+    ) -> list[SessionEvent]:
+        items: list[Dict[str, Any]] = []
+        start_key = None
+        while True:
+            kwargs: Dict[str, Any] = {
+                "TableName": self.table_name,
+                "KeyConditionExpression": (
+                    "sessionKey = :session AND begins_with(recordKey, :prefix)"
+                ),
+                "ExpressionAttributeValues": self._serialize({
+                    ":session": _session_key(user_id, session_id),
+                    ":prefix": "OUTBOX#",
+                }),
+                "ConsistentRead": True,
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            response = self.client.query(**kwargs)
+            items.extend(self._deserialize(item) for item in response.get("Items", []))
+            start_key = response.get("LastEvaluatedKey")
+            if not start_key:
+                break
+        events = [SessionEvent.from_record(item) for item in items]
+        return sorted(events, key=lambda item: (item.created_at, item.event_id))
+
+    def claim_next(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+        *,
+        event_lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxEvent]:
+        current = now or utc_now()
+        now_epoch = int(current.timestamp())
+        now_iso = _iso(current)
+        candidates = [
+            event
+            for event in self.list_events(user_id, session_id)
+            if (
+                event.status == PENDING and event.available_at <= now_iso
+            ) or (
+                event.status == PROCESSING
+                and (event.event_lease_until or 0) < now_epoch
+            )
+        ]
+        for event in candidates:
+            try:
+                self.client.transact_write_items(
+                    TransactItems=[
+                        {
+                            "ConditionCheck": {
+                                "TableName": self.table_name,
+                                "Key": self._key(user_id, session_id, "STATE"),
+                                "ConditionExpression": (
+                                    "leaseOwner = :owner AND leaseEpoch = :epoch "
+                                    "AND leaseUntil >= :now_epoch"
+                                ),
+                                "ExpressionAttributeValues": self._serialize({
+                                    ":owner": lease.owner,
+                                    ":epoch": lease.epoch,
+                                    ":now_epoch": now_epoch,
+                                }),
+                            }
+                        },
+                        {
+                            "Update": {
+                                "TableName": self.table_name,
+                                "Key": self._key(
+                                    user_id,
+                                    session_id,
+                                    _event_key(event.event_id),
+                                ),
+                                "UpdateExpression": (
+                                    "SET #status = :processing, leaseOwner = :owner, "
+                                    "leaseEpoch = :epoch, eventLeaseUntil = :until, "
+                                    "attempts = if_not_exists(attempts, :zero) + :one, "
+                                    "updatedAt = :updated"
+                                ),
+                                "ConditionExpression": (
+                                    "(#status = :pending AND availableAt <= :now_iso) OR "
+                                    "(#status = :processing AND eventLeaseUntil < :now_epoch)"
+                                ),
+                                "ExpressionAttributeNames": {"#status": "status"},
+                                "ExpressionAttributeValues": self._serialize({
+                                    ":processing": PROCESSING,
+                                    ":pending": PENDING,
+                                    ":owner": lease.owner,
+                                    ":epoch": lease.epoch,
+                                    ":until": now_epoch + event_lease_seconds,
+                                    ":zero": 0,
+                                    ":one": 1,
+                                    ":updated": now_iso,
+                                    ":now_iso": now_iso,
+                                    ":now_epoch": now_epoch,
+                                }),
+                            }
+                        },
+                    ]
+                )
+                return replace(
+                    event,
+                    status=PROCESSING,
+                    attempts=event.attempts + 1,
+                    lease_owner=lease.owner,
+                    lease_epoch=lease.epoch,
+                    event_lease_until=now_epoch + event_lease_seconds,
+                )
+            except Exception as error:
+                if not _is_condition_failure(error):
+                    raise
+        return None
+
+    def acknowledge(
+        self,
+        event: MailboxEvent,
+        lease: MailboxLease,
+        *,
+        session_events: Sequence[SessionEvent] = (),
+        now: Optional[datetime] = None,
+    ) -> bool:
+        current = now or utc_now()
+        now_epoch = int(current.timestamp())
+        if len(session_events) > 98:
+            raise ValueError("A mailbox acknowledgement supports at most 98 session events")
+        projection_ttl = int(
+            (current + timedelta(days=SESSION_EVENT_TTL_DAYS)).timestamp()
+        )
+        projections = [
+            {
+                "Put": {
+                    "TableName": self.table_name,
+                    "Item": self._serialize(item.to_record(ttl=projection_ttl)),
+                }
+            }
+            for item in session_events
+        ]
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    self._lease_condition(event.user_id, event.session_id, lease, now_epoch),
+                    {
+                        "Update": {
+                            "TableName": self.table_name,
+                            "Key": self._key(
+                                event.user_id,
+                                event.session_id,
+                                _event_key(event.event_id),
+                            ),
+                            "UpdateExpression": (
+                                "SET #status = :processed, processedAt = :processed_at, "
+                                "updatedAt = :processed_at, #ttl = :ttl "
+                                "REMOVE leaseOwner, leaseEpoch, eventLeaseUntil, lastError"
+                            ),
+                            "ConditionExpression": (
+                                "#status = :processing AND leaseOwner = :owner "
+                                "AND leaseEpoch = :epoch"
+                            ),
+                            "ExpressionAttributeNames": {
+                                "#status": "status",
+                                "#ttl": "ttl",
+                            },
+                            "ExpressionAttributeValues": self._serialize({
+                                ":processed": PROCESSED,
+                                ":processing": PROCESSING,
+                                ":processed_at": _iso(current),
+                                ":ttl": int(
+                                    (
+                                        current
+                                        + timedelta(days=TERMINAL_TTL_DAYS)
+                                    ).timestamp()
+                                ),
+                                ":owner": lease.owner,
+                                ":epoch": lease.epoch,
+                            }),
+                        }
+                    },
+                    *projections,
+                ]
+            )
+            return True
+        except Exception as error:
+            if _is_condition_failure(error):
+                return False
+            raise
+
+    def retry(
+        self,
+        event: MailboxEvent,
+        lease: MailboxLease,
+        error: str,
+        *,
+        delay_seconds: int,
+        max_attempts: int,
+        now: Optional[datetime] = None,
+    ) -> str:
+        current = now or utc_now()
+        status = DEAD if event.attempts >= max_attempts else PENDING
+        values: Dict[str, Any] = {
+            ":next_status": status,
+            ":processing": PROCESSING,
+            ":available": _iso(current + timedelta(seconds=delay_seconds)),
+            ":updated": _iso(current),
+            ":error": error[:2000],
+            ":owner": lease.owner,
+            ":epoch": lease.epoch,
+        }
+        update = (
+            "SET #status = :next_status, availableAt = :available, "
+            "updatedAt = :updated, lastError = :error "
+        )
+        if status == DEAD:
+            update += ", #ttl = :ttl "
+            values[":ttl"] = int(
+                (current + timedelta(days=TERMINAL_TTL_DAYS)).timestamp()
+            )
+        update += "REMOVE leaseOwner, leaseEpoch, eventLeaseUntil"
+        attribute_names = {"#status": "status"}
+        if status == DEAD:
+            attribute_names["#ttl"] = "ttl"
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    self._lease_condition(
+                        event.user_id,
+                        event.session_id,
+                        lease,
+                        int(current.timestamp()),
+                    ),
+                    {
+                        "Update": {
+                            "TableName": self.table_name,
+                            "Key": self._key(
+                                event.user_id,
+                                event.session_id,
+                                _event_key(event.event_id),
+                            ),
+                            "UpdateExpression": update,
+                            "ConditionExpression": (
+                                "#status = :processing AND leaseOwner = :owner "
+                                "AND leaseEpoch = :epoch"
+                            ),
+                            "ExpressionAttributeNames": attribute_names,
+                            "ExpressionAttributeValues": self._serialize(values),
+                        }
+                    },
+                ]
+            )
+            return status
+        except Exception as exc:
+            if _is_condition_failure(exc):
+                return event.status
+            raise
+
+    def _lease_condition(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+        now_epoch: int,
+    ) -> Dict[str, Any]:
+        return {
+            "ConditionCheck": {
+                "TableName": self.table_name,
+                "Key": self._key(user_id, session_id, "STATE"),
+                "ConditionExpression": (
+                    "leaseOwner = :owner AND leaseEpoch = :epoch "
+                    "AND leaseUntil >= :now"
+                ),
+                "ExpressionAttributeValues": self._serialize({
+                    ":owner": lease.owner,
+                    ":epoch": lease.epoch,
+                    ":now": now_epoch,
+                }),
+            }
+        }
+
+
+class FileMailboxRepository(MailboxRepository):
+    """Atomic local-development store with the same fencing semantics."""
+
+    def __init__(self, storage_dir: Path):
+        self.storage_dir = Path(storage_dir)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    def _path(self, user_id: str, session_id: str) -> Path:
+        digest = sha256(_session_key(user_id, session_id).encode("utf-8")).hexdigest()
+        return self.storage_dir / f"{digest}.json"
+
+    def _load(self, user_id: str, session_id: str) -> Dict[str, Any]:
+        path = self._path(user_id, session_id)
+        if not path.exists():
+            return {
+                "state": {"leaseEpoch": 0, "version": 0},
+                "events": {},
+                "sessionEvents": {},
+            }
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data.setdefault("sessionEvents", {})
+        return data
+
+    def _save(self, user_id: str, session_id: str, data: Dict[str, Any]) -> None:
+        path = self._path(user_id, session_id)
+        fd, temp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, ensure_ascii=False, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, path)
+        finally:
+            if os.path.exists(temp_name):
+                os.unlink(temp_name)
+
+    def enqueue(self, event: MailboxEvent) -> bool:
+        with self._lock:
+            data = self._load(event.user_id, event.session_id)
+            if data["state"].get("deletedAt"):
+                raise SessionDeletedError(
+                    f"Session {event.session_id} has been deleted"
+                )
+            if event.event_id in data["events"]:
+                return False
+            data["events"][event.event_id] = event.to_record()
+            self._save(event.user_id, event.session_id, data)
+            return True
+
+    def tombstone_session(
+        self,
+        user_id: str,
+        session_id: str,
+        *,
+        now: Optional[datetime] = None,
+    ) -> None:
+        current = now or utc_now()
+        with self._lock:
+            data = self._load(user_id, session_id)
+            data["state"].update({
+                "deletedAt": _iso(current),
+                "updatedAt": _iso(current),
+                "status": "deleted",
+            })
+            data["state"].pop("leaseOwner", None)
+            data["state"].pop("leaseUntil", None)
+            self._save(user_id, session_id, data)
+
+    def is_session_deleted(self, user_id: str, session_id: str) -> bool:
+        with self._lock:
+            return bool(
+                self._load(user_id, session_id)["state"].get("deletedAt")
+            )
+
+    def acquire_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        owner: str,
+        *,
+        lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxLease]:
+        current = now or utc_now()
+        now_epoch = int(current.timestamp())
+        with self._lock:
+            data = self._load(user_id, session_id)
+            state = data["state"]
+            if state.get("deletedAt"):
+                return None
+            if (
+                state.get("leaseUntil", 0) >= now_epoch
+                and state.get("leaseOwner") != owner
+            ):
+                return None
+            state["leaseOwner"] = owner
+            state["leaseUntil"] = now_epoch + lease_seconds
+            state["leaseEpoch"] = int(state.get("leaseEpoch", 0)) + 1
+            state["version"] = int(state.get("version", 0)) + 1
+            state["updatedAt"] = _iso(current)
+            self._save(user_id, session_id, data)
+            return MailboxLease(
+                owner=owner,
+                epoch=state["leaseEpoch"],
+                expires_at=state["leaseUntil"],
+            )
+
+    def release_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+    ) -> bool:
+        with self._lock:
+            data = self._load(user_id, session_id)
+            state = data["state"]
+            if (
+                state.get("leaseOwner") != lease.owner
+                or state.get("leaseEpoch") != lease.epoch
+            ):
+                return False
+            state.pop("leaseOwner", None)
+            state.pop("leaseUntil", None)
+            self._save(user_id, session_id, data)
+            return True
+
+    def renew_lease(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+        *,
+        lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxLease]:
+        current = now or utc_now()
+        now_epoch = int(current.timestamp())
+        with self._lock:
+            data = self._load(user_id, session_id)
+            state = data["state"]
+            if (
+                state.get("leaseOwner") != lease.owner
+                or state.get("leaseEpoch") != lease.epoch
+                or state.get("leaseUntil", 0) < now_epoch
+            ):
+                return None
+            state["leaseUntil"] = now_epoch + lease_seconds
+            state["updatedAt"] = _iso(current)
+            self._save(user_id, session_id, data)
+            return MailboxLease(
+                owner=lease.owner,
+                epoch=lease.epoch,
+                expires_at=state["leaseUntil"],
+            )
+
+    def list_events(self, user_id: str, session_id: str) -> list[MailboxEvent]:
+        with self._lock:
+            data = self._load(user_id, session_id)
+            events = [
+                MailboxEvent.from_record(record)
+                for record in data["events"].values()
+            ]
+        return sorted(events, key=lambda item: (item.created_at, item.event_id))
+
+    def list_session_events(
+        self,
+        user_id: str,
+        session_id: str,
+    ) -> list[SessionEvent]:
+        with self._lock:
+            data = self._load(user_id, session_id)
+            events = [
+                SessionEvent.from_record(record)
+                for record in data["sessionEvents"].values()
+            ]
+        return sorted(events, key=lambda item: (item.created_at, item.event_id))
+
+    def claim_next(
+        self,
+        user_id: str,
+        session_id: str,
+        lease: MailboxLease,
+        *,
+        event_lease_seconds: int,
+        now: Optional[datetime] = None,
+    ) -> Optional[MailboxEvent]:
+        current = now or utc_now()
+        now_epoch = int(current.timestamp())
+        now_iso = _iso(current)
+        with self._lock:
+            data = self._load(user_id, session_id)
+            state = data["state"]
+            if (
+                state.get("leaseOwner") != lease.owner
+                or state.get("leaseEpoch") != lease.epoch
+                or state.get("leaseUntil", 0) < now_epoch
+            ):
+                return None
+            records = sorted(
+                data["events"].values(),
+                key=lambda item: (item["createdAt"], item["eventId"]),
+            )
+            for record in records:
+                eligible = (
+                    record["status"] == PENDING
+                    and record["availableAt"] <= now_iso
+                ) or (
+                    record["status"] == PROCESSING
+                    and record.get("eventLeaseUntil", 0) < now_epoch
+                )
+                if not eligible:
+                    continue
+                record.update({
+                    "status": PROCESSING,
+                    "leaseOwner": lease.owner,
+                    "leaseEpoch": lease.epoch,
+                    "eventLeaseUntil": now_epoch + event_lease_seconds,
+                    "attempts": int(record.get("attempts", 0)) + 1,
+                    "updatedAt": now_iso,
+                })
+                self._save(user_id, session_id, data)
+                return MailboxEvent.from_record(record)
+        return None
+
+    def acknowledge(
+        self,
+        event: MailboxEvent,
+        lease: MailboxLease,
+        *,
+        session_events: Sequence[SessionEvent] = (),
+        now: Optional[datetime] = None,
+    ) -> bool:
+        current = now or utc_now()
+        with self._lock:
+            data = self._load(event.user_id, event.session_id)
+            record = data["events"].get(event.event_id)
+            if not self._owns(
+                record,
+                data["state"],
+                lease,
+                now_epoch=int(current.timestamp()),
+            ):
+                return False
+            record.update({
+                "status": PROCESSED,
+                "processedAt": _iso(current),
+                "updatedAt": _iso(current),
+                "ttl": int(
+                    (current + timedelta(days=TERMINAL_TTL_DAYS)).timestamp()
+                ),
+            })
+            self._clear_event_lease(record)
+            projection_ttl = int(
+                (current + timedelta(days=SESSION_EVENT_TTL_DAYS)).timestamp()
+            )
+            for item in session_events:
+                data["sessionEvents"][item.event_id] = item.to_record(
+                    ttl=projection_ttl
+                )
+            self._save(event.user_id, event.session_id, data)
+            return True
+
+    def retry(
+        self,
+        event: MailboxEvent,
+        lease: MailboxLease,
+        error: str,
+        *,
+        delay_seconds: int,
+        max_attempts: int,
+        now: Optional[datetime] = None,
+    ) -> str:
+        current = now or utc_now()
+        with self._lock:
+            data = self._load(event.user_id, event.session_id)
+            record = data["events"].get(event.event_id)
+            if not self._owns(
+                record,
+                data["state"],
+                lease,
+                now_epoch=int(current.timestamp()),
+            ):
+                return event.status
+            status = DEAD if int(record.get("attempts", 0)) >= max_attempts else PENDING
+            record.update({
+                "status": status,
+                "availableAt": _iso(current + timedelta(seconds=delay_seconds)),
+                "updatedAt": _iso(current),
+                "lastError": error[:2000],
+            })
+            if status == DEAD:
+                record["ttl"] = int(
+                    (current + timedelta(days=TERMINAL_TTL_DAYS)).timestamp()
+                )
+            self._clear_event_lease(record)
+            self._save(event.user_id, event.session_id, data)
+            return status
+
+    @staticmethod
+    def _owns(
+        record: Optional[Dict[str, Any]],
+        state: Dict[str, Any],
+        lease: MailboxLease,
+        *,
+        now_epoch: int,
+    ) -> bool:
+        return bool(
+            record
+            and record.get("status") == PROCESSING
+            and record.get("leaseOwner") == lease.owner
+            and record.get("leaseEpoch") == lease.epoch
+            and not state.get("deletedAt")
+            and state.get("leaseOwner") == lease.owner
+            and state.get("leaseEpoch") == lease.epoch
+            and state.get("leaseUntil", 0) >= now_epoch
+        )
+
+    @staticmethod
+    def _clear_event_lease(record: Dict[str, Any]) -> None:
+        record.pop("leaseOwner", None)
+        record.pop("leaseEpoch", None)
+        record.pop("eventLeaseUntil", None)
+
+
+def create_mailbox_repository() -> MailboxRepository:
+    table_name = os.environ.get("SESSION_ORCHESTRATION_TABLE")
+    if table_name:
+        return DynamoDBMailboxRepository(
+            table_name,
+            region_name=os.environ.get("AWS_REGION", "us-west-2"),
+        )
+
+    from agent.factory.session_manager_factory import get_sessions_dir
+
+    return FileMailboxRepository(get_sessions_dir() / "mailbox")
+
+
+_repository_instance: Optional[MailboxRepository] = None
+_repository_lock = threading.Lock()
+
+
+def get_mailbox_repository() -> MailboxRepository:
+    global _repository_instance
+    if _repository_instance is None:
+        with _repository_lock:
+            if _repository_instance is None:
+                _repository_instance = create_mailbox_repository()
+    return _repository_instance
+
+
+def reset_mailbox_repository() -> None:
+    """Reset the process cache for tests or configuration reloads."""
+    global _repository_instance
+    with _repository_lock:
+        _repository_instance = None

--- a/chatbot-app/agentcore/src/agent/mailbox_runtime.py
+++ b/chatbot-app/agentcore/src/agent/mailbox_runtime.py
@@ -1,0 +1,81 @@
+"""Runtime bridge between durable mailbox storage and the FastAPI event loop."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from typing import Dict, Optional
+
+from agent.mailbox import get_mailbox_repository
+from agent.session_coordinator import (
+    DrainResult,
+    MailboxEventHandler,
+    SessionCoordinator,
+)
+
+
+_runtime_loop: Optional[asyncio.AbstractEventLoop] = None
+_handlers: Dict[str, MailboxEventHandler] = {}
+_runtime_lock = threading.Lock()
+
+
+def mailbox_delivery_enabled() -> bool:
+    return os.environ.get("SESSION_MAILBOX_DELIVERY_ENABLED", "").lower() == "true"
+
+
+def register_mailbox_runtime(
+    loop: asyncio.AbstractEventLoop,
+    handlers: Dict[str, MailboxEventHandler],
+) -> None:
+    global _runtime_loop, _handlers
+    with _runtime_lock:
+        _runtime_loop = loop
+        _handlers = dict(handlers)
+
+
+def clear_mailbox_runtime() -> None:
+    global _runtime_loop, _handlers
+    with _runtime_lock:
+        _runtime_loop = None
+        _handlers = {}
+
+
+async def drain_session_mailbox(
+    user_id: str,
+    session_id: str,
+    *,
+    owner: Optional[str] = None,
+    max_events: int = 20,
+) -> DrainResult:
+    with _runtime_lock:
+        handlers = dict(_handlers)
+    coordinator = SessionCoordinator(get_mailbox_repository(), handlers)
+    return await coordinator.drain(
+        user_id,
+        session_id,
+        owner=owner,
+        max_events=max_events,
+    )
+
+
+async def notify_session_mailbox(user_id: str, session_id: str) -> DrainResult:
+    """Request a drain from any worker thread/event loop."""
+    with _runtime_lock:
+        loop = _runtime_loop
+    if loop is None or loop.is_closed():
+        raise RuntimeError("Session mailbox runtime is not available")
+
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+
+    if current_loop is loop:
+        return await drain_session_mailbox(user_id, session_id)
+
+    future = asyncio.run_coroutine_threadsafe(
+        drain_session_mailbox(user_id, session_id),
+        loop,
+    )
+    return await asyncio.wrap_future(future)

--- a/chatbot-app/agentcore/src/agent/research_jobs.py
+++ b/chatbot-app/agentcore/src/agent/research_jobs.py
@@ -48,6 +48,14 @@ def _job_sk(session_id: str, job_id: str) -> str:
     return f"RESEARCH_JOB#{session_id}#{job_id}"
 
 
+def _orchestration_session_key(user_id: str, session_id: str) -> str:
+    return f"USER#{user_id}#SESSION#{session_id}"
+
+
+def _orchestration_job_key(job_id: str) -> str:
+    return f"JOB#{job_id}"
+
+
 def _local_job_dir(session_id: str) -> Path:
     path = get_sessions_dir() / f"session_{_safe_component(session_id)}" / "research_jobs"
     path.mkdir(parents=True, exist_ok=True)
@@ -74,14 +82,27 @@ def _is_cloud_storage() -> bool:
 
 def _save_job(record: Dict[str, Any]) -> None:
     if _is_cloud_storage():
-        table_name = os.environ["DYNAMODB_USERS_TABLE"]
         region = os.environ.get("AWS_REGION", "us-west-2")
-        item = {
-            **record,
-            "userId": record["userId"],
-            "sk": _job_sk(record["sessionId"], record["jobId"]),
-            "recordType": "RESEARCH_JOB",
-        }
+        orchestration_table = os.environ.get("SESSION_ORCHESTRATION_TABLE")
+        if orchestration_table:
+            table_name = orchestration_table
+            item = {
+                **record,
+                "sessionKey": _orchestration_session_key(
+                    record["userId"],
+                    record["sessionId"],
+                ),
+                "recordKey": _orchestration_job_key(record["jobId"]),
+                "recordType": "JOB",
+            }
+        else:
+            table_name = os.environ["DYNAMODB_USERS_TABLE"]
+            item = {
+                **record,
+                "userId": record["userId"],
+                "sk": _job_sk(record["sessionId"], record["jobId"]),
+                "recordType": "RESEARCH_JOB",
+            }
         boto3.resource("dynamodb", region_name=region).Table(table_name).put_item(Item=item)
         return
 
@@ -129,10 +150,41 @@ def _load_report(record: Dict[str, Any]) -> str:
 
 def _list_jobs(user_id: str, session_id: str) -> list[Dict[str, Any]]:
     if _is_cloud_storage():
-        table_name = os.environ["DYNAMODB_USERS_TABLE"]
         region = os.environ.get("AWS_REGION", "us-west-2")
-        table = boto3.resource("dynamodb", region_name=region).Table(table_name)
-        items = []
+        dynamodb = boto3.resource("dynamodb", region_name=region)
+        jobs_by_id: Dict[str, Dict[str, Any]] = {}
+
+        orchestration_table = os.environ.get("SESSION_ORCHESTRATION_TABLE")
+        if orchestration_table:
+            table = dynamodb.Table(orchestration_table)
+            start_key = None
+            while True:
+                query_kwargs = {
+                    "KeyConditionExpression": (
+                        "sessionKey = :session_key "
+                        "AND begins_with(recordKey, :prefix)"
+                    ),
+                    "ExpressionAttributeValues": {
+                        ":session_key": _orchestration_session_key(
+                            user_id,
+                            session_id,
+                        ),
+                        ":prefix": "JOB#",
+                    },
+                }
+                if start_key:
+                    query_kwargs["ExclusiveStartKey"] = start_key
+                response = table.query(**query_kwargs)
+                for item in response.get("Items", []):
+                    if item.get("jobId"):
+                        jobs_by_id[item["jobId"]] = item
+                start_key = response.get("LastEvaluatedKey")
+                if not start_key:
+                    break
+
+        # Read legacy rows during migration. New writes use the orchestration
+        # table as soon as it is configured.
+        legacy_table = dynamodb.Table(os.environ["DYNAMODB_USERS_TABLE"])
         start_key = None
         while True:
             query_kwargs = {
@@ -144,11 +196,13 @@ def _list_jobs(user_id: str, session_id: str) -> list[Dict[str, Any]]:
             }
             if start_key:
                 query_kwargs["ExclusiveStartKey"] = start_key
-            response = table.query(**query_kwargs)
-            items.extend(response.get("Items", []))
+            response = legacy_table.query(**query_kwargs)
+            for item in response.get("Items", []):
+                if item.get("jobId") and item["jobId"] not in jobs_by_id:
+                    jobs_by_id[item["jobId"]] = item
             start_key = response.get("LastEvaluatedKey")
             if not start_key:
-                return items
+                return list(jobs_by_id.values())
 
     jobs = []
     for path in _local_job_dir(session_id).glob("*.json"):
@@ -181,6 +235,89 @@ def _build_artifact(record: Dict[str, Any], report: str) -> Dict[str, Any]:
     }
 
 
+def _artifact_payload_ref(record: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    if record.get("artifactBucket") and record.get("artifactS3Key"):
+        return {
+            "bucket": record["artifactBucket"],
+            "key": record["artifactS3Key"],
+        }
+    if record.get("artifactPath"):
+        return {"path": record["artifactPath"]}
+    return None
+
+
+def _build_artifact_reference(
+    record: Dict[str, Any],
+    artifact: Dict[str, Any],
+) -> Dict[str, Any]:
+    reference = {
+        key: value
+        for key, value in artifact.items()
+        if key != "content"
+    }
+    payload_ref = _artifact_payload_ref(record)
+    if payload_ref:
+        reference["content_ref"] = payload_ref
+    return reference
+
+
+def _mailbox_write_enabled() -> bool:
+    return os.environ.get("SESSION_MAILBOX_WRITE_ENABLED", "").lower() == "true"
+
+
+def _completion_event_id(record: Dict[str, Any]) -> str:
+    return f"research-result:{record['jobId']}"
+
+
+def _enqueue_completion_event(record: Dict[str, Any]) -> Optional[str]:
+    """Publish the deterministic completion event when mailbox writes are enabled."""
+    if not _mailbox_write_enabled():
+        return None
+
+    from agent.mailbox import MailboxEvent, get_mailbox_repository
+
+    event_id = _completion_event_id(record)
+    payload_ref = _artifact_payload_ref(record)
+
+    event = MailboxEvent.create(
+        event_id=event_id,
+        event_type="async_result.ready",
+        session_id=record["sessionId"],
+        user_id=record["userId"],
+        source_type="research_job",
+        source_id=record["jobId"],
+        correlation={
+            "jobId": record["jobId"],
+            "artifactId": record["artifactId"],
+        },
+        payload={
+            "resultType": "research",
+            "artifact": record.get("artifact", {}),
+        },
+        payload_ref=payload_ref,
+    )
+    inserted = get_mailbox_repository().enqueue(event)
+    logger.info(
+        "[ResearchJob] Mailbox completion %s (%s)",
+        event_id,
+        "inserted" if inserted else "duplicate",
+    )
+    return event_id
+
+
+def _completion_event_exists(record: Dict[str, Any]) -> bool:
+    event_id = record.get("mailboxEventId") or _completion_event_id(record)
+    from agent.mailbox import get_mailbox_repository
+
+    return any(
+        event.event_id == event_id
+        for event in get_mailbox_repository().list_events(
+            record["userId"],
+            record["sessionId"],
+        )
+    )
+
+
 def load_pending_results(user_id: str, session_id: str) -> list[Dict[str, Any]]:
     """Load reports that are durable but were not delivered to the agent."""
     pending = []
@@ -210,6 +347,24 @@ def load_pending_results(user_id: str, session_id: str) -> list[Dict[str, Any]]:
             session_id,
         )
     return pending
+
+
+def recover_pending_mailbox_events(user_id: str, session_id: str) -> list[str]:
+    """Recreate deterministic mailbox events for legacy or interrupted jobs."""
+    recovered = []
+    for item in load_pending_results(user_id, session_id):
+        record = item["record"]
+        # Re-enqueue even when the job already has its deterministic ID. A
+        # prior write may have failed after the job record was prepared but
+        # before the INBOX transaction became durable.
+        event_id = _enqueue_completion_event(record)
+        if event_id:
+            record["mailboxEventId"] = event_id
+            record.pop("mailboxWriteError", None)
+            _save_job(record)
+        if event_id:
+            recovered.append(event_id)
+    return recovered
 
 
 def mark_delivered(record: Dict[str, Any]) -> None:
@@ -245,6 +400,12 @@ async def _deliver(record: Dict[str, Any], artifact: Dict[str, Any]) -> None:
 
     future = asyncio.run_coroutine_threadsafe(handler(dict(record), artifact), loop)
     await asyncio.wrap_future(future)
+
+
+async def _notify_mailbox(record: Dict[str, Any]):
+    from agent.mailbox_runtime import notify_session_mailbox
+
+    return await notify_session_mailbox(record["userId"], record["sessionId"])
 
 
 def _publish_progress(record: Dict[str, Any], event: Dict[str, Any]) -> None:
@@ -304,11 +465,79 @@ async def _run_job(record: Dict[str, Any], event_factory: EventFactory) -> None:
         record.update(_save_report(record, report))
         artifact = _build_artifact(record, report)
         record["artifact"] = {key: value for key, value in artifact.items() if key != "content"}
+        if _mailbox_write_enabled():
+            record["mailboxEventId"] = _completion_event_id(record)
+
+        # Persist every field needed by a mailbox consumer before publishing
+        # the INBOX record. Once enqueue succeeds, the dispatcher may deliver
+        # and mark this job delivered immediately; the worker must not write a
+        # stale "completed" or "delivering" snapshot afterward.
+        record.update(status="delivering", updatedAt=_now())
         _save_job(record)
+        try:
+            mailbox_event_id = _enqueue_completion_event(record)
+            if mailbox_event_id:
+                record["mailboxEventId"] = mailbox_event_id
+        except Exception as exc:
+            from agent.mailbox import SessionDeletedError
+
+            if isinstance(exc, SessionDeletedError):
+                record.update(
+                    status="cancelled",
+                    updatedAt=_now(),
+                    deliveryError=str(exc),
+                )
+                _save_job(record)
+                logger.info(
+                    "[ResearchJob] Cancelled delivery to deleted session %s",
+                    record["sessionId"],
+                )
+                return
+            try:
+                event_exists = _completion_event_exists(record)
+            except Exception:
+                logger.exception(
+                    "[ResearchJob] Failed to reconcile mailbox write for %s",
+                    record["jobId"],
+                )
+                record.update(
+                    status="completed",
+                    deliveryError=str(exc),
+                    mailboxWriteError=str(exc),
+                    updatedAt=_now(),
+                )
+                _save_job(record)
+                return
+            if event_exists:
+                # The enqueue response was ambiguous, but the strongly
+                # consistent mailbox read proves that delivery is durable.
+                logger.warning(
+                    "[ResearchJob] Recovered ambiguous mailbox write for %s",
+                    record["jobId"],
+                )
+            else:
+                record.pop("mailboxEventId", None)
+                record["mailboxWriteError"] = str(exc)
+                _save_job(record)
+                logger.exception(
+                    "[ResearchJob] Mailbox write failed for %s",
+                    record["jobId"],
+                )
 
         try:
-            record.update(status="delivering", updatedAt=_now())
-            _save_job(record)
+            from agent.mailbox_runtime import mailbox_delivery_enabled
+
+            if mailbox_delivery_enabled():
+                if not record.get("mailboxEventId"):
+                    raise RuntimeError(
+                        "Mailbox delivery is enabled but completion enqueue failed"
+                    )
+                result = await _notify_mailbox(record)
+                if result.dead:
+                    raise RuntimeError("Mailbox delivery reached dead-letter state")
+                # The mailbox handler owns the delivered projection. Another
+                # coordinator may already be processing the event.
+                return
             await _deliver(record, artifact)
         except Exception as exc:
             record.update(

--- a/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
+++ b/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
@@ -1,10 +1,13 @@
 """Compacting Session Manager for Long Context Optimization."""
 
 import copy
+import hashlib
 import json
 import logging
 import sys
+import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional, Dict, List
@@ -49,6 +52,12 @@ class CompactionState:
             summary=data.get("summary"),
             updatedAt=data.get("updatedAt")
         )
+
+
+@dataclass
+class MailboxPersistenceScope:
+    origin_event_id: str
+    message_index: int = 0
 
 
 class CompactingSessionManager(AgentCoreMemorySessionManager):
@@ -126,6 +135,8 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
         # API call metrics for performance measurement
         self._api_call_count = 0
         self._api_call_total_ms = 0.0
+        self._mailbox_scope: Optional[MailboxPersistenceScope] = None
+        self._mailbox_scope_lock = threading.Lock()
 
         mode_str = "metrics_only" if metrics_only else "full_compaction"
         logger.debug(f"CompactingSessionManager: mode={mode_str}")
@@ -169,6 +180,82 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
         elapsed_ms = (time.time() - start) * 1000
         self._api_call_count += 1
         self._api_call_total_ms += elapsed_ms
+
+    @contextmanager
+    def mailbox_event_scope(self, origin_event_id: str):
+        """Make message writes idempotent for one durable mailbox event."""
+        with self._mailbox_scope_lock:
+            if self._mailbox_scope is not None:
+                raise RuntimeError("Nested mailbox persistence scopes are not supported")
+            self._mailbox_scope = MailboxPersistenceScope(origin_event_id)
+        try:
+            yield
+        finally:
+            with self._mailbox_scope_lock:
+                self._mailbox_scope = None
+
+    @override
+    def create_message(
+        self,
+        session_id: str,
+        agent_id: str,
+        session_message: SessionMessage,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Attach stable identity and an AgentCore idempotency token in mailbox scope."""
+        with self._mailbox_scope_lock:
+            scope = self._mailbox_scope
+            if scope is None:
+                scoped_message = None
+            else:
+                message_index = scope.message_index
+                scope.message_index += 1
+                scoped_message = (scope.origin_event_id, message_index)
+
+        if scoped_message is None:
+            return super().create_message(
+                session_id,
+                agent_id,
+                session_message,
+                **kwargs,
+            )
+
+        origin_event_id, message_index = scoped_message
+        logical_message_id = f"mailbox:{origin_event_id}:{message_index}"
+        role = session_message.message.get("role", "")
+        metadata = dict(kwargs.pop("metadata", {}) or {})
+        metadata.update({
+            "originEventId": {"stringValue": origin_event_id},
+            "logicalMessageId": {"stringValue": logical_message_id},
+            "visibility": {
+                "stringValue": "internal" if role == "user" else "conversation"
+            },
+        })
+
+        token_material = (
+            f"{self.config.memory_id}\n{session_id}\n"
+            f"{origin_event_id}\n{message_index}"
+        )
+        client_token = hashlib.sha256(token_material.encode("utf-8")).hexdigest()
+        event_name = "before-parameter-build.bedrock-agentcore.CreateEvent"
+        unique_id = f"mailbox-client-token-{client_token}"
+        emitter = self.memory_client.gmdp_client.meta.events
+
+        def inject_idempotency(params, **_):
+            params["clientToken"] = client_token
+            params["extractionMode"] = "SKIP"
+
+        emitter.register_first(event_name, inject_idempotency, unique_id=unique_id)
+        try:
+            return super().create_message(
+                session_id,
+                agent_id,
+                session_message,
+                metadata=metadata,
+                **kwargs,
+            )
+        finally:
+            emitter.unregister(event_name, unique_id=unique_id)
 
     @override
     def sync_agent(self, agent: "Agent", **kwargs: Any) -> None:

--- a/chatbot-app/agentcore/src/agent/session_coordinator.py
+++ b/chatbot-app/agentcore/src/agent/session_coordinator.py
@@ -1,0 +1,191 @@
+"""Single-writer coordinator for durable session mailbox events."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, Optional, Sequence
+from uuid import uuid4
+
+from agent.mailbox import (
+    MailboxEvent,
+    MailboxLease,
+    MailboxRepository,
+    SessionEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+MailboxEventHandler = Callable[
+    [MailboxEvent],
+    Awaitable[Optional[Sequence[SessionEvent]]],
+]
+
+
+class NonRetryableMailboxError(RuntimeError):
+    """The event is valid but replay cannot make it succeed."""
+
+
+@dataclass
+class DrainResult:
+    acquired: bool = False
+    processed: int = 0
+    retried: int = 0
+    dead: int = 0
+    lease_lost: bool = False
+
+
+class SessionCoordinator:
+    def __init__(
+        self,
+        repository: MailboxRepository,
+        handlers: Dict[str, MailboxEventHandler],
+        *,
+        lease_seconds: int = 120,
+        event_lease_seconds: int = 120,
+        max_attempts: int = 5,
+        retry_delay_seconds: int = 5,
+    ):
+        if lease_seconds < 3:
+            raise ValueError("lease_seconds must be at least 3")
+        self.repository = repository
+        self.handlers = dict(handlers)
+        self.lease_seconds = lease_seconds
+        self.event_lease_seconds = event_lease_seconds
+        self.max_attempts = max_attempts
+        self.retry_delay_seconds = retry_delay_seconds
+
+    async def drain(
+        self,
+        user_id: str,
+        session_id: str,
+        *,
+        owner: Optional[str] = None,
+        max_events: int = 20,
+    ) -> DrainResult:
+        result = DrainResult()
+        owner = owner or f"coordinator-{uuid4().hex}"
+        lease = await asyncio.to_thread(
+            self.repository.acquire_lease,
+            user_id,
+            session_id,
+            owner,
+            lease_seconds=self.lease_seconds,
+        )
+        if lease is None:
+            return result
+        result.acquired = True
+
+        active_lease = [lease]
+        lease_lost = asyncio.Event()
+        heartbeat = asyncio.create_task(
+            self._heartbeat(user_id, session_id, active_lease, lease_lost)
+        )
+        try:
+            for _ in range(max_events):
+                if lease_lost.is_set():
+                    result.lease_lost = True
+                    break
+
+                event = await asyncio.to_thread(
+                    self.repository.claim_next,
+                    user_id,
+                    session_id,
+                    active_lease[0],
+                    event_lease_seconds=self.event_lease_seconds,
+                )
+                if event is None:
+                    break
+
+                handler = self.handlers.get(event.event_type)
+                try:
+                    if handler is None:
+                        raise NonRetryableMailboxError(
+                            f"No handler registered for {event.event_type}"
+                        )
+                    session_events = await handler(event)
+                except asyncio.CancelledError:
+                    # An ambiguous side effect must not be made pending
+                    # immediately. The event lease expiry is the recovery gate.
+                    raise
+                except Exception as error:
+                    if lease_lost.is_set():
+                        result.lease_lost = True
+                        break
+                    max_attempts = (
+                        1 if isinstance(error, NonRetryableMailboxError)
+                        else self.max_attempts
+                    )
+                    status = await asyncio.to_thread(
+                        self.repository.retry,
+                        event,
+                        active_lease[0],
+                        str(error),
+                        delay_seconds=self.retry_delay_seconds,
+                        max_attempts=max_attempts,
+                    )
+                    if status == "dead":
+                        result.dead += 1
+                    else:
+                        result.retried += 1
+                    logger.exception(
+                        "[SessionCoordinator] Event %s failed with status %s",
+                        event.event_id,
+                        status,
+                    )
+                    if status != "dead":
+                        # Do not consume all attempts in one drain when the
+                        # retry delay is short or clock precision overlaps.
+                        break
+                    continue
+
+                if lease_lost.is_set():
+                    result.lease_lost = True
+                    break
+                acknowledged = await asyncio.to_thread(
+                    self.repository.acknowledge,
+                    event,
+                    active_lease[0],
+                    session_events=tuple(session_events or ()),
+                )
+                if not acknowledged:
+                    result.lease_lost = True
+                    break
+                result.processed += 1
+        finally:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except asyncio.CancelledError:
+                pass
+            if not lease_lost.is_set():
+                await asyncio.to_thread(
+                    self.repository.release_lease,
+                    user_id,
+                    session_id,
+                    active_lease[0],
+                )
+        return result
+
+    async def _heartbeat(
+        self,
+        user_id: str,
+        session_id: str,
+        active_lease: list[MailboxLease],
+        lease_lost: asyncio.Event,
+    ) -> None:
+        interval = max(1.0, self.lease_seconds / 3)
+        while True:
+            await asyncio.sleep(interval)
+            renewed = await asyncio.to_thread(
+                self.repository.renew_lease,
+                user_id,
+                session_id,
+                active_lease[0],
+                lease_seconds=self.lease_seconds,
+            )
+            if renewed is None:
+                lease_lost.set()
+                return
+            active_lease[0] = renewed

--- a/chatbot-app/agentcore/src/main.py
+++ b/chatbot-app/agentcore/src/main.py
@@ -73,15 +73,21 @@ async def lifespan(app: FastAPI):
     os.makedirs(sessions_dir, exist_ok=True)
     logger.info("Sessions directory ready")
 
+    from agent.mailbox_runtime import clear_mailbox_runtime, register_mailbox_runtime
     from agent.research_jobs import register_delivery_handler, clear_delivery_handler
-    from routers.chat import deliver_research_job
+    from routers.chat import deliver_mailbox_event, deliver_research_job
 
     register_delivery_handler(asyncio.get_running_loop(), deliver_research_job)
+    register_mailbox_runtime(
+        asyncio.get_running_loop(),
+        {"async_result.ready": deliver_mailbox_event},
+    )
 
     yield  # Application is running
 
     # Shutdown
     clear_delivery_handler()
+    clear_mailbox_runtime()
     logger.info("=== Agent Core Service Shutting Down ===")
     # TODO: Cleanup agent pool, MCP clients, etc.
 

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -14,10 +14,13 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from typing import AsyncGenerator, List, Optional
 import asyncio
+import base64
 import logging
 import json
 import os
 import time
+from contextlib import nullcontext
+from datetime import datetime, timezone
 
 from models.schemas import FileContent
 from agent import async_tasks
@@ -35,6 +38,28 @@ registry = ExecutionRegistry()
 _BACKGROUND_RESEARCH_TAG = "background-research-result"
 
 router = APIRouter(tags=["chat"])
+
+
+def _is_mailbox_dispatcher_request(http_request: Request) -> bool:
+    expected_client_id = os.environ.get("M2M_CLIENT_ID")
+    if not expected_client_id:
+        return os.environ.get("ENVIRONMENT", "development") == "development"
+
+    authorization = http_request.headers.get("authorization", "")
+    if not authorization.lower().startswith("bearer "):
+        return False
+    token = authorization.split(" ", 1)[1]
+    try:
+        encoded_payload = token.split(".")[1]
+        encoded_payload += "=" * (-len(encoded_payload) % 4)
+        claims = json.loads(
+            base64.urlsafe_b64decode(encoded_payload.encode("ascii"))
+        )
+    except (IndexError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    # Signature, issuer, expiry, and audience are already checked by the
+    # AgentCore Runtime custom JWT authorizer.
+    return claims.get("client_id") == expected_client_id
 
 
 async def keepalive_stream(
@@ -193,6 +218,38 @@ async def invocations(http_request: Request):
     # Debug: log incoming action for stop signal troubleshooting
     if action:
         logger.info(f"[Invocation] action={action}, thread_id={thread_id}, state_keys={list(state.keys())}")
+
+    if action == "drain_mailbox":
+        if not _is_mailbox_dispatcher_request(http_request):
+            raise HTTPException(status_code=403, detail="Mailbox dispatcher token required")
+        user_id = state.get("user_id")
+        if not user_id or not thread_id:
+            raise HTTPException(
+                status_code=400,
+                detail="thread_id and state.user_id are required",
+            )
+
+        from agent.mailbox import PENDING, PROCESSING, get_mailbox_repository
+        from agent.mailbox_runtime import drain_session_mailbox
+
+        result = await drain_session_mailbox(user_id, thread_id)
+        remaining = await asyncio.to_thread(
+            get_mailbox_repository().list_events,
+            user_id,
+            thread_id,
+        )
+        pending = sum(
+            item.status in (PENDING, PROCESSING)
+            for item in remaining
+        )
+        return {
+            "status": "drained" if pending == 0 else "pending",
+            "processed": result.processed,
+            "retried": result.retried,
+            "dead": result.dead,
+            "acquired": result.acquired,
+            "pending": pending,
+        }
 
     # Warmup — triggers container cold start, Python modules load (TOOL_REGISTRY, etc.)
     if action == "warmup":
@@ -389,11 +446,22 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
         f"disabled_skills={disabled_skills}"
     )
 
-    # Recover reports that were durably completed but whose idle continuation
-    # failed (for example because the process restarted). The next foreground
-    # turn becomes the retry boundary.
-    from agent.research_jobs import load_pending_results
-    pending_research = load_pending_results(user_id, session_id)
+    from agent.mailbox_runtime import mailbox_delivery_enabled
+
+    use_mailbox_delivery = mailbox_delivery_enabled()
+    pending_research = []
+    if use_mailbox_delivery:
+        # A foreground invocation is also a recovery signal. Recreate any
+        # deterministic completion envelopes that predate mailbox delivery;
+        # the coordinator will materialize them as separate assistant turns.
+        from agent.research_jobs import recover_pending_mailbox_events
+
+        recover_pending_mailbox_events(user_id, session_id)
+    else:
+        # Legacy fallback while mailbox delivery is disabled.
+        from agent.research_jobs import load_pending_results
+
+        pending_research = load_pending_results(user_id, session_id)
     if pending_research:
         reports = "\n\n".join(
             (
@@ -530,7 +598,17 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
                 if execution.status == ExecutionStatus.RUNNING:
                     execution.status = ExecutionStatus.COMPLETED
                 execution.completed_at = time.time()
+                execution._new_event.set()
                 logger.info(f"[Execution] AG-UI completed {execution.execution_id}, {len(execution.events)} events buffered")
+                if use_mailbox_delivery:
+                    # The foreground run has reached a safe boundary. A
+                    # coordinator holding this session's lease may now append
+                    # one or more asynchronous completion turns.
+                    from agent.mailbox_runtime import drain_session_mailbox
+
+                    asyncio.create_task(
+                        drain_session_mailbox(user_id, session_id)
+                    )
 
         execution.task = asyncio.create_task(run_agui_to_buffer())
 
@@ -590,14 +668,34 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                     user_id=user_id,
                     model_id=record.get("modelId") or None,
                 )
+                # Mailbox retries are at-least-once. Keep continuation
+                # generation pure so an ambiguous retry cannot repeat external
+                # tool side effects.
+                tool_registry = getattr(agent.agent, "tool_registry", None)
+                registered_tools = getattr(tool_registry, "registry", None)
+                if isinstance(registered_tools, dict):
+                    registered_tools.clear()
+
+                from agent.research_jobs import _build_artifact_reference
 
                 artifacts = dict(agent.agent.state.get("artifacts") or {})
-                artifacts[artifact["id"]] = artifact
+                artifacts[artifact["id"]] = _build_artifact_reference(
+                    record,
+                    artifact,
+                )
                 agent.agent.state.set("artifacts", artifacts)
                 # Delivery is not successful unless the canonical agent state is
                 # durable. Let sync failures propagate so the job remains ready
                 # for retry instead of being falsely marked delivered.
                 agent.session_manager.sync_agent(agent.agent)
+
+                commit_id = record.get("mailboxEventId") or run_id
+                existing_commits = dict(
+                    agent.agent.state.get("mailbox_commits") or {}
+                )
+                if commit_id in existing_commits:
+                    execution.status = ExecutionStatus.COMPLETED
+                    return
 
                 report = artifact.get("content", "")
                 hidden_message = (
@@ -606,7 +704,8 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                     "Background research requested earlier has completed. "
                     "The full report is now stored as an artifact. Incorporate "
                     "the result into the ongoing conversation and tell the user "
-                    "the report is ready. Do not start another research job.\n\n"
+                    "the report is ready. Do not call tools or start another "
+                    "research job.\n\n"
                     f"{report}\n"
                     f"</{_BACKGROUND_RESEARCH_TAG}>"
                 )
@@ -622,18 +721,35 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                     "session_manager": agent.session_manager,
                     "background_research_job_id": record["jobId"],
                 }
-                stream = processor.process_stream(
-                    agent.agent,
-                    hidden_message,
-                    session_id=session_id,
-                    invocation_state=invocation_state,
-                    elicitation_bridge=getattr(agent, "elicitation_bridge", None),
+                scope = getattr(agent.session_manager, "mailbox_event_scope", None)
+                scope_context = (
+                    scope(commit_id)
+                    if scope
+                    else nullcontext()
                 )
-                async for sse_chunk in stream:
-                    execution.append_event(
-                        sse_chunk,
-                        _extract_event_type(sse_chunk),
+                with scope_context:
+                    stream = processor.process_stream(
+                        agent.agent,
+                        hidden_message,
+                        session_id=session_id,
+                        invocation_state=invocation_state,
+                        elicitation_bridge=getattr(agent, "elicitation_bridge", None),
                     )
+                    async for sse_chunk in stream:
+                        execution.append_event(
+                            sse_chunk,
+                            _extract_event_type(sse_chunk),
+                        )
+
+                commits = dict(agent.agent.state.get("mailbox_commits") or {})
+                commits[commit_id] = {
+                    "completedAt": datetime.now(timezone.utc).isoformat(),
+                    "sourceId": record["jobId"],
+                }
+                if len(commits) > 100:
+                    commits = dict(list(commits.items())[-100:])
+                agent.agent.state.set("mailbox_commits", commits)
+                agent.session_manager.sync_agent(agent.agent)
                 execution.status = ExecutionStatus.COMPLETED
             except asyncio.CancelledError:
                 execution.status = ExecutionStatus.STOPPED
@@ -660,6 +776,79 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                 record["jobId"],
             )
             await asyncio.sleep(0)
+
+
+async def deliver_mailbox_event(event):
+    """Materialize one generic asynchronous result into the conversation."""
+    if event.source.get("type") != "research_job":
+        raise RuntimeError(f"Unsupported async result source: {event.source}")
+
+    from agent.research_jobs import (
+        _build_artifact,
+        _list_jobs,
+        _load_report,
+        mark_delivered,
+    )
+
+    job_id = event.source["id"]
+    record = next(
+        (
+            item
+            for item in _list_jobs(event.user_id, event.session_id)
+            if item.get("jobId") == job_id
+        ),
+        None,
+    )
+    if record is None:
+        raise RuntimeError(f"Research job not found: {job_id}")
+
+    record["mailboxEventId"] = event.event_id
+    report = _load_report(record)
+    artifact = _build_artifact(record, report)
+    await deliver_research_job(record, artifact)
+    mark_delivered(record)
+
+    from agent.mailbox import SessionEvent
+
+    run_id = f"research-delivery-{job_id}"
+    correlation = {
+        **event.correlation,
+        "jobId": job_id,
+        "artifactId": artifact["id"],
+        "runId": run_id,
+    }
+    artifact_metadata = {
+        key: value
+        for key, value in artifact.items()
+        if key != "content"
+    }
+    return [
+        SessionEvent.create(
+            event_id=f"{event.event_id}:artifact",
+            event_type="artifact.upserted",
+            session_id=event.session_id,
+            user_id=event.user_id,
+            origin_event_id=event.event_id,
+            correlation=correlation,
+            payload={
+                "artifact": artifact_metadata,
+                "payloadRef": event.payload_ref,
+            },
+        ),
+        SessionEvent.create(
+            event_id=f"{event.event_id}:assistant",
+            event_type="assistant.turn.completed",
+            session_id=event.session_id,
+            user_id=event.user_id,
+            origin_event_id=event.event_id,
+            correlation=correlation,
+            payload={
+                "executionId": f"{event.session_id}:{run_id}",
+                "logicalMessageId": f"mailbox:{event.event_id}:1",
+                "source": event.source,
+            },
+        ),
+    ]
 
 
 _cleanup_task: Optional[asyncio.Task] = None

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -40,6 +40,20 @@ _BACKGROUND_RESEARCH_TAG = "background-research-result"
 router = APIRouter(tags=["chat"])
 
 
+def _build_background_research_message(report: str) -> str:
+    """Build model input without exposing mailbox correlation identifiers."""
+    return (
+        f"<{_BACKGROUND_RESEARCH_TAG}>\n"
+        "Background research requested earlier has completed. "
+        "The full report is now stored as an artifact. Incorporate "
+        "the result into the ongoing conversation and tell the user "
+        "the report is ready. Do not call tools or start another "
+        "research job.\n\n"
+        f"{report}\n"
+        f"</{_BACKGROUND_RESEARCH_TAG}>"
+    )
+
+
 def _is_mailbox_dispatcher_request(http_request: Request) -> bool:
     expected_client_id = os.environ.get("M2M_CLIENT_ID")
     if not expected_client_id:
@@ -465,7 +479,7 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
     if pending_research:
         reports = "\n\n".join(
             (
-                f"<completed-background-research artifact_id=\"{item['artifact']['id']}\">\n"
+                "<completed-background-research>\n"
                 f"{item['artifact']['content']}\n"
                 "</completed-background-research>"
             )
@@ -697,17 +711,8 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                     execution.status = ExecutionStatus.COMPLETED
                     return
 
-                report = artifact.get("content", "")
-                hidden_message = (
-                    f"<{_BACKGROUND_RESEARCH_TAG} "
-                    f"job_id=\"{record['jobId']}\" artifact_id=\"{artifact['id']}\">\n"
-                    "Background research requested earlier has completed. "
-                    "The full report is now stored as an artifact. Incorporate "
-                    "the result into the ongoing conversation and tell the user "
-                    "the report is ready. Do not call tools or start another "
-                    "research job.\n\n"
-                    f"{report}\n"
-                    f"</{_BACKGROUND_RESEARCH_TAG}>"
+                hidden_message = _build_background_research_message(
+                    artifact.get("content", ""),
                 )
                 processor = AGUIStreamEventProcessor(
                     thread_id=session_id,
@@ -719,7 +724,6 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                     "run_id": run_id,
                     "model_id": agent.model_id,
                     "session_manager": agent.session_manager,
-                    "background_research_job_id": record["jobId"],
                 }
                 scope = getattr(agent.session_manager, "mailbox_event_scope", None)
                 scope_context = (

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -10,12 +10,15 @@ Tests cover:
 - Lifecycle actions (warmup, stop, elicitation, execution_status, resume)
 - Standalone GET endpoints (execution-status, resume)
 """
+import asyncio
+import base64
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi import Request
 from fastapi.testclient import TestClient
 import json
 import uuid
+from types import SimpleNamespace
 
 
 def _agui_payload(
@@ -34,6 +37,11 @@ def _agui_payload(
         "context": [],
         "state": state,
     }
+
+
+def _unsigned_test_token(claims: dict) -> str:
+    encoded = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
 
 
 # ============================================================
@@ -205,7 +213,7 @@ class TestExecutionRegistry:
     async def test_tail_stream_stops_on_disconnect(self):
         """Test that tail stream stops when client disconnects."""
         from routers.chat import _create_tail_stream
-        from streaming.execution_registry import ExecutionRegistry, ExecutionStatus
+        from streaming.execution_registry import ExecutionRegistry
         ExecutionRegistry.reset()
         registry = ExecutionRegistry()
         execution = await registry.create_execution("sess5", "user1", "run5")
@@ -222,6 +230,126 @@ class TestExecutionRegistry:
         # Should only have the metadata event before disconnect
         assert len(chunks) == 1
         assert "execution_meta" in chunks[0]
+
+
+class TestMailboxDelivery:
+    @pytest.mark.asyncio
+    async def test_generic_event_loads_research_job_and_marks_delivered(
+        self,
+        monkeypatch,
+    ):
+        from agent import research_jobs
+        from routers import chat
+
+        record = {
+            "jobId": "job-1",
+            "sessionId": "session-1",
+            "userId": "user-1",
+            "artifactId": "artifact-1",
+        }
+        delivered = AsyncMock()
+        marked = MagicMock()
+        monkeypatch.setattr(research_jobs, "_list_jobs", lambda *_: [record])
+        monkeypatch.setattr(research_jobs, "_load_report", lambda _: "# Report")
+        monkeypatch.setattr(
+            research_jobs,
+            "_build_artifact",
+            lambda item, report: {"id": item["artifactId"], "content": report},
+        )
+        monkeypatch.setattr(research_jobs, "mark_delivered", marked)
+        monkeypatch.setattr(chat, "deliver_research_job", delivered)
+        event = SimpleNamespace(
+            event_id="research-result:job-1",
+            user_id="user-1",
+            session_id="session-1",
+            source={"type": "research_job", "id": "job-1"},
+            correlation={"artifactId": "artifact-1"},
+            payload_ref={"bucket": "bucket", "key": "report.md"},
+        )
+
+        projections = await chat.deliver_mailbox_event(event)
+
+        assert record["mailboxEventId"] == "research-result:job-1"
+        delivered.assert_awaited_once()
+        marked.assert_called_once_with(record)
+        assert [item.event_type for item in projections] == [
+            "artifact.upserted",
+            "assistant.turn.completed",
+        ]
+        assert projections[1].payload["executionId"] == (
+            "session-1:research-delivery-job-1"
+        )
+        assert projections[1].payload["logicalMessageId"] == (
+            "mailbox:research-result:job-1:1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_committed_event_skips_duplicate_agent_generation(
+        self,
+        monkeypatch,
+    ):
+        from routers import chat
+        from streaming.execution_registry import ExecutionStatus
+
+        class State:
+            def __init__(self):
+                self.values = {
+                    "artifacts": {},
+                    "mailbox_commits": {
+                        "research-result:job-1": {"sourceId": "job-1"}
+                    },
+                }
+
+            def get(self, key):
+                return self.values.get(key)
+
+            def set(self, key, value):
+                self.values[key] = value
+
+        execution = SimpleNamespace(
+            execution_id="session-1:research-delivery-job-1",
+            status=ExecutionStatus.RUNNING,
+            task=None,
+            completed_at=None,
+            _new_event=asyncio.Event(),
+        )
+
+        class Registry:
+            async def create_execution(self, *args, **kwargs):
+                return execution
+
+        session_manager = MagicMock()
+        agent = SimpleNamespace(state=State())
+        wrapper = SimpleNamespace(
+            agent=agent,
+            session_manager=session_manager,
+            model_id="model-1",
+            elicitation_bridge=None,
+            close=MagicMock(),
+        )
+        monkeypatch.setattr(chat, "registry", Registry())
+        monkeypatch.setattr(chat, "create_agent", MagicMock(return_value=wrapper))
+        processor = MagicMock()
+        monkeypatch.setattr(chat, "AGUIStreamEventProcessor", processor)
+
+        await chat.deliver_research_job(
+            {
+                "jobId": "job-1",
+                "sessionId": "session-1",
+                "userId": "user-1",
+                "artifactId": "artifact-1",
+                "mailboxEventId": "research-result:job-1",
+                "artifactPath": "/tmp/job-1.md",
+            },
+            {"id": "artifact-1", "content": "# Report"},
+        )
+
+        processor.assert_not_called()
+        assert agent.state.get("artifacts")["artifact-1"] == {
+            "id": "artifact-1",
+            "content_ref": {"path": "/tmp/job-1.md"},
+        }
+        assert session_manager.sync_agent.call_count == 1
 
 
 # ============================================================
@@ -374,6 +502,81 @@ class TestLifecycleActions:
 
         assert response.status_code == 200
         assert response.json() == {"status": "warm"}
+
+    def test_mailbox_drain_rejects_user_token(self, monkeypatch):
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        monkeypatch.setenv("M2M_CLIENT_ID", "dispatcher-client")
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            headers={
+                "Authorization": (
+                    f"Bearer {_unsigned_test_token({'client_id': 'web-client'})}"
+                )
+            },
+            json={
+                "thread_id": "session-1",
+                "run_id": str(uuid.uuid4()),
+                "state": {"action": "drain_mailbox", "user_id": "user-1"},
+            },
+        )
+
+        assert response.status_code == 403
+
+    def test_mailbox_drain_accepts_dispatcher_and_reports_empty(
+        self,
+        monkeypatch,
+    ):
+        from agent import mailbox, mailbox_runtime
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        monkeypatch.setenv("M2M_CLIENT_ID", "dispatcher-client")
+        drain = AsyncMock(
+            return_value=SimpleNamespace(
+                processed=1,
+                retried=0,
+                dead=0,
+                acquired=True,
+            )
+        )
+        repository = MagicMock()
+        repository.list_events.return_value = []
+        monkeypatch.setattr(mailbox_runtime, "drain_session_mailbox", drain)
+        monkeypatch.setattr(mailbox, "get_mailbox_repository", lambda: repository)
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            headers={
+                "Authorization": (
+                    f"Bearer {_unsigned_test_token({'client_id': 'dispatcher-client'})}"
+                )
+            },
+            json={
+                "thread_id": "session-1",
+                "run_id": str(uuid.uuid4()),
+                "state": {"action": "drain_mailbox", "user_id": "user-1"},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "status": "drained",
+            "processed": 1,
+            "retried": 0,
+            "dead": 0,
+            "acquired": True,
+            "pending": 0,
+        }
+        drain.assert_awaited_once_with("user-1", "session-1")
 
     @patch('agent.stop_signal.get_stop_signal_provider')
     def test_stop_sets_signal(self, mock_get_provider):

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -233,6 +233,16 @@ class TestExecutionRegistry:
 
 
 class TestMailboxDelivery:
+    def test_model_input_excludes_internal_correlation_ids(self):
+        from routers import chat
+
+        message = chat._build_background_research_message("# Finished report")
+
+        assert message.startswith("<background-research-result>\n")
+        assert "job_id" not in message
+        assert "artifact_id" not in message
+        assert "# Finished report" in message
+
     @pytest.mark.asyncio
     async def test_generic_event_loads_research_job_and_marks_delivered(
         self,

--- a/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
+++ b/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
@@ -72,6 +72,81 @@ class TestCompactingSessionManagerInit:
         assert manager.user_id == 'test-user-123'
         assert manager.summarization_strategy_id == 'custom-strategy-123'
 
+
+class TestMailboxPersistenceScope:
+    @pytest.fixture
+    def manager(self):
+        with patch(
+            'agent.session.compacting_session_manager.AgentCoreMemorySessionManager.__init__'
+        ) as parent_init:
+            parent_init.return_value = None
+            from agent.session.compacting_session_manager import CompactingSessionManager
+
+            config = MagicMock()
+            config.memory_id = "memory-1"
+            config.session_id = "session-1"
+            config.actor_id = "user-1"
+            manager = CompactingSessionManager(config)
+            manager.config = config
+            manager.memory_client = MagicMock()
+            return manager
+
+    @patch(
+        'agent.session.compacting_session_manager.AgentCoreMemorySessionManager.create_message'
+    )
+    def test_scope_adds_stable_metadata_and_client_token(self, parent_create, manager):
+        from strands.types.session import SessionMessage
+
+        parent_create.return_value = {"eventId": "stored-1"}
+        message = SessionMessage.from_message(
+            {"role": "user", "content": [{"text": "internal"}]},
+            0,
+        )
+
+        with manager.mailbox_event_scope("mailbox-event-1"):
+            result = manager.create_message("session-1", "default", message)
+
+        assert result == {"eventId": "stored-1"}
+        metadata = parent_create.call_args.kwargs["metadata"]
+        assert metadata["originEventId"]["stringValue"] == "mailbox-event-1"
+        assert metadata["logicalMessageId"]["stringValue"] == (
+            "mailbox:mailbox-event-1:0"
+        )
+        assert metadata["visibility"]["stringValue"] == "internal"
+
+        emitter = manager.memory_client.gmdp_client.meta.events
+        callback = emitter.register_first.call_args.args[1]
+        params = {}
+        callback(params)
+        assert len(params["clientToken"]) == 64
+        assert params["extractionMode"] == "SKIP"
+        emitter.unregister.assert_called_once()
+
+    @patch(
+        'agent.session.compacting_session_manager.AgentCoreMemorySessionManager.create_message'
+    )
+    def test_scope_assigns_deterministic_sequence(self, parent_create, manager):
+        from strands.types.session import SessionMessage
+
+        parent_create.return_value = {"eventId": "stored"}
+        assistant = SessionMessage.from_message(
+            {"role": "assistant", "content": [{"text": "ready"}]},
+            0,
+        )
+
+        with manager.mailbox_event_scope("mailbox-event-1"):
+            manager.create_message("session-1", "default", assistant)
+            manager.create_message("session-1", "default", assistant)
+
+        calls = parent_create.call_args_list
+        assert calls[0].kwargs["metadata"]["logicalMessageId"]["stringValue"].endswith(
+            ":0"
+        )
+        assert calls[1].kwargs["metadata"]["logicalMessageId"]["stringValue"].endswith(
+            ":1"
+        )
+        assert calls[0].kwargs["metadata"]["visibility"]["stringValue"] == "conversation"
+
 class TestCompactionState:
     """Test CompactionState dataclass"""
 
@@ -1555,5 +1630,4 @@ class TestEndToEndScenarios:
 
         assert manager.compaction_state.checkpoint == 50
         assert manager.compaction_state.summary == "Previous summary"
-
 

--- a/chatbot-app/agentcore/tests/unit/test_mailbox.py
+++ b/chatbot-app/agentcore/tests/unit/test_mailbox.py
@@ -1,0 +1,412 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from agent.mailbox import (
+    DEAD,
+    PENDING,
+    PROCESSED,
+    DynamoDBMailboxRepository,
+    FileMailboxRepository,
+    MailboxEvent,
+    SessionDeletedError,
+    SessionEvent,
+)
+
+
+NOW = datetime(2026, 8, 6, 12, 0, tzinfo=timezone.utc)
+
+
+def event(event_id: str, *, now: datetime = NOW) -> MailboxEvent:
+    return MailboxEvent.create(
+        event_id=event_id,
+        event_type="async_result.ready",
+        session_id="session-1",
+        user_id="user-1",
+        source_type="test",
+        source_id=event_id,
+        now=now,
+    )
+
+
+def test_enqueue_is_idempotent(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    item = event("event-1")
+
+    assert repository.enqueue(item) is True
+    assert repository.enqueue(item) is False
+    assert [stored.event_id for stored in repository.list_events("user-1", "session-1")] == [
+        "event-1"
+    ]
+
+
+def test_deleted_session_rejects_new_events_and_leases(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.tombstone_session("user-1", "session-1", now=NOW)
+
+    with pytest.raises(SessionDeletedError):
+        repository.enqueue(event("event-1"))
+    assert repository.acquire_lease(
+        "user-1",
+        "session-1",
+        "worker-1",
+        lease_seconds=30,
+        now=NOW,
+    ) is None
+
+
+def test_tombstone_fences_claimed_event_acknowledgement(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+    lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=30, now=NOW
+    )
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW,
+    )
+
+    repository.tombstone_session(
+        "user-1",
+        "session-1",
+        now=NOW + timedelta(seconds=1),
+    )
+
+    assert repository.acknowledge(
+        claimed,
+        lease,
+        now=NOW + timedelta(seconds=1),
+    ) is False
+    assert repository.list_events("user-1", "session-1")[0].status == "processing"
+
+
+def test_expired_session_lease_cannot_acknowledge(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+    lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=10, now=NOW
+    )
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW,
+    )
+
+    assert repository.acknowledge(
+        claimed,
+        lease,
+        now=NOW + timedelta(seconds=11),
+    ) is False
+
+
+def test_claims_events_in_creation_order(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("later", now=NOW + timedelta(seconds=1)))
+    repository.enqueue(event("earlier"))
+    lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=30, now=NOW
+    )
+
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW + timedelta(seconds=2),
+    )
+
+    assert claimed.event_id == "earlier"
+    assert claimed.attempts == 1
+
+
+def test_only_one_owner_holds_a_live_session_lease(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+
+    first = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=30, now=NOW
+    )
+    blocked = repository.acquire_lease(
+        "user-1", "session-1", "worker-2", lease_seconds=30, now=NOW
+    )
+    second = repository.acquire_lease(
+        "user-1",
+        "session-1",
+        "worker-2",
+        lease_seconds=30,
+        now=NOW + timedelta(seconds=31),
+    )
+
+    assert first is not None
+    assert blocked is None
+    assert second.epoch > first.epoch
+
+
+def test_renew_keeps_epoch_and_cannot_resurrect_expired_lease(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=10, now=NOW
+    )
+
+    renewed = repository.renew_lease(
+        "user-1",
+        "session-1",
+        lease,
+        lease_seconds=10,
+        now=NOW + timedelta(seconds=5),
+    )
+    expired = repository.renew_lease(
+        "user-1",
+        "session-1",
+        renewed,
+        lease_seconds=10,
+        now=NOW + timedelta(seconds=16),
+    )
+
+    assert renewed.epoch == lease.epoch
+    assert renewed.expires_at > lease.expires_at
+    assert expired is None
+
+
+def test_stale_owner_cannot_ack_after_lease_recovery(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+    first = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=10, now=NOW
+    )
+    first_claim = repository.claim_next(
+        "user-1",
+        "session-1",
+        first,
+        event_lease_seconds=10,
+        now=NOW,
+    )
+
+    recovered_at = NOW + timedelta(seconds=11)
+    second = repository.acquire_lease(
+        "user-1", "session-1", "worker-2", lease_seconds=10, now=recovered_at
+    )
+    second_claim = repository.claim_next(
+        "user-1",
+        "session-1",
+        second,
+        event_lease_seconds=10,
+        now=recovered_at,
+    )
+
+    assert repository.acknowledge(first_claim, first, now=recovered_at) is False
+    assert repository.acknowledge(second_claim, second, now=recovered_at) is True
+    assert repository.list_events("user-1", "session-1")[0].status == PROCESSED
+
+
+def test_acknowledge_atomically_publishes_session_events(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+    lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=30, now=NOW
+    )
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW,
+    )
+    projection = SessionEvent.create(
+        event_id="event-1:assistant",
+        event_type="assistant.turn.completed",
+        session_id="session-1",
+        user_id="user-1",
+        origin_event_id="event-1",
+        payload={"executionId": "session-1:run-1"},
+        now=NOW,
+    )
+
+    assert repository.acknowledge(
+        claimed,
+        lease,
+        session_events=[projection],
+        now=NOW,
+    )
+
+    stored = repository.list_session_events("user-1", "session-1")
+    assert stored == [projection]
+
+
+def test_retry_then_dead_letter(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+
+    first_lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=30, now=NOW
+    )
+    first_claim = repository.claim_next(
+        "user-1", "session-1", first_lease, event_lease_seconds=30, now=NOW
+    )
+    assert repository.retry(
+        first_claim,
+        first_lease,
+        "temporary",
+        delay_seconds=5,
+        max_attempts=2,
+        now=NOW,
+    ) == PENDING
+    repository.release_lease("user-1", "session-1", first_lease)
+
+    retry_at = NOW + timedelta(seconds=6)
+    second_lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-2", lease_seconds=30, now=retry_at
+    )
+    second_claim = repository.claim_next(
+        "user-1",
+        "session-1",
+        second_lease,
+        event_lease_seconds=30,
+        now=retry_at,
+    )
+    assert repository.retry(
+        second_claim,
+        second_lease,
+        "permanent",
+        delay_seconds=5,
+        max_attempts=2,
+        now=retry_at,
+    ) == DEAD
+    assert repository.list_events("user-1", "session-1")[0].status == DEAD
+
+
+def conditional_failure(operation: str = "PutItem") -> ClientError:
+    return ClientError(
+        {
+            "Error": {
+                "Code": "ConditionalCheckFailedException",
+                "Message": "condition failed",
+            }
+        },
+        operation,
+    )
+
+
+def transaction_condition_failure() -> ClientError:
+    return ClientError(
+        {
+            "Error": {
+                "Code": "TransactionCanceledException",
+                "Message": "transaction cancelled",
+            },
+            "CancellationReasons": [
+                {"Code": "ConditionalCheckFailed"},
+                {"Code": "None"},
+            ],
+        },
+        "TransactWriteItems",
+    )
+
+
+def test_dynamodb_enqueue_uses_event_key_for_idempotency():
+    client = MagicMock()
+    repository = DynamoDBMailboxRepository("mailbox-table", client=client)
+    item = event("event-1")
+
+    assert repository.enqueue(item) is True
+    transaction = client.transact_write_items.call_args.kwargs["TransactItems"]
+    assert transaction[0]["ConditionCheck"]["Key"] == repository._key(
+        "user-1", "session-1", "STATE"
+    )
+    put = transaction[1]["Put"]
+    assert put["TableName"] == "mailbox-table"
+    assert put["ConditionExpression"] == "attribute_not_exists(recordKey)"
+    assert repository._deserialize(put["Item"])["recordKey"] == "INBOX#event-1"
+
+    client.transact_write_items.side_effect = transaction_condition_failure()
+    client.get_item.return_value = {}
+    assert repository.enqueue(item) is False
+
+
+def test_dynamodb_enqueue_rejects_tombstoned_session():
+    client = MagicMock()
+    repository = DynamoDBMailboxRepository("mailbox-table", client=client)
+    client.transact_write_items.side_effect = transaction_condition_failure()
+    client.get_item.return_value = {
+        "Item": repository._serialize({
+            "sessionKey": "USER#user-1#SESSION#session-1",
+            "recordKey": "STATE",
+            "deletedAt": NOW.isoformat(),
+        })
+    }
+
+    with pytest.raises(SessionDeletedError):
+        repository.enqueue(event("event-1"))
+
+
+def test_dynamodb_claim_is_fenced_by_session_state():
+    client = MagicMock()
+    repository = DynamoDBMailboxRepository("mailbox-table", client=client)
+    stored = event("event-1")
+    client.query.return_value = {"Items": [repository._serialize(stored.to_record())]}
+    lease = type("Lease", (), {"owner": "worker-1", "epoch": 4, "expires_at": 0})()
+
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW,
+    )
+
+    assert claimed.status == "processing"
+    transaction = client.transact_write_items.call_args.kwargs["TransactItems"]
+    state_check = transaction[0]["ConditionCheck"]
+    assert repository._deserialize(state_check["Key"])["recordKey"] == "STATE"
+    assert "leaseEpoch = :epoch" in state_check["ConditionExpression"]
+    assert transaction[1]["Update"]["Key"] == repository._key(
+        "user-1", "session-1", "INBOX#event-1"
+    )
+
+
+def test_dynamodb_ack_rejects_a_stale_transaction():
+    client = MagicMock()
+    repository = DynamoDBMailboxRepository("mailbox-table", client=client)
+    client.transact_write_items.side_effect = transaction_condition_failure()
+    claimed = event("event-1")
+    claimed.status = "processing"
+    claimed.attempts = 1
+    lease = type("Lease", (), {"owner": "worker-1", "epoch": 4, "expires_at": 0})()
+
+    assert repository.acknowledge(claimed, lease, now=NOW) is False
+
+
+def test_dynamodb_ack_writes_projections_in_fenced_transaction():
+    client = MagicMock()
+    repository = DynamoDBMailboxRepository("mailbox-table", client=client)
+    claimed = event("event-1")
+    claimed.status = "processing"
+    claimed.attempts = 1
+    projection = SessionEvent.create(
+        event_id="event-1:assistant",
+        event_type="assistant.turn.completed",
+        session_id="session-1",
+        user_id="user-1",
+        origin_event_id="event-1",
+        now=NOW,
+    )
+    lease = type("Lease", (), {"owner": "worker-1", "epoch": 4, "expires_at": 0})()
+
+    assert repository.acknowledge(
+        claimed,
+        lease,
+        session_events=[projection],
+        now=NOW,
+    )
+
+    transaction = client.transact_write_items.call_args.kwargs["TransactItems"]
+    assert len(transaction) == 3
+    stored = repository._deserialize(transaction[2]["Put"]["Item"])
+    assert stored["recordKey"] == "OUTBOX#event-1:assistant"
+    assert stored["originEventId"] == "event-1"

--- a/chatbot-app/agentcore/tests/unit/test_mailbox_runtime.py
+++ b/chatbot-app/agentcore/tests/unit/test_mailbox_runtime.py
@@ -1,0 +1,69 @@
+import asyncio
+import threading
+
+import pytest
+
+from agent import mailbox_runtime
+from agent.mailbox import FileMailboxRepository, MailboxEvent
+
+
+@pytest.fixture(autouse=True)
+def clear_runtime():
+    mailbox_runtime.clear_mailbox_runtime()
+    yield
+    mailbox_runtime.clear_mailbox_runtime()
+
+
+@pytest.mark.asyncio
+async def test_notify_drains_on_registered_runtime_loop(monkeypatch, tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(
+        MailboxEvent.create(
+            event_id="event-1",
+            event_type="test.ready",
+            session_id="session-1",
+            user_id="user-1",
+            source_type="test",
+            source_id="source-1",
+        )
+    )
+    observed = []
+    target_loop = asyncio.new_event_loop()
+    started = threading.Event()
+
+    def run_loop():
+        asyncio.set_event_loop(target_loop)
+        started.set()
+        target_loop.run_forever()
+
+    thread = threading.Thread(target=run_loop)
+    thread.start()
+    started.wait(timeout=2)
+
+    async def handler(event):
+        observed.append((event.event_id, asyncio.get_running_loop()))
+
+    monkeypatch.setattr(mailbox_runtime, "get_mailbox_repository", lambda: repository)
+    mailbox_runtime.register_mailbox_runtime(
+        target_loop,
+        {"test.ready": handler},
+    )
+
+    try:
+        result = await mailbox_runtime.notify_session_mailbox(
+            "user-1",
+            "session-1",
+        )
+    finally:
+        target_loop.call_soon_threadsafe(target_loop.stop)
+        thread.join(timeout=2)
+        target_loop.close()
+
+    assert result.processed == 1
+    assert observed == [("event-1", target_loop)]
+
+
+@pytest.mark.asyncio
+async def test_notify_fails_when_runtime_is_unavailable():
+    with pytest.raises(RuntimeError, match="not available"):
+        await mailbox_runtime.notify_session_mailbox("user-1", "session-1")

--- a/chatbot-app/agentcore/tests/unit/test_research_jobs.py
+++ b/chatbot-app/agentcore/tests/unit/test_research_jobs.py
@@ -1,5 +1,6 @@
 import asyncio
 from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -36,6 +37,7 @@ async def test_report_is_durable_before_delivery(monkeypatch):
         lambda *args, **kwargs: 1,
     )
     monkeypatch.setattr(research_jobs.async_tasks, "end", lambda task_id: True)
+    monkeypatch.setattr(research_jobs, "_mailbox_write_enabled", lambda: False)
 
     async def deliver(record, artifact):
         deliveries.append((deepcopy(record), deepcopy(artifact)))
@@ -59,11 +61,11 @@ async def test_report_is_durable_before_delivery(monkeypatch):
     await research_jobs._run_job(record, events)
 
     report_index = next(i for i, item in enumerate(writes) if item[0] == "report")
-    completed_index = next(
+    delivery_ready_index = next(
         i for i, item in enumerate(writes)
-        if item[0] == "job" and item[1]["status"] == "completed"
+        if item[0] == "job" and item[1]["status"] == "delivering"
     )
-    assert report_index < completed_index
+    assert report_index < delivery_ready_index
     assert deliveries[0][1]["id"] == "research-tool-1"
     assert writes[-1][1]["status"] == "delivered"
 
@@ -83,6 +85,7 @@ async def test_delivery_failure_keeps_completed_job_retryable(monkeypatch):
     )
     monkeypatch.setattr(research_jobs.async_tasks, "begin", lambda *args, **kwargs: 1)
     monkeypatch.setattr(research_jobs.async_tasks, "end", lambda task_id: True)
+    monkeypatch.setattr(research_jobs, "_mailbox_write_enabled", lambda: False)
 
     async def fail_delivery(record, artifact):
         raise RuntimeError("delivery unavailable")
@@ -140,6 +143,376 @@ def test_start_returns_without_running_worker_inline(monkeypatch):
     assert saved[0]["status"] == "queued"
     assert len(started) == 1
     assert started[0].daemon is True
+
+
+def test_cloud_job_writes_use_orchestration_table(monkeypatch):
+    table = MagicMock()
+    resource = MagicMock()
+    resource.Table.return_value = table
+    monkeypatch.setenv("DYNAMODB_USERS_TABLE", "users-table")
+    monkeypatch.setenv("SESSION_ORCHESTRATION_TABLE", "orchestration-table")
+    monkeypatch.setattr(research_jobs.boto3, "resource", lambda *args, **kwargs: resource)
+    record = {
+        "jobId": "job-1",
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "status": "queued",
+    }
+
+    research_jobs._save_job(record)
+
+    resource.Table.assert_called_once_with("orchestration-table")
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["sessionKey"] == "USER#user-1#SESSION#session-1"
+    assert item["recordKey"] == "JOB#job-1"
+    assert item["recordType"] == "JOB"
+    assert "sk" not in item
+
+
+def test_cloud_job_reads_merge_orchestration_and_legacy_rows(monkeypatch):
+    orchestration = MagicMock()
+    orchestration.query.return_value = {
+        "Items": [{
+            "jobId": "new-job",
+            "sessionId": "session-1",
+            "userId": "user-1",
+        }],
+    }
+    legacy = MagicMock()
+    legacy.query.return_value = {
+        "Items": [
+            {
+                "jobId": "new-job",
+                "status": "stale",
+            },
+            {
+                "jobId": "old-job",
+                "sessionId": "session-1",
+                "userId": "user-1",
+            },
+        ],
+    }
+    resource = MagicMock()
+    resource.Table.side_effect = lambda name: (
+        orchestration if name == "orchestration-table" else legacy
+    )
+    monkeypatch.setenv("DYNAMODB_USERS_TABLE", "users-table")
+    monkeypatch.setenv("SESSION_ORCHESTRATION_TABLE", "orchestration-table")
+    monkeypatch.setattr(research_jobs.boto3, "resource", lambda *args, **kwargs: resource)
+
+    jobs = research_jobs._list_jobs("user-1", "session-1")
+
+    assert {item["jobId"] for item in jobs} == {"new-job", "old-job"}
+    assert next(item for item in jobs if item["jobId"] == "new-job").get("status") != (
+        "stale"
+    )
+    assert orchestration.query.call_args.kwargs["ExpressionAttributeValues"] == {
+        ":session_key": "USER#user-1#SESSION#session-1",
+        ":prefix": "JOB#",
+    }
+
+
+def test_completion_mailbox_event_is_small_and_idempotent(monkeypatch):
+    observed = []
+
+    class Repository:
+        def enqueue(self, event):
+            observed.append(event)
+            return len(observed) == 1
+
+    monkeypatch.setattr(research_jobs, "_mailbox_write_enabled", lambda: True)
+    monkeypatch.setattr(
+        "agent.mailbox.get_mailbox_repository",
+        lambda: Repository(),
+    )
+    record = {
+        "jobId": "a" * 32,
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "artifactId": "research-tool-1",
+        "artifact": {
+            "id": "research-tool-1",
+            "title": "Report",
+            "type": "research",
+        },
+        "artifactBucket": "bucket",
+        "artifactS3Key": "research/report.md",
+    }
+
+    first = research_jobs._enqueue_completion_event(record)
+    second = research_jobs._enqueue_completion_event(record)
+
+    assert first == second == f"research-result:{record['jobId']}"
+    assert observed[0].event_type == "async_result.ready"
+    assert observed[0].payload_ref == {
+        "bucket": "bucket",
+        "key": "research/report.md",
+    }
+    assert "content" not in observed[0].payload["artifact"]
+
+
+def test_artifact_state_reference_excludes_report_body():
+    artifact = {
+        "id": "artifact-1",
+        "title": "Report",
+        "content": "# Large report",
+    }
+
+    reference = research_jobs._build_artifact_reference(
+        {
+            "artifactBucket": "bucket",
+            "artifactS3Key": "reports/job-1.md",
+        },
+        artifact,
+    )
+
+    assert reference == {
+        "id": "artifact-1",
+        "title": "Report",
+        "content_ref": {
+            "bucket": "bucket",
+            "key": "reports/job-1.md",
+        },
+    }
+
+
+def test_recover_pending_job_creates_deterministic_mailbox_event(monkeypatch):
+    saved = []
+    record = {
+        "jobId": "job-1",
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "status": "completed",
+    }
+    monkeypatch.setattr(
+        research_jobs,
+        "load_pending_results",
+        lambda user_id, session_id: [{"record": record, "artifact": {}}],
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_enqueue_completion_event",
+        lambda item: "research-result:job-1",
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_job",
+        lambda item: saved.append(deepcopy(item)),
+    )
+
+    recovered = research_jobs.recover_pending_mailbox_events(
+        "user-1",
+        "session-1",
+    )
+
+    assert recovered == ["research-result:job-1"]
+    assert saved[0]["mailboxEventId"] == "research-result:job-1"
+
+
+def test_recover_pending_job_reenqueues_existing_idempotency_key(monkeypatch):
+    record = {
+        "jobId": "job-1",
+        "mailboxEventId": "research-result:job-1",
+    }
+    monkeypatch.setattr(
+        research_jobs,
+        "load_pending_results",
+        lambda user_id, session_id: [{"record": record, "artifact": {}}],
+    )
+    enqueue = MagicMock(return_value="research-result:job-1")
+    save = MagicMock()
+    monkeypatch.setattr(research_jobs, "_enqueue_completion_event", enqueue)
+    monkeypatch.setattr(research_jobs, "_save_job", save)
+
+    recovered = research_jobs.recover_pending_mailbox_events(
+        "user-1",
+        "session-1",
+    )
+
+    assert recovered == ["research-result:job-1"]
+    enqueue.assert_called_once_with(record)
+    save.assert_called_once_with(record)
+
+
+@pytest.mark.asyncio
+async def test_mailbox_delivery_notifies_instead_of_direct_callback(monkeypatch):
+    writes = []
+    enqueue_snapshots = []
+    direct_deliveries = []
+    notifications = []
+
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_job",
+        lambda record: writes.append(deepcopy(record)),
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_report",
+        lambda record, report: {
+            "artifactPath": "/tmp/report.md",
+        },
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_enqueue_completion_event",
+        lambda record: (
+            enqueue_snapshots.append(deepcopy(record))
+            or "research-result:job-1"
+        ),
+    )
+    monkeypatch.setattr(research_jobs, "_mailbox_write_enabled", lambda: True)
+    monkeypatch.setattr(research_jobs.async_tasks, "begin", lambda *args, **kwargs: 1)
+    monkeypatch.setattr(research_jobs.async_tasks, "end", lambda task_id: True)
+    monkeypatch.setattr(
+        "agent.mailbox_runtime.mailbox_delivery_enabled",
+        lambda: True,
+    )
+
+    async def direct_delivery(record, artifact):
+        direct_deliveries.append(record)
+
+    async def notify(record):
+        notifications.append(record["mailboxEventId"])
+        return type("Result", (), {"dead": 0})()
+
+    monkeypatch.setattr(research_jobs, "_deliver", direct_delivery)
+    monkeypatch.setattr(research_jobs, "_notify_mailbox", notify)
+
+    async def events():
+        yield {"status": "success", "content": [{"text": "# Report"}]}
+
+    record = {
+        "jobId": "job-1",
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "artifactId": "research-tool-1",
+        "plan": "plan",
+        "status": "queued",
+        "createdAt": "now",
+        "updatedAt": "now",
+    }
+    await research_jobs._run_job(record, events)
+
+    assert notifications == ["research-result:job-1"]
+    assert direct_deliveries == []
+    assert writes[-1]["status"] == "delivering"
+    assert enqueue_snapshots[0]["status"] == "delivering"
+    assert enqueue_snapshots[0]["mailboxEventId"] == "research-result:job-1"
+    assert writes.index(next(
+        item for item in writes
+        if item.get("mailboxEventId") == "research-result:job-1"
+    )) == len(writes) - 1
+
+
+@pytest.mark.asyncio
+async def test_deleted_session_cancels_completed_research_delivery(monkeypatch):
+    from agent.mailbox import SessionDeletedError
+
+    writes = []
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_job",
+        lambda record: writes.append(deepcopy(record)),
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_report",
+        lambda record, report: {"artifactPath": "/tmp/report.md"},
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_enqueue_completion_event",
+        MagicMock(side_effect=SessionDeletedError("deleted")),
+    )
+    monkeypatch.setattr(research_jobs.async_tasks, "begin", lambda *args, **kwargs: 1)
+    monkeypatch.setattr(research_jobs.async_tasks, "end", lambda task_id: True)
+    delivery = AsyncMock()
+    monkeypatch.setattr(research_jobs, "_deliver", delivery)
+
+    async def events():
+        yield {"status": "success", "content": [{"text": "# Report"}]}
+
+    record = {
+        "jobId": "job-1",
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "artifactId": "artifact-1",
+        "status": "queued",
+        "createdAt": "now",
+        "updatedAt": "now",
+    }
+    await research_jobs._run_job(record, events)
+
+    assert writes[-1]["status"] == "cancelled"
+    delivery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mailbox_write_failure_stays_retryable_without_direct_delivery(
+    monkeypatch,
+):
+    writes = []
+    deliveries = []
+    notifications = []
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_job",
+        lambda record: writes.append(deepcopy(record)),
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_save_report",
+        lambda record, report: {"artifactPath": "/tmp/report.md"},
+    )
+    monkeypatch.setattr(research_jobs, "_mailbox_write_enabled", lambda: True)
+    monkeypatch.setattr(
+        research_jobs,
+        "_enqueue_completion_event",
+        MagicMock(side_effect=RuntimeError("write failed")),
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "_completion_event_exists",
+        lambda record: False,
+    )
+    monkeypatch.setattr(research_jobs.async_tasks, "begin", lambda *args, **kwargs: 1)
+    monkeypatch.setattr(research_jobs.async_tasks, "end", lambda task_id: True)
+    monkeypatch.setattr(
+        "agent.mailbox_runtime.mailbox_delivery_enabled",
+        lambda: True,
+    )
+
+    async def direct_delivery(record, artifact):
+        deliveries.append(record["jobId"])
+
+    async def notify(record):
+        notifications.append(record["jobId"])
+
+    monkeypatch.setattr(research_jobs, "_deliver", direct_delivery)
+    monkeypatch.setattr(research_jobs, "_notify_mailbox", notify)
+
+    async def events():
+        yield {"status": "success", "content": [{"text": "# Report"}]}
+
+    record = {
+        "jobId": "job-1",
+        "sessionId": "session-1",
+        "userId": "user-1",
+        "artifactId": "artifact-1",
+        "status": "queued",
+        "createdAt": "now",
+        "updatedAt": "now",
+    }
+    await research_jobs._run_job(record, events)
+
+    assert notifications == []
+    assert deliveries == []
+    assert writes[-1]["status"] == "completed"
+    assert writes[-1]["deliveryError"] == (
+        "Mailbox delivery is enabled but completion enqueue failed"
+    )
+    assert "mailboxEventId" not in writes[-1]
 
 
 @pytest.mark.asyncio

--- a/chatbot-app/agentcore/tests/unit/test_session_coordinator.py
+++ b/chatbot-app/agentcore/tests/unit/test_session_coordinator.py
@@ -1,0 +1,137 @@
+import asyncio
+
+import pytest
+
+from agent.mailbox import (
+    DEAD,
+    PROCESSED,
+    FileMailboxRepository,
+    MailboxEvent,
+    SessionEvent,
+)
+from agent.session_coordinator import SessionCoordinator
+
+
+def mailbox_event(event_id: str, event_type: str = "test.ready") -> MailboxEvent:
+    return MailboxEvent.create(
+        event_id=event_id,
+        event_type=event_type,
+        session_id="session-1",
+        user_id="user-1",
+        source_type="test",
+        source_id=event_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_processes_events_once_in_order(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1"))
+    repository.enqueue(mailbox_event("event-2"))
+    observed = []
+
+    async def handler(event):
+        observed.append(event.event_id)
+
+    result = await SessionCoordinator(
+        repository,
+        {"test.ready": handler},
+    ).drain("user-1", "session-1", owner="worker-1")
+
+    assert result.processed == 2
+    assert observed == ["event-1", "event-2"]
+    assert [event.status for event in repository.list_events("user-1", "session-1")] == [
+        PROCESSED,
+        PROCESSED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handler_projections_are_committed_with_acknowledgement(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1"))
+
+    async def handler(event):
+        return [
+            SessionEvent.create(
+                event_id=f"{event.event_id}:assistant",
+                event_type="assistant.turn.completed",
+                session_id=event.session_id,
+                user_id=event.user_id,
+                origin_event_id=event.event_id,
+            )
+        ]
+
+    result = await SessionCoordinator(
+        repository,
+        {"test.ready": handler},
+    ).drain("user-1", "session-1", owner="worker-1")
+
+    assert result.processed == 1
+    assert [
+        item.event_id
+        for item in repository.list_session_events("user-1", "session-1")
+    ] == ["event-1:assistant"]
+
+
+@pytest.mark.asyncio
+async def test_second_coordinator_cannot_enter_live_session(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1"))
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(event):
+        entered.set()
+        await release.wait()
+
+    coordinator = SessionCoordinator(repository, {"test.ready": handler})
+    first_task = asyncio.create_task(
+        coordinator.drain("user-1", "session-1", owner="worker-1")
+    )
+    await entered.wait()
+
+    second = await coordinator.drain(
+        "user-1", "session-1", owner="worker-2"
+    )
+    release.set()
+    first = await first_task
+
+    assert first.processed == 1
+    assert second.acquired is False
+
+
+@pytest.mark.asyncio
+async def test_failure_is_retried_then_dead_lettered(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1"))
+
+    async def handler(event):
+        raise RuntimeError("failed")
+
+    coordinator = SessionCoordinator(
+        repository,
+        {"test.ready": handler},
+        max_attempts=2,
+        retry_delay_seconds=0,
+    )
+
+    first = await coordinator.drain("user-1", "session-1", owner="worker-1")
+    second = await coordinator.drain("user-1", "session-1", owner="worker-2")
+
+    assert first.retried == 1
+    assert second.dead == 1
+    assert repository.list_events("user-1", "session-1")[0].status == DEAD
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_is_not_retried(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1", "unknown"))
+
+    result = await SessionCoordinator(repository, {}).drain(
+        "user-1", "session-1", owner="worker-1"
+    )
+
+    assert result.dead == 1
+    assert repository.list_events("user-1", "session-1")[0].status == DEAD

--- a/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
+++ b/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
@@ -12,7 +12,7 @@ async function readChatInterfaceSource(): Promise<string> {
 }
 
 describe('durable research completion replay', () => {
-  it('uses the durable research job hook as the completion source', async () => {
+  it('uses the durable research job hook as the artifact source', async () => {
     const source = await readChatInterfaceSource()
 
     expect(source).toContain('useResearchJobs(')
@@ -25,7 +25,7 @@ describe('durable research completion replay', () => {
     const source = await readChatInterfaceSource()
     const effect = source.slice(
       source.indexOf('A completed report is readable'),
-      source.indexOf('Background continuations have their own buffered'),
+      source.indexOf('Durable session projections are the generic delivery signal'),
     )
 
     expect(effect).toContain('researchArtifactVersionsRef')
@@ -46,19 +46,25 @@ describe('durable research completion replay', () => {
     expect(reset).toContain('researchArtifactVersionsRef.current.clear()')
   })
 
-  it('replays the background delivery execution instead of replacing history', async () => {
+  it('replays background delivery from generic durable session events', async () => {
     const source = await readChatInterfaceSource()
     const effect = source.slice(
-      source.indexOf('Background continuations have their own buffered'),
+      source.indexOf('Durable session projections are the generic delivery signal'),
       source.indexOf('// Keep reloadFromStorage ref'),
     )
 
-    expect(effect).toContain('research-delivery-${jobId}')
-    expect(effect).toContain('await replayExecution(executionId)')
-    expect(effect).toContain('for (const jobId of unseen)')
+    expect(source).toContain('useSessionEvents(sessionId)')
+    expect(effect).toContain("event.eventType === 'assistant.turn.completed'")
+    expect(effect).toContain('event.payload.executionId,')
+    expect(effect).toContain('event.payload.logicalMessageId')
+    expect(effect).toContain('representedOriginEventIds.has(event.originEventId)')
+    expect(effect).toContain('isLoadingMessages')
+    expect(effect).toContain('for (const event of unseen)')
+    expect(effect).toContain('if (!replayed) break')
+    expect(effect).toContain('reloadedDeliveriesRef.current.delete(event.eventId)')
     expect(effect).toContain('queuedMessages.length > 0')
     expect(effect).toContain("agentStatus !== 'idle'")
-    expect(effect).not.toContain('await loadSession(sessionId)')
+    expect(effect).not.toContain('deliveredJobIds')
   })
 
   it('marks the first visible event of each run as a new assistant turn', async () => {

--- a/chatbot-app/frontend/__tests__/hooks/useArtifacts.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useArtifacts.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useArtifacts } from '@/hooks/useArtifacts'
+import type { Artifact } from '@/types/artifact'
+
+const firstArtifact: Artifact = {
+  id: 'research-1',
+  type: 'research',
+  title: 'First session report',
+  content: '# Report',
+  timestamp: '2026-08-06T00:00:00Z',
+}
+
+describe('useArtifacts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not expose or copy artifacts when the active session changes', async () => {
+    const hook = renderHook(
+      ({ sessionId }) => useArtifacts(sessionId),
+      { initialProps: { sessionId: 'session-1' } },
+    )
+
+    await waitFor(() => {
+      expect(hook.result.current.artifacts).toEqual([])
+    })
+
+    act(() => {
+      hook.result.current.addArtifact(firstArtifact)
+    })
+    expect(hook.result.current.artifacts).toEqual([firstArtifact])
+
+    const staleAddArtifact = hook.result.current.addArtifact
+    hook.rerender({ sessionId: 'session-2' })
+
+    expect(hook.result.current.artifacts).toEqual([])
+    expect(hook.result.current.selectedArtifactId).toBeNull()
+
+    act(() => {
+      staleAddArtifact({
+        ...firstArtifact,
+        id: 'late-session-1-artifact',
+      })
+    })
+
+    expect(hook.result.current.artifacts).toEqual([])
+
+    const secondArtifact: Artifact = {
+      ...firstArtifact,
+      id: 'session-2-artifact',
+      title: 'Second session report',
+    }
+    act(() => {
+      hook.result.current.addArtifact(secondArtifact)
+    })
+
+    expect(hook.result.current.artifacts).toEqual([secondArtifact])
+    expect(sessionStorage.setItem).toHaveBeenLastCalledWith(
+      'artifacts-session-2',
+      JSON.stringify([secondArtifact]),
+    )
+  })
+})

--- a/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
@@ -68,11 +68,12 @@ const INTERRUPT = {
 
 function setup(handleStreamEvent = vi.fn()) {
   const stopFetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '' })
+  const setMessages = vi.fn()
   const hook = renderHook(() =>
     useChatAPI({
       backendUrl: 'http://localhost:8000',
       setUIState: vi.fn(),
-      setMessages: vi.fn(),
+      setMessages,
       handleStreamEvent,
       resetStreamingState: vi.fn(),
       sessionId: 'session-1',
@@ -81,7 +82,7 @@ function setup(handleStreamEvent = vi.fn()) {
       currentTemperature: 0.5,
     } as any),
   )
-  return { hook, stopFetch, handleStreamEvent }
+  return { hook, stopFetch, handleStreamEvent, setMessages }
 }
 
 /** Runs one turn whose stream ends with the given events. */
@@ -181,7 +182,7 @@ describe('useChatAPI — background execution replay', () => {
     const handleStreamEvent = vi.fn().mockImplementation(async event => {
       if (event.type === 'RUN_FINISHED') await cleanup
     })
-    const { hook } = setup(handleStreamEvent)
+    const { hook, setMessages } = setup(handleStreamEvent)
     await act(async () => {
       await Promise.resolve()
       await Promise.resolve()
@@ -203,7 +204,9 @@ describe('useChatAPI — background execution replay', () => {
     let replayed = false
     let replayPromise: Promise<boolean> | undefined
     await act(async () => {
-      replayPromise = hook.result.current.replayExecution(executionId)
+      replayPromise = hook.result.current.replayExecution(executionId, {
+        logicalMessageId: 'mailbox:research-result:job-1:1',
+      })
       await Promise.resolve()
     })
     expect(replayed).toBe(false)
@@ -228,5 +231,19 @@ describe('useChatAPI — background execution replay', () => {
     expect(handleStreamEvent.mock.calls.map(([event]) => event.type)).toEqual(
       events.map(event => event.type),
     )
+    const identityUpdate =
+      setMessages.mock.calls[setMessages.mock.calls.length - 1]?.[0]
+    expect(identityUpdate([
+      {
+        id: 'completion-1',
+        text: 'Research is ready.',
+        timestamp: '2026-08-06T00:00:00Z',
+      },
+    ])).toEqual([
+      expect.objectContaining({
+        id: 'mailbox:research-result:job-1:1',
+        logicalMessageId: 'mailbox:research-result:job-1:1',
+      }),
+    ])
   })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
@@ -134,4 +134,23 @@ describe('useResearchJobs', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(hook.result.current.jobs[0]?.status).toBe('running')
   })
+
+  it('hides the previous session snapshot immediately when switching sessions', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([runningJob]))
+      .mockImplementationOnce(() => new Promise<Response>(() => {}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ sessionId }) => useResearchJobs(sessionId),
+      { initialProps: { sessionId: 'session-1' } },
+    )
+    await flushAsyncWork()
+    expect(hook.result.current.jobs).toEqual([runningJob])
+
+    hook.rerender({ sessionId: 'session-2' })
+
+    expect(hook.result.current.jobs).toEqual([])
+    expect(hook.result.current.deliveredJobIds).toEqual([])
+  })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
@@ -112,4 +112,22 @@ describe('useSessionEvents', () => {
 
     expect(hook.result.current.events).toEqual([])
   })
+
+  it('hides the previous session projections immediately when switching sessions', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([completion]))
+      .mockImplementationOnce(() => new Promise<Response>(() => {}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ sessionId }) => useSessionEvents(sessionId),
+      { initialProps: { sessionId: 'session-1' } },
+    )
+    await flushAsyncWork()
+    expect(hook.result.current.events).toEqual([completion])
+
+    hook.rerender({ sessionId: 'session-2' })
+
+    expect(hook.result.current.events).toEqual([])
+  })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSessionEvents } from '@/hooks/useSessionEvents'
+
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: vi.fn().mockResolvedValue({
+    tokens: {
+      accessToken: {
+        toString: () => 'session-event-token',
+      },
+    },
+  }),
+}))
+
+function response(events: unknown[]) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ events }),
+  } as Response)
+}
+
+async function flushAsyncWork() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+const completion = {
+  schemaVersion: 1,
+  eventId: 'research-result:job-1:assistant',
+  eventType: 'assistant.turn.completed',
+  sessionId: 'session-1',
+  userId: 'user-1',
+  createdAt: '2026-08-06T00:00:02Z',
+  originEventId: 'research-result:job-1',
+  correlation: { jobId: 'job-1' },
+  payload: {
+    executionId: 'session-1:research-delivery-job-1',
+  },
+}
+
+describe('useSessionEvents', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('baselines existing projections and emits only newly discovered events', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response([completion]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(() => useSessionEvents('session-1'))
+    await flushAsyncWork()
+    expect(hook.result.current.events).toEqual([])
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(hook.result.current.events).toEqual([completion])
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/session/events?session_id=session-1',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer session-event-token',
+        }),
+      }),
+    )
+  })
+
+  it('surfaces initial projections so the consumer can close the history race', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => response([completion])))
+
+    const hook = renderHook(() => useSessionEvents('session-1'))
+    await flushAsyncWork()
+
+    expect(hook.result.current.events).toEqual([completion])
+  })
+
+  it('removes a projection after truncate deletes it from durable storage', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([completion]))
+      .mockImplementationOnce(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(() => useSessionEvents('session-1'))
+    await flushAsyncWork()
+    expect(hook.result.current.events).toEqual([completion])
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(hook.result.current.events).toEqual([])
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/message-metadata.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/message-metadata.test.ts
@@ -1,0 +1,91 @@
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const send = vi.hoisted(() => vi.fn())
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: class {
+    send = send
+  },
+  QueryCommand: class {
+    input: Record<string, unknown>
+
+    constructor(input: Record<string, unknown>) {
+      this.input = input
+    }
+  },
+  UpdateItemCommand: class {
+    input: Record<string, any>
+
+    constructor(input: Record<string, any>) {
+      this.input = input
+    }
+  },
+}))
+
+describe('message metadata records', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('SESSION_ORCHESTRATION_TABLE', 'orchestration-table')
+    send.mockReset()
+  })
+
+  it('stores allowed fields under the logical message identity', async () => {
+    send.mockResolvedValue({})
+    const { updateMessageMetadataRecord } = await import('@/lib/message-metadata')
+
+    await updateMessageMetadataRecord(
+      'user-1',
+      'session-1',
+      'mailbox:event-1:1',
+      {
+        feedback: { type: 'positive' },
+        unsupported: 'ignored',
+      },
+    )
+
+    const command = send.mock.calls[0][0]
+    expect(command.input.TableName).toBe('orchestration-table')
+    expect(unmarshall(command.input.Key)).toEqual({
+      sessionKey: 'USER#user-1#SESSION#session-1',
+      recordKey: 'MESSAGE_META#mailbox:event-1:1',
+    })
+    expect(command.input.ExpressionAttributeNames).toMatchObject({
+      '#field0': 'feedback',
+    })
+    expect(Object.values(command.input.ExpressionAttributeNames)).not.toContain(
+      'unsupported',
+    )
+  })
+
+  it('reads paginated records keyed by logical message id', async () => {
+    send
+      .mockResolvedValueOnce({
+        Items: [
+          marshall({
+            logicalMessageId: 'message-1',
+            feedback: { type: 'positive' },
+          }),
+        ],
+        LastEvaluatedKey: marshall({
+          sessionKey: 'USER#user-1#SESSION#session-1',
+          recordKey: 'MESSAGE_META#message-1',
+        }),
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          marshall({
+            logicalMessageId: 'message-2',
+            documents: [{ id: 'doc-1' }],
+          }),
+        ],
+      })
+    const { listMessageMetadataRecords } = await import('@/lib/message-metadata')
+
+    const records = await listMessageMetadataRecords('user-1', 'session-1')
+
+    expect(Object.keys(records)).toEqual(['message-1', 'message-2'])
+    expect(records['message-2'].documents).toEqual([{ id: 'doc-1' }])
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/research-jobs.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/research-jobs.test.ts
@@ -25,12 +25,15 @@ describe('parseResearchStartReceipt', () => {
 })
 
 describe('hideBackgroundResearchInputs', () => {
-  it('moves the hidden wake-up boundary to the delivery response', () => {
+  it.each([
+    '<background-research-result>',
+    '<background-research-result job_id="legacy-job">',
+  ])('moves the hidden wake-up boundary to the delivery response for %s', tag => {
     const messages = hideBackgroundResearchInputs([
       { role: 'assistant', content: [{ text: 'Research started.' }] },
       {
         role: 'user',
-        content: [{ text: '<background-research-result job_id="job-1">' }],
+        content: [{ text: tag }],
       },
       { role: 'assistant', content: [{ text: 'Research complete.' }] },
     ])

--- a/chatbot-app/frontend/src/app/api/conversation/history/route.ts
+++ b/chatbot-app/frontend/src/app/api/conversation/history/route.ts
@@ -22,6 +22,13 @@ let GetParameterCommand: any
 // Cache for MEMORY_ID
 let cachedMemoryId: string | null = null
 
+function eventMetadataString(event: any, key: string): string | undefined {
+  const value = event?.metadata?.[key]
+  if (typeof value === 'string') return value
+  if (typeof value?.stringValue === 'string') return value.stringValue
+  return undefined
+}
+
 async function getMemoryId(): Promise<string | null> {
   // Use environment variable if available
   const envMemoryId = process.env.MEMORY_ID || process.env.NEXT_PUBLIC_MEMORY_ID
@@ -226,9 +233,14 @@ export async function GET(request: NextRequest) {
             continue
           }
 
+          const logicalMessageId = eventMetadataString(event, 'logicalMessageId')
+          const originEventId = eventMetadataString(event, 'originEventId')
           const message: any = {
             ...parsed.message,
-            id: event.eventId || `msg-${sessionId}-${msgIndex}`,
+            id: logicalMessageId || event.eventId || `msg-${sessionId}-${msgIndex}`,
+            ...(logicalMessageId && { logicalMessageId }),
+            ...(event.eventId && { eventId: event.eventId }),
+            ...(originEventId && { originEventId }),
             timestamp: event.eventTime || new Date().toISOString()
           }
           // Extract SDK-persisted metadata (usage + metrics) from message.metadata
@@ -259,9 +271,14 @@ export async function GET(request: NextRequest) {
               const blobMessageData = JSON.parse(blobParsed[0])
 
               if (blobMessageData?.message) {
+                const logicalMessageId = eventMetadataString(event, 'logicalMessageId')
+                const originEventId = eventMetadataString(event, 'originEventId')
                 const message: any = {
                   ...blobMessageData.message,
-                  id: event.eventId || `msg-${sessionId}-${msgIndex}`,
+                  id: logicalMessageId || event.eventId || `msg-${sessionId}-${msgIndex}`,
+                  ...(logicalMessageId && { logicalMessageId }),
+                  ...(event.eventId && { eventId: event.eventId }),
+                  ...(originEventId && { originEventId }),
                   timestamp: event.eventTime || new Date().toISOString()
                 }
                 if (blobMessageData.message.metadata?.usage) {
@@ -299,10 +316,21 @@ export async function GET(request: NextRequest) {
       sessionMetadata = session?.metadata
     }
 
-    // Merge DynamoDB metadata with messages (overrides SDK metadata for backward compat)
-    if (sessionMetadata?.messages) {
+    let messageMetadataRecords: Record<string, any> = {}
+    if (!IS_LOCAL && userId !== 'anonymous') {
+      const { listMessageMetadataRecords } = await import('@/lib/message-metadata')
+      messageMetadataRecords = await listMessageMetadataRecords(userId, sessionId)
+    }
+
+    // Individual orchestration records win. The legacy session metadata map is
+    // retained as a read fallback until old sessions age out.
+    if (sessionMetadata?.messages || Object.keys(messageMetadataRecords).length > 0) {
       messages = messages.map(msg => {
-        const messageMetadata = sessionMetadata.messages[msg.id]
+        const identity = msg.logicalMessageId || msg.id
+        const messageMetadata =
+          messageMetadataRecords[identity] ||
+          sessionMetadata?.messages?.[identity] ||
+          sessionMetadata?.messages?.[msg.eventId]
         if (messageMetadata) {
           return {
             ...msg,
@@ -317,7 +345,11 @@ export async function GET(request: NextRequest) {
         }
         return msg
       })
-      console.log(`[API] Merged metadata for ${Object.keys(sessionMetadata.messages).length} message(s)`)
+      console.log(
+        `[API] Merged individual metadata for ${
+          Object.keys(messageMetadataRecords).length
+        } message(s)`,
+      )
     }
 
     // Synthetic background-research inputs wake the supervisor but are an

--- a/chatbot-app/frontend/src/app/api/session/delete/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/delete/route.ts
@@ -31,6 +31,12 @@ export async function DELETE(request: NextRequest) {
 
     console.log(`[API] Deleting session ${sessionId} for user ${userId}`)
 
+    // Fence mailbox delivery before removing the list projection. A background
+    // worker that completes after this point will observe the tombstone and
+    // cancel instead of recreating conversation state.
+    const { tombstoneSessionOrchestration } = await import('@/lib/session-lifecycle')
+    await tombstoneSessionOrchestration(userId, sessionId)
+
     if (userId === 'anonymous') {
       // Anonymous user - delete from local file storage
       if (IS_LOCAL) {

--- a/chatbot-app/frontend/src/app/api/session/events/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/events/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { extractUserFromRequest } from '@/lib/auth-utils'
+import { listSessionEvents } from '@/lib/session-events'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionId = request.nextUrl.searchParams.get('session_id')
+    if (!sessionId) {
+      return NextResponse.json(
+        { error: 'Missing session_id parameter' },
+        { status: 400 },
+      )
+    }
+
+    const user = await extractUserFromRequest(request)
+    const events = await listSessionEvents(user.userId, sessionId)
+    return NextResponse.json({ events })
+  } catch (error) {
+    console.error('[SessionEvents] Failed to list events:', error)
+    return NextResponse.json(
+      { error: 'Failed to list session events' },
+      { status: 500 },
+    )
+  }
+}

--- a/chatbot-app/frontend/src/app/api/session/truncate/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/truncate/route.ts
@@ -41,7 +41,12 @@ export async function POST(request: NextRequest) {
     const user = await extractUserFromRequest(request)
     const userId = user.userId
 
-    const { sessionId, fromEventId, fromTimestamp } = await request.json()
+    const {
+      sessionId,
+      fromEventId,
+      fromTimestamp,
+      originEventId,
+    } = await request.json()
     if (!sessionId) {
       return NextResponse.json({ success: false, error: 'sessionId is required' }, { status: 400 })
     }
@@ -58,6 +63,14 @@ export async function POST(request: NextRequest) {
       if (typeof fromTimestamp === 'number') {
         const { truncateSessionMessages } = await import('@/lib/local-session-store')
         const deleted = truncateSessionMessages(userId, sessionId, fromTimestamp)
+        if (originEventId) {
+          const { deleteSessionEventProjection } = await import('@/lib/session-events')
+          await deleteSessionEventProjection(
+            userId,
+            sessionId,
+            `${originEventId}:assistant`,
+          )
+        }
         console.log(`[truncate] LOCAL - Deleted ${deleted} messages`)
         return NextResponse.json({ success: true, sessionId, deleted })
       }
@@ -152,6 +165,15 @@ export async function POST(request: NextRequest) {
       if (i + BATCH_SIZE < toDelete.length) {
         await sleep(500)
       }
+    }
+
+    if (originEventId) {
+      const { deleteSessionEventProjection } = await import('@/lib/session-events')
+      await deleteSessionEventProjection(
+        userId,
+        sessionId,
+        `${originEventId}:assistant`,
+      )
     }
 
     console.log(`[truncate] Deleted ${toDelete.length} events from session ${sessionId}`)

--- a/chatbot-app/frontend/src/app/api/session/update-metadata/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/update-metadata/route.ts
@@ -51,6 +51,20 @@ export async function POST(request: NextRequest) {
         console.warn(`[API] LOCAL - Session not found: ${sessionId}`)
       }
     } else {
+      const {
+        messageMetadataEnabled,
+        updateMessageMetadataRecord,
+      } = await import('@/lib/message-metadata')
+      if (messageMetadataEnabled()) {
+        await updateMessageMetadataRecord(
+          userId,
+          sessionId,
+          messageId,
+          metadata,
+        )
+        return NextResponse.json({ success: true })
+      }
+
       const { updateSession, getSession } = await import('@/lib/dynamodb-client')
       const session = await getSession(userId, sessionId)
       console.log(`[API] Session found: ${!!session}, metadata: ${JSON.stringify(session?.metadata || null)}`)

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -6,6 +6,7 @@ import { useChat } from "@/hooks/useChat"
 import { useArtifacts } from "@/hooks/useArtifacts"
 import { useCanvasHandlers } from "@/hooks/useCanvasHandlers"
 import { useResearchJobs } from "@/hooks/useResearchJobs"
+import { useSessionEvents } from "@/hooks/useSessionEvents"
 import { ArtifactType } from "@/types/artifact"
 import { ChatMessage } from "@/components/chat/ChatMessage"
 import { AssistantTurn } from "@/components/chat/AssistantTurn"
@@ -237,10 +238,20 @@ export function ChatInterface() {
     }
     return invocationIds.size
   }, [groupedMessages])
-  const { jobs: researchJobs, deliveredJobIds } = useResearchJobs(
+  const { jobs: researchJobs } = useResearchJobs(
     sessionId,
     researchInvocationCount,
   )
+  const { events: sessionEvents } = useSessionEvents(sessionId)
+  const representedOriginEventIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const group of groupedMessages) {
+      for (const message of group.messages) {
+        if (message.originEventId) ids.add(message.originEventId)
+      }
+    }
+    return ids
+  }, [groupedMessages])
   const reloadedDeliveriesRef = useRef<Set<string>>(new Set())
   const researchArtifactVersionsRef = useRef<Map<string, string>>(new Map())
 
@@ -272,28 +283,55 @@ export function ChatInterface() {
     }
   }, [researchJobs, addArtifact, sessionId])
 
-  // Background continuations have their own buffered AG-UI execution. Replay
-  // each one through the normal stream handler so its assistant turn appears
-  // live, while the durable job continues to own the tool card and artifact.
+  // Durable session projections are the generic delivery signal. The AG-UI
+  // execution remains a transient optimization for live rendering; when it is
+  // gone, replayExecution falls back to canonical AgentCore history.
   useEffect(() => {
     const userTurnWaiting = queuedMessages.length > 0 && queueHoldReason === null
-    if (agentStatus !== 'idle' || userTurnWaiting || deliveredJobIds.length === 0) return
-    const unseen = deliveredJobIds.filter(id => !reloadedDeliveriesRef.current.has(id))
+    if (isLoadingMessages || agentStatus !== 'idle' || userTurnWaiting) return
+    for (const event of sessionEvents) {
+      if (representedOriginEventIds.has(event.originEventId)) {
+        reloadedDeliveriesRef.current.add(event.eventId)
+      }
+    }
+    const unseen = sessionEvents.filter(event =>
+      event.eventType === 'assistant.turn.completed' &&
+      typeof event.payload?.executionId === 'string' &&
+      !representedOriginEventIds.has(event.originEventId) &&
+      !reloadedDeliveriesRef.current.has(event.eventId)
+    )
     if (unseen.length === 0) return
-    unseen.forEach(id => reloadedDeliveriesRef.current.add(id))
+    unseen.forEach(event => reloadedDeliveriesRef.current.add(event.eventId))
     void (async () => {
-      for (const jobId of unseen) {
-        const executionId = `${sessionId}:research-delivery-${jobId}`
-        await replayExecution(executionId)
+      for (const event of unseen) {
+        try {
+          const replayed = await replayExecution(
+            event.payload.executionId,
+            {
+              logicalMessageId:
+                typeof event.payload.logicalMessageId === 'string'
+                  ? event.payload.logicalMessageId
+                  : undefined,
+            },
+          )
+          // A failed/expired buffer reloads canonical history, which already
+          // contains every committed completion in this batch.
+          if (!replayed) break
+        } catch (error) {
+          reloadedDeliveriesRef.current.delete(event.eventId)
+          console.warn('[ChatInterface] Failed to render session event:', error)
+          break
+        }
       }
     })()
   }, [
     agentStatus,
-    deliveredJobIds,
+    isLoadingMessages,
     queueHoldReason,
     queuedMessages.length,
+    representedOriginEventIds,
     replayExecution,
-    sessionId,
+    sessionEvents,
   ])
 
   // Keep reloadFromStorage ref in sync for the onSessionLoaded callback

--- a/chatbot-app/frontend/src/hooks/useArtifacts.ts
+++ b/chatbot-app/frontend/src/hooks/useArtifacts.ts
@@ -1,6 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { Artifact } from '@/types/artifact'
 
+interface ArtifactSessionState {
+  sessionId: string
+  artifacts: Artifact[]
+  selectedArtifactId: string | null
+  loadedFromBackend: boolean
+}
+
 /**
  * Convert backend artifact format to frontend Artifact.
  */
@@ -55,39 +62,41 @@ function readStorageArtifacts(sessionId: string): Artifact[] {
 export function useArtifacts(
   sessionId: string
 ) {
-  const [artifacts, setArtifacts] = useState<Artifact[]>([])
-  const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null)
+  const [sessionState, setSessionState] = useState<ArtifactSessionState>({
+    sessionId,
+    artifacts: [],
+    selectedArtifactId: null,
+    loadedFromBackend: false,
+  })
   const [isCanvasOpen, setIsCanvasOpen] = useState<boolean>(false)
-  const [loadedFromBackend, setLoadedFromBackend] = useState<boolean>(false)
   const [justUpdated, setJustUpdated] = useState<boolean>(false)
+  const activeSessionIdRef = useRef(sessionId)
+  activeSessionIdRef.current = sessionId
 
-  // Tracks which sessionId the current artifacts state belongs to (guards auto-sync)
-  const loadedSessionIdRef = useRef<string | null>(null)
-
-  // Reset on session switch
-  useEffect(() => {
-    loadedSessionIdRef.current = null
-    setArtifacts([])
-    setSelectedArtifactId(null)
-    setLoadedFromBackend(false)
-  }, [sessionId])
+  // Never expose a snapshot owned by the previous session, even during the
+  // render before the session initialization effect runs.
+  const isCurrentSession = sessionState.sessionId === sessionId
+  const artifacts = isCurrentSession ? sessionState.artifacts : []
+  const selectedArtifactId = isCurrentSession
+    ? sessionState.selectedArtifactId
+    : null
+  const loadedFromBackend =
+    isCurrentSession && sessionState.loadedFromBackend
 
   // Load artifacts from sessionStorage on session init (populated by history API)
   useEffect(() => {
-    if (loadedFromBackend) return
-
     const loaded = readStorageArtifacts(sessionId)
-    if (loaded.length > 0) {
-      setArtifacts(loaded)
-    }
-    loadedSessionIdRef.current = sessionId
-    setLoadedFromBackend(true)
-  }, [sessionId, loadedFromBackend])
+    setSessionState({
+      sessionId,
+      artifacts: loaded,
+      selectedArtifactId: null,
+      loadedFromBackend: true,
+    })
+  }, [sessionId])
 
-  // Auto-sync to sessionStorage; guard against stale session writes
+  // Auto-sync only the snapshot owned by the active session.
   useEffect(() => {
     if (!loadedFromBackend) return
-    if (loadedSessionIdRef.current !== sessionId) return
     sessionStorage.setItem(`artifacts-${sessionId}`, JSON.stringify(artifacts))
   }, [sessionId, loadedFromBackend, artifacts])
 
@@ -100,60 +109,90 @@ export function useArtifacts(
   }, [])
 
   const openArtifact = useCallback((id: string) => {
-    setSelectedArtifactId(id)
+    setSessionState(current => current.sessionId === sessionId
+      ? { ...current, selectedArtifactId: id }
+      : current
+    )
     setIsCanvasOpen(true)
-  }, [])
+  }, [sessionId])
 
   const closeCanvas = useCallback(() => {
     setIsCanvasOpen(false)
-    setSelectedArtifactId(null)
-  }, [])
+    setSessionState(current => current.sessionId === sessionId
+      ? { ...current, selectedArtifactId: null }
+      : current
+    )
+  }, [sessionId])
 
   const addArtifact = useCallback((artifact: Artifact) => {
-    setArtifacts(prev => {
-      const existingIndex = prev.findIndex(a => a.id === artifact.id)
+    setSessionState(current => {
+      if (current.sessionId !== sessionId) return current
+      const existingIndex = current.artifacts.findIndex(a => a.id === artifact.id)
       if (existingIndex >= 0) {
-        return prev.map((a, i) => i === existingIndex ? artifact : a)
+        return {
+          ...current,
+          artifacts: current.artifacts.map((a, i) =>
+            i === existingIndex ? artifact : a
+          ),
+        }
       }
-      return [...prev, artifact]
+      return { ...current, artifacts: [...current.artifacts, artifact] }
     })
-  }, [])
+  }, [sessionId])
 
   const removeArtifact = useCallback((artifactId: string) => {
-    setArtifacts(prev => prev.filter(a => a.id !== artifactId))
-    if (selectedArtifactId === artifactId) {
-      setSelectedArtifactId(null)
-    }
-  }, [selectedArtifactId])
+    setSessionState(current => {
+      if (current.sessionId !== sessionId) return current
+      return {
+        ...current,
+        artifacts: current.artifacts.filter(a => a.id !== artifactId),
+        selectedArtifactId:
+          current.selectedArtifactId === artifactId
+            ? null
+            : current.selectedArtifactId,
+      }
+    })
+  }, [sessionId])
 
   const updateArtifact = useCallback((artifactId: string, updates: Partial<Artifact>) => {
-    setArtifacts(prev => prev.map(a =>
-      a.id === artifactId ? { ...a, ...updates } : a
-    ))
-  }, [])
+    setSessionState(current => current.sessionId === sessionId
+      ? {
+          ...current,
+          artifacts: current.artifacts.map(a =>
+            a.id === artifactId ? { ...a, ...updates } : a
+          ),
+        }
+      : current
+    )
+  }, [sessionId])
 
   /**
    * Refresh artifacts from history API.
    * Returns the refreshed artifacts array for immediate use.
    */
   const refreshArtifacts = useCallback(async (options?: { skipFlashEffect?: boolean }): Promise<Artifact[]> => {
-
+    const requestedSessionId = sessionId
     try {
       const response = await fetch(`/api/conversation/history?session_id=${sessionId}`)
       if (response.ok) {
         const data = await response.json()
         const artifactsData = data.artifacts || []
-        if (Array.isArray(artifactsData) && artifactsData.length > 0) {
-          const converted = artifactsData.map((item: any) => toFrontendArtifact(item, sessionId))
-          loadedSessionIdRef.current = sessionId
-          setArtifacts(converted)
+        const converted = Array.isArray(artifactsData)
+          ? artifactsData.map((item: any) =>
+              toFrontendArtifact(item, requestedSessionId)
+            )
+          : []
+        if (activeSessionIdRef.current !== requestedSessionId) return []
+        setSessionState(current => current.sessionId === requestedSessionId
+          ? { ...current, artifacts: converted, loadedFromBackend: true }
+          : current
+        )
 
-          if (!options?.skipFlashEffect) {
-            setJustUpdated(true)
-            setTimeout(() => setJustUpdated(false), 1500)
-          }
-          return converted
+        if (!options?.skipFlashEffect) {
+          setJustUpdated(true)
+          setTimeout(() => setJustUpdated(false), 1500)
         }
+        return converted
       }
     } catch (error) {
       console.error('[useArtifacts] Failed to refresh artifacts:', error)
@@ -167,9 +206,20 @@ export function useArtifacts(
    */
   const reloadFromStorage = useCallback(() => {
     const loaded = readStorageArtifacts(sessionId)
-    loadedSessionIdRef.current = sessionId
-    setArtifacts(loaded)  // always sync — clears stale state when storage was removed
-    setLoadedFromBackend(true)
+    if (activeSessionIdRef.current !== sessionId) return
+    setSessionState({
+      sessionId,
+      artifacts: loaded,
+      selectedArtifactId: null,
+      loadedFromBackend: true,
+    })
+  }, [sessionId])
+
+  const setSelectedArtifactId = useCallback((id: string | null) => {
+    setSessionState(current => current.sessionId === sessionId
+      ? { ...current, selectedArtifactId: id }
+      : current
+    )
   }, [sessionId])
 
   return {

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -3,7 +3,11 @@ import { Message, ToolExecution } from '@/types/chat'
 import { ReasoningState, ChatSessionState, ChatUIState, InterruptState, AgentStatus, PendingOAuthState } from '@/types/events'
 import { detectBackendUrl } from '@/utils/chat'
 import { useStreamEvents } from './useStreamEvents'
-import { useChatAPI, SessionPreferences } from './useChatAPI'
+import {
+  useChatAPI,
+  ReplayMessageIdentity,
+  SessionPreferences,
+} from './useChatAPI'
 import { usePolling, hasOngoingA2ATools, A2A_TOOLS_REQUIRING_POLLING } from './usePolling'
 import { useMessageQueue, QueuedMessage, QueueHoldReason } from './useMessageQueue'
 import { getApiUrl } from '@/config/environment'
@@ -39,7 +43,10 @@ interface UseChatReturn {
   showProgressPanel: boolean
   toggleProgressPanel: () => void
   sendMessage: (text: string, files?: File[], systemPrompt?: string, selectedArtifactId?: string | null) => Promise<void>
-  replayExecution: (executionId: string) => Promise<boolean>
+  replayExecution: (
+    executionId: string,
+    messageIdentity?: ReplayMessageIdentity,
+  ) => Promise<boolean>
   stopGeneration: () => Promise<void>
   // Queue for turns composed while the agent is busy
   queuedMessages: QueuedMessage[]
@@ -628,17 +635,26 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     })
   }, [enqueue, sessionId])
 
-  const replayExecution = useCallback(async (executionId: string) => {
-    const replayed = await apiReplayExecution(executionId)
+  const replayExecution = useCallback(async (
+    executionId: string,
+    messageIdentity?: ReplayMessageIdentity,
+  ) => {
+    const replaySessionId = sessionId
+    const replayed = messageIdentity
+      ? await apiReplayExecution(executionId, messageIdentity)
+      : await apiReplayExecution(executionId)
+    if (currentSessionIdRef.current !== replaySessionId) return false
     if (!replayed) {
       // Runtime buffers expire; history contains the same durable assistant
       // response and preserves its synthetic turn boundary.
-      await loadSessionWithPreferences(sessionId)
+      await loadSessionWithPreferences(replaySessionId)
     }
+
+    if (currentSessionIdRef.current !== replaySessionId) return replayed
 
     // A message composed while the delivery was rendering is a normal queued
     // user turn. Dispatch it only after replay or history fallback completes.
-    await flushNext(sessionId, {
+    await flushNext(replaySessionId, {
       hasInterrupt: sessionState.interrupt !== null,
       hasPendingOAuth: !!sessionState.pendingOAuth,
     })
@@ -776,14 +792,21 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     const currentSessionId = sessionId
     if (!currentSessionId) return
 
-    // History messages have their eventId as message.id (non-numeric string).
-    // Newly sent messages in the current session have String(Date.now()) as id (numeric).
-    const isHistoryMessage = isNaN(Number(message.id))
-    const params = isHistoryMessage
-      ? { fromEventId: message.id }
-      : { fromTimestamp: message.rawTimestamp }
+    // History messages keep AgentCore eventId as a storage locator while the
+    // UI may use a stable logicalMessageId as message.id.
+    const isHistoryMessage = !!message.eventId
+    const messageTimestamp =
+      message.rawTimestamp ?? new Date(message.timestamp).getTime()
+    const params = {
+      ...(isHistoryMessage
+        ? { fromEventId: message.eventId || message.id }
+        : { fromTimestamp: messageTimestamp }),
+      ...(message.originEventId && {
+        originEventId: message.originEventId,
+      }),
+    }
 
-    if (!isHistoryMessage && !message.rawTimestamp) {
+    if (!isHistoryMessage && !Number.isFinite(messageTimestamp)) {
       console.warn('[truncate] Missing rawTimestamp for non-history message, aborting')
       return
     }

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -177,10 +177,18 @@ export interface SessionPreferences {
   customPromptText?: string
 }
 
+export interface ReplayMessageIdentity {
+  logicalMessageId?: string
+  eventId?: string
+}
+
 interface UseChatAPIReturn {
   newChat: () => Promise<boolean>
   sendMessage: (messageToSend: string, files?: File[], onSuccess?: () => void, onError?: (error: string) => void) => Promise<void>
-  replayExecution: (executionId: string) => Promise<boolean>
+  replayExecution: (
+    executionId: string,
+    messageIdentity?: ReplayMessageIdentity,
+  ) => Promise<boolean>
   cleanup: () => void
   sendStopSignal: () => Promise<boolean>
   loadSession: (sessionId: string) => Promise<{ preferences: SessionPreferences | null; messages: Message[] }>
@@ -391,7 +399,11 @@ export const useChatAPI = ({
   }, [])
 
   // Truncate session from a given event (by eventId or timestamp fallback)
-  const truncateSession = useCallback(async (params: { fromEventId?: string; fromTimestamp?: number }): Promise<boolean> => {
+  const truncateSession = useCallback(async (params: {
+    fromEventId?: string
+    fromTimestamp?: number
+    originEventId?: string
+  }): Promise<boolean> => {
     try {
       const currentSessionId = sessionIdRef.current
       if (!currentSessionId) return false
@@ -1072,6 +1084,15 @@ export const useChatAPI = ({
 
           const currentMessage: Message = {
             id: msg.id || `${newSessionId}-${index}`,
+            ...(msg.logicalMessageId && {
+              logicalMessageId: msg.logicalMessageId
+            }),
+            ...(msg.eventId && {
+              eventId: msg.eventId
+            }),
+            ...(msg.originEventId && {
+              originEventId: msg.originEventId
+            }),
             text: cleanedText,
             sender: msg.role === 'user' ? 'user' : 'bot',
             timestamp: msg.timestamp ? new Date(msg.timestamp).toLocaleTimeString() : new Date().toLocaleTimeString(),
@@ -1218,7 +1239,10 @@ export const useChatAPI = ({
     }
   }, [setMessages, getAuthHeaders, reconnect, handleStreamEvent, setUIState])
 
-  const replayExecution = useCallback(async (executionId: string): Promise<boolean> => {
+  const replayExecution = useCallback(async (
+    executionId: string,
+    messageIdentity?: ReplayMessageIdentity,
+  ): Promise<boolean> => {
     const separator = executionId.lastIndexOf(':')
     const executionSessionId = separator >= 0
       ? executionId.substring(0, separator)
@@ -1260,6 +1284,7 @@ export const useChatAPI = ({
       let buffer = ''
       let currentEventId: number | null = null
       let terminalEventSeen = false
+      let replayedMessageId: string | null = null
 
       try {
         while (true) {
@@ -1296,6 +1321,12 @@ export const useChatAPI = ({
                 (AGUI_EVENT_TYPES as readonly string[]).includes(eventData.type)
               ) {
                 if (
+                  eventData.type === 'TEXT_MESSAGE_START' &&
+                  typeof eventData.messageId === 'string'
+                ) {
+                  replayedMessageId = eventData.messageId
+                }
+                if (
                   eventData.type === 'RUN_FINISHED' ||
                   eventData.type === 'RUN_ERROR'
                 ) {
@@ -1311,12 +1342,32 @@ export const useChatAPI = ({
       } finally {
         reader.releaseLock()
       }
+      if (
+        terminalEventSeen &&
+        replayedMessageId &&
+        messageIdentity?.logicalMessageId
+      ) {
+        setMessages(current => current.map(message =>
+          message.id === replayedMessageId
+            ? {
+                ...message,
+                id: messageIdentity.logicalMessageId!,
+                logicalMessageId: messageIdentity.logicalMessageId,
+                ...(messageIdentity.eventId && {
+                  eventId: messageIdentity.eventId,
+                }),
+                rawTimestamp:
+                  message.rawTimestamp ?? new Date(message.timestamp).getTime(),
+              }
+            : message
+        ))
+      }
       return terminalEventSeen || failReplay()
     } catch (error) {
       logger.warn(`[useChatAPI] Failed to replay ${executionId}:`, error)
       return failReplay()
     }
-  }, [getAuthHeaders, handleStreamEvent, setUIState])
+  }, [getAuthHeaders, handleStreamEvent, setMessages, setUIState])
 
   const cleanup = useCallback(() => {
     abortRef.current?.unsubscribe()

--- a/chatbot-app/frontend/src/hooks/useResearchJobs.ts
+++ b/chatbot-app/frontend/src/hooks/useResearchJobs.ts
@@ -8,6 +8,7 @@ const DISCOVERY_WINDOW_MS = 15000
 export function useResearchJobs(sessionId: string, refreshToken = 0) {
   const [jobs, setJobs] = useState<ResearchJob[]>([])
   const [deliveredJobIds, setDeliveredJobIds] = useState<string[]>([])
+  const [snapshotSessionId, setSnapshotSessionId] = useState(sessionId)
   const statusesRef = useRef<Map<string, string> | null>(null)
   const jobsRef = useRef<ResearchJob[]>([])
   const refreshingRef = useRef(false)
@@ -88,7 +89,10 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
           current.artifact?.content !== job.artifact?.content
       })
       jobsRef.current = nextJobs
-      if (changed) setJobs(nextJobs)
+      if (changed) {
+        setSnapshotSessionId(requestedSessionId)
+        setJobs(nextJobs)
+      }
     } finally {
       refreshingRef.current = false
       if (pendingRefreshRef.current && sessionRef.current === requestedSessionId) {
@@ -106,6 +110,7 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     invocationCountRef.current = 0
     refreshingRef.current = false
     pendingRefreshRef.current = false
+    setSnapshotSessionId(sessionId)
     setJobs([])
     setDeliveredJobIds([])
     void refresh()
@@ -123,5 +128,10 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     void refresh()
   }, [refresh, refreshToken])
 
-  return { jobs, deliveredJobIds, refresh }
+  return {
+    jobs: snapshotSessionId === sessionId ? jobs : [],
+    deliveredJobIds:
+      snapshotSessionId === sessionId ? deliveredJobIds : [],
+    refresh,
+  }
 }

--- a/chatbot-app/frontend/src/hooks/useSessionEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useSessionEvents.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from '@/lib/api-client'
+import type { SessionEventProjection } from '@/lib/session-events'
+
+const POLL_INTERVAL_MS = 2000
+
+export function useSessionEvents(sessionId: string) {
+  const [events, setEvents] = useState<SessionEventProjection[]>([])
+  const seenRef = useRef<Set<string> | null>(null)
+  const refreshingRef = useRef(false)
+  const sessionRef = useRef(sessionId)
+  sessionRef.current = sessionId
+
+  const refresh = useCallback(async () => {
+    if (!sessionId || refreshingRef.current) return
+    const requestedSessionId = sessionId
+    refreshingRef.current = true
+    try {
+      const response = await apiFetch(
+        `session/events?session_id=${encodeURIComponent(sessionId)}`,
+        { cache: 'no-store' },
+      )
+      if (!response.ok) return
+      const data = await response.json()
+      if (sessionRef.current !== requestedSessionId) return
+      const next: SessionEventProjection[] = Array.isArray(data.events)
+        ? data.events
+        : []
+
+      if (seenRef.current === null) {
+        seenRef.current = new Set(next.map(item => item.eventId))
+        // The history request and this first projection read are independent.
+        // Let the consumer suppress events already represented by history so
+        // a completion committed between the two reads cannot be lost.
+        setEvents(next)
+        return
+      }
+
+      const discovered = next.filter(item => !seenRef.current!.has(item.eventId))
+      discovered.forEach(item => seenRef.current!.add(item.eventId))
+      const durableIds = new Set(next.map(item => item.eventId))
+      setEvents(current => {
+        const retained = current.filter(item => durableIds.has(item.eventId))
+        if (
+          discovered.length === 0 &&
+          retained.length === current.length
+        ) {
+          return current
+        }
+        return [...retained, ...discovered]
+      })
+    } finally {
+      refreshingRef.current = false
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    seenRef.current = null
+    refreshingRef.current = false
+    setEvents([])
+    void refresh()
+
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === 'visible') void refresh()
+    }, POLL_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  return { events, refresh }
+}

--- a/chatbot-app/frontend/src/hooks/useSessionEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useSessionEvents.ts
@@ -6,6 +6,7 @@ const POLL_INTERVAL_MS = 2000
 
 export function useSessionEvents(sessionId: string) {
   const [events, setEvents] = useState<SessionEventProjection[]>([])
+  const [snapshotSessionId, setSnapshotSessionId] = useState(sessionId)
   const seenRef = useRef<Set<string> | null>(null)
   const refreshingRef = useRef(false)
   const sessionRef = useRef(sessionId)
@@ -32,6 +33,7 @@ export function useSessionEvents(sessionId: string) {
         // The history request and this first projection read are independent.
         // Let the consumer suppress events already represented by history so
         // a completion committed between the two reads cannot be lost.
+        setSnapshotSessionId(requestedSessionId)
         setEvents(next)
         return
       }
@@ -39,6 +41,7 @@ export function useSessionEvents(sessionId: string) {
       const discovered = next.filter(item => !seenRef.current!.has(item.eventId))
       discovered.forEach(item => seenRef.current!.add(item.eventId))
       const durableIds = new Set(next.map(item => item.eventId))
+      setSnapshotSessionId(requestedSessionId)
       setEvents(current => {
         const retained = current.filter(item => durableIds.has(item.eventId))
         if (
@@ -57,6 +60,7 @@ export function useSessionEvents(sessionId: string) {
   useEffect(() => {
     seenRef.current = null
     refreshingRef.current = false
+    setSnapshotSessionId(sessionId)
     setEvents([])
     void refresh()
 
@@ -66,5 +70,8 @@ export function useSessionEvents(sessionId: string) {
     return () => window.clearInterval(timer)
   }, [refresh])
 
-  return { events, refresh }
+  return {
+    events: snapshotSessionId === sessionId ? events : [],
+    refresh,
+  }
 }

--- a/chatbot-app/frontend/src/lib/message-metadata.ts
+++ b/chatbot-app/frontend/src/lib/message-metadata.ts
@@ -1,0 +1,105 @@
+import {
+  DynamoDBClient,
+  QueryCommand,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+
+const AWS_REGION =
+  process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
+const TABLE_NAME = process.env.SESSION_ORCHESTRATION_TABLE || ''
+const ALLOWED_FIELDS = new Set([
+  'feedback',
+  'documents',
+  'latency',
+  'tokenUsage',
+])
+
+function sessionKey(userId: string, sessionId: string): string {
+  return `USER#${userId}#SESSION#${sessionId}`
+}
+
+export function messageMetadataEnabled(): boolean {
+  return TABLE_NAME.length > 0
+}
+
+export async function updateMessageMetadataRecord(
+  userId: string,
+  sessionId: string,
+  logicalMessageId: string,
+  metadata: Record<string, any>,
+): Promise<void> {
+  if (!TABLE_NAME) throw new Error('Session orchestration table is not configured')
+
+  const entries = Object.entries(metadata).filter(([key]) => ALLOWED_FIELDS.has(key))
+  if (entries.length === 0) return
+
+  const names: Record<string, string> = {
+    '#recordType': 'recordType',
+    '#logicalMessageId': 'logicalMessageId',
+    '#userId': 'userId',
+    '#sessionId': 'sessionId',
+    '#updatedAt': 'updatedAt',
+  }
+  const values: Record<string, any> = {
+    ':recordType': 'MESSAGE_META',
+    ':logicalMessageId': logicalMessageId,
+    ':userId': userId,
+    ':sessionId': sessionId,
+    ':updatedAt': new Date().toISOString(),
+  }
+  const updates = [
+    '#recordType = :recordType',
+    '#logicalMessageId = :logicalMessageId',
+    '#userId = :userId',
+    '#sessionId = :sessionId',
+    '#updatedAt = :updatedAt',
+  ]
+  entries.forEach(([key, value], index) => {
+    names[`#field${index}`] = key
+    values[`:field${index}`] = value
+    updates.push(`#field${index} = :field${index}`)
+  })
+
+  await new DynamoDBClient({ region: AWS_REGION }).send(new UpdateItemCommand({
+    TableName: TABLE_NAME,
+    Key: marshall({
+      sessionKey: sessionKey(userId, sessionId),
+      recordKey: `MESSAGE_META#${logicalMessageId}`,
+    }),
+    UpdateExpression: `SET ${updates.join(', ')}`,
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: marshall(values, { removeUndefinedValues: true }),
+  }))
+}
+
+export async function listMessageMetadataRecords(
+  userId: string,
+  sessionId: string,
+): Promise<Record<string, Record<string, any>>> {
+  if (!TABLE_NAME) return {}
+
+  const client = new DynamoDBClient({ region: AWS_REGION })
+  const records: Record<string, Record<string, any>> = {}
+  let exclusiveStartKey: Record<string, any> | undefined
+  do {
+    const response = await client.send(new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression:
+        'sessionKey = :sessionKey AND begins_with(recordKey, :prefix)',
+      ExpressionAttributeValues: {
+        ':sessionKey': { S: sessionKey(userId, sessionId) },
+        ':prefix': { S: 'MESSAGE_META#' },
+      },
+      ConsistentRead: true,
+      ExclusiveStartKey: exclusiveStartKey,
+    }))
+    for (const item of response.Items || []) {
+      const record = unmarshall(item)
+      if (!record.logicalMessageId) continue
+      records[record.logicalMessageId] = record
+    }
+    exclusiveStartKey = response.LastEvaluatedKey
+  } while (exclusiveStartKey)
+  return records
+}

--- a/chatbot-app/frontend/src/lib/research-jobs.ts
+++ b/chatbot-app/frontend/src/lib/research-jobs.ts
@@ -9,7 +9,9 @@ import { unmarshall } from '@aws-sdk/util-dynamodb'
 
 const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 const AWS_REGION = process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
-const TABLE_NAME = process.env.DYNAMODB_USERS_TABLE || 'strands-agent-chatbot-users-v2'
+const USERS_TABLE_NAME =
+  process.env.DYNAMODB_USERS_TABLE || 'strands-agent-chatbot-users-v2'
+const ORCHESTRATION_TABLE_NAME = process.env.SESSION_ORCHESTRATION_TABLE || ''
 
 export type ResearchJobStatus =
   | 'queued'
@@ -17,6 +19,7 @@ export type ResearchJobStatus =
   | 'completed'
   | 'delivering'
   | 'delivered'
+  | 'cancelled'
   | 'error'
 
 export interface ResearchJob {
@@ -116,23 +119,50 @@ function readLocalJobs(sessionId: string, userId: string): ResearchJob[] {
 
 async function readCloudJobs(sessionId: string, userId: string): Promise<ResearchJob[]> {
   const client = new DynamoDBClient({ region: AWS_REGION })
-  const jobs: ResearchJob[] = []
-  let exclusiveStartKey: Record<string, any> | undefined
+  const jobsById = new Map<string, ResearchJob>()
+
+  if (ORCHESTRATION_TABLE_NAME) {
+    let exclusiveStartKey: Record<string, any> | undefined
+    do {
+      const response = await client.send(new QueryCommand({
+        TableName: ORCHESTRATION_TABLE_NAME,
+        KeyConditionExpression:
+          'sessionKey = :sessionKey AND begins_with(recordKey, :prefix)',
+        ExpressionAttributeValues: {
+          ':sessionKey': { S: `USER#${userId}#SESSION#${sessionId}` },
+          ':prefix': { S: 'JOB#' },
+        },
+        ConsistentRead: true,
+        ExclusiveStartKey: exclusiveStartKey,
+      }))
+      for (const item of response.Items || []) {
+        const job = unmarshall(item) as ResearchJob
+        jobsById.set(job.jobId, job)
+      }
+      exclusiveStartKey = response.LastEvaluatedKey
+    } while (exclusiveStartKey)
+  }
+
+  let legacyStartKey: Record<string, any> | undefined
   do {
     const response = await client.send(new QueryCommand({
-      TableName: TABLE_NAME,
+      TableName: USERS_TABLE_NAME,
       KeyConditionExpression: 'userId = :userId AND begins_with(sk, :prefix)',
       ExpressionAttributeValues: {
         ':userId': { S: userId },
         ':prefix': { S: `RESEARCH_JOB#${sessionId}#` },
       },
       ConsistentRead: true,
-      ExclusiveStartKey: exclusiveStartKey,
+      ExclusiveStartKey: legacyStartKey,
     }))
-    jobs.push(...(response.Items || []).map(item => unmarshall(item) as ResearchJob))
-    exclusiveStartKey = response.LastEvaluatedKey
-  } while (exclusiveStartKey)
-  return jobs
+    for (const item of response.Items || []) {
+      const job = unmarshall(item) as ResearchJob
+      if (!jobsById.has(job.jobId)) jobsById.set(job.jobId, job)
+    }
+    legacyStartKey = response.LastEvaluatedKey
+  } while (legacyStartKey)
+
+  return Array.from(jobsById.values())
 }
 
 export async function listResearchJobs(

--- a/chatbot-app/frontend/src/lib/research-start-receipt.ts
+++ b/chatbot-app/frontend/src/lib/research-start-receipt.ts
@@ -37,7 +37,7 @@ export function hideBackgroundResearchInputs<T extends {
       Array.isArray(message.content) &&
       message.content.some(part =>
         typeof part?.text === 'string' &&
-        part.text.includes('<background-research-result '),
+        part.text.includes('<background-research-result'),
       )
 
     if (isBackgroundInput) {

--- a/chatbot-app/frontend/src/lib/session-events.ts
+++ b/chatbot-app/frontend/src/lib/session-events.ts
@@ -1,0 +1,136 @@
+import fs from 'fs'
+import path from 'path'
+import { createHash, randomUUID } from 'crypto'
+import {
+  DeleteItemCommand,
+  DynamoDBClient,
+  QueryCommand,
+} from '@aws-sdk/client-dynamodb'
+import { unmarshall } from '@aws-sdk/util-dynamodb'
+
+const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
+const AWS_REGION =
+  process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
+const TABLE_NAME = process.env.SESSION_ORCHESTRATION_TABLE || ''
+
+export interface SessionEventProjection {
+  schemaVersion: number
+  eventId: string
+  eventType: string
+  sessionId: string
+  userId: string
+  createdAt: string
+  originEventId: string
+  correlation: Record<string, string>
+  payload: Record<string, any>
+}
+
+function sessionKey(userId: string, sessionId: string): string {
+  return `USER#${userId}#SESSION#${sessionId}`
+}
+
+function readLocalEvents(
+  userId: string,
+  sessionId: string,
+): SessionEventProjection[] {
+  const digest = createHash('sha256')
+    .update(sessionKey(userId, sessionId))
+    .digest('hex')
+  const mailboxDir = path.resolve(process.cwd(), '..', 'agentcore', 'sessions', 'mailbox')
+  const mailboxPath = path.resolve(mailboxDir, `${digest}.json`)
+  if (!mailboxPath.startsWith(mailboxDir + path.sep) || !fs.existsSync(mailboxPath)) {
+    return []
+  }
+
+  try {
+    const data = JSON.parse(fs.readFileSync(mailboxPath, 'utf-8'))
+    return Object.values(data.sessionEvents || {}) as SessionEventProjection[]
+  } catch {
+    return []
+  }
+}
+
+async function readCloudEvents(
+  userId: string,
+  sessionId: string,
+): Promise<SessionEventProjection[]> {
+  if (!TABLE_NAME) return []
+
+  const client = new DynamoDBClient({ region: AWS_REGION })
+  const events: SessionEventProjection[] = []
+  let exclusiveStartKey: Record<string, any> | undefined
+  do {
+    const response = await client.send(new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression:
+        'sessionKey = :sessionKey AND begins_with(recordKey, :prefix)',
+      ExpressionAttributeValues: {
+        ':sessionKey': { S: sessionKey(userId, sessionId) },
+        ':prefix': { S: 'OUTBOX#' },
+      },
+      ConsistentRead: true,
+      ExclusiveStartKey: exclusiveStartKey,
+    }))
+    events.push(
+      ...(response.Items || []).map(
+        item => unmarshall(item) as SessionEventProjection,
+      ),
+    )
+    exclusiveStartKey = response.LastEvaluatedKey
+  } while (exclusiveStartKey)
+
+  return events
+}
+
+export async function listSessionEvents(
+  userId: string,
+  sessionId: string,
+): Promise<SessionEventProjection[]> {
+  const events = (IS_LOCAL || userId === 'anonymous')
+    ? readLocalEvents(userId, sessionId)
+    : await readCloudEvents(userId, sessionId)
+  return events.sort(
+    (left, right) =>
+      left.createdAt.localeCompare(right.createdAt) ||
+      left.eventId.localeCompare(right.eventId),
+  )
+}
+
+export async function deleteSessionEventProjection(
+  userId: string,
+  sessionId: string,
+  eventId: string,
+): Promise<void> {
+  if (IS_LOCAL || userId === 'anonymous') {
+    const digest = createHash('sha256')
+      .update(sessionKey(userId, sessionId))
+      .digest('hex')
+    const mailboxDir = path.resolve(
+      process.cwd(),
+      '..',
+      'agentcore',
+      'sessions',
+      'mailbox',
+    )
+    const mailboxPath = path.resolve(mailboxDir, `${digest}.json`)
+    if (!mailboxPath.startsWith(mailboxDir + path.sep) || !fs.existsSync(mailboxPath)) {
+      return
+    }
+    const data = JSON.parse(fs.readFileSync(mailboxPath, 'utf-8'))
+    if (!data.sessionEvents?.[eventId]) return
+    delete data.sessionEvents[eventId]
+    const temporaryPath = `${mailboxPath}.${randomUUID()}.tmp`
+    fs.writeFileSync(temporaryPath, JSON.stringify(data, null, 2))
+    fs.renameSync(temporaryPath, mailboxPath)
+    return
+  }
+
+  if (!TABLE_NAME) return
+  await new DynamoDBClient({ region: AWS_REGION }).send(new DeleteItemCommand({
+    TableName: TABLE_NAME,
+    Key: {
+      sessionKey: { S: sessionKey(userId, sessionId) },
+      recordKey: { S: `OUTBOX#${eventId}` },
+    },
+  }))
+}

--- a/chatbot-app/frontend/src/lib/session-lifecycle.ts
+++ b/chatbot-app/frontend/src/lib/session-lifecycle.ts
@@ -1,0 +1,71 @@
+import fs from 'fs'
+import path from 'path'
+import { createHash, randomUUID } from 'crypto'
+import { DynamoDBClient, UpdateItemCommand } from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+
+const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
+const AWS_REGION =
+  process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
+const TABLE_NAME = process.env.SESSION_ORCHESTRATION_TABLE || ''
+
+function sessionKey(userId: string, sessionId: string): string {
+  return `USER#${userId}#SESSION#${sessionId}`
+}
+
+function tombstoneLocalSession(userId: string, sessionId: string, deletedAt: string) {
+  const digest = createHash('sha256')
+    .update(sessionKey(userId, sessionId))
+    .digest('hex')
+  const mailboxDir = path.resolve(process.cwd(), '..', 'agentcore', 'sessions', 'mailbox')
+  fs.mkdirSync(mailboxDir, { recursive: true })
+  const mailboxPath = path.resolve(mailboxDir, `${digest}.json`)
+  const data = fs.existsSync(mailboxPath)
+    ? JSON.parse(fs.readFileSync(mailboxPath, 'utf-8'))
+    : {
+        state: { leaseEpoch: 0, version: 0 },
+        events: {},
+        sessionEvents: {},
+      }
+  data.state = {
+    ...(data.state || {}),
+    deletedAt,
+    updatedAt: deletedAt,
+    status: 'deleted',
+  }
+  delete data.state.leaseOwner
+  delete data.state.leaseUntil
+  const temporaryPath = `${mailboxPath}.${randomUUID()}.tmp`
+  fs.writeFileSync(temporaryPath, JSON.stringify(data, null, 2))
+  fs.renameSync(temporaryPath, mailboxPath)
+}
+
+export async function tombstoneSessionOrchestration(
+  userId: string,
+  sessionId: string,
+): Promise<void> {
+  const deletedAt = new Date().toISOString()
+  if (IS_LOCAL || userId === 'anonymous') {
+    tombstoneLocalSession(userId, sessionId, deletedAt)
+    return
+  }
+  if (!TABLE_NAME) return
+
+  await new DynamoDBClient({ region: AWS_REGION }).send(new UpdateItemCommand({
+    TableName: TABLE_NAME,
+    Key: marshall({
+      sessionKey: sessionKey(userId, sessionId),
+      recordKey: 'STATE',
+    }),
+    UpdateExpression:
+      'SET deletedAt = :deleted, updatedAt = :deleted, #status = :status ' +
+      'REMOVE leaseOwner, leaseUntil',
+    ExpressionAttributeNames: {
+      '#status': 'status',
+    },
+    ExpressionAttributeValues: marshall({
+      ':deleted': deletedAt,
+      ':status': 'deleted',
+    }),
+  }))
+}

--- a/chatbot-app/frontend/src/types/chat.ts
+++ b/chatbot-app/frontend/src/types/chat.ts
@@ -22,6 +22,9 @@ export interface ToolExecution {
 
 export interface Message {
   id: string
+  logicalMessageId?: string
+  eventId?: string
+  originEventId?: string
   text: string
   sender: 'user' | 'bot'
   timestamp: string

--- a/docs/architecture/session-mailbox.md
+++ b/docs/architecture/session-mailbox.md
@@ -1,0 +1,485 @@
+# Durable Session Mailbox Architecture
+
+Status: Implemented for asynchronous research delivery; extensible to other
+external completions
+
+## Implementation Status
+
+Implemented:
+
+- Dedicated orchestration table, mailbox, fencing lease, retry, and dead letter.
+- Research completion adapter with deterministic event IDs.
+- AgentCore Memory idempotency metadata for mailbox-originated messages.
+- Generic `artifact.upserted` and `assistant.turn.completed` projections.
+- Foreground safe-boundary recovery and M2M DynamoDB Stream dispatcher.
+- Research job migration from the users table to orchestration records.
+- Stable logical message identity with legacy event-ID fallback.
+- Session delete tombstones that reject late background delivery.
+- Truncate invalidation for mailbox assistant projections when origin identity
+  is available.
+
+Compatibility paths remain for legacy research jobs, message metadata maps,
+and non-research artifacts. General tool artifacts still require the catalog
+migration described below. Full asynchronous cleanup of deleted-session
+Memory, S3 objects, job rows, and message metadata remains Phase 6 work.
+
+Foreground user turns and their synchronous tool calls intentionally remain in
+the existing AG-UI/Strands execution loop. They do not pay for a DynamoDB
+mailbox round trip. The mailbox is the durable ingress for work that outlives
+or originates outside that loop. Tool progress and token events remain
+transient; only terminal asynchronous transitions use durable projections.
+
+## Decision
+
+Chat execution will use a durable, per-session mailbox with one coordinator
+writer per session for background inputs. Background work may run in parallel,
+but only the session coordinator may apply those results to the canonical
+conversation or Strands agent state. Foreground turns continue through the
+existing Runtime session and execution registry.
+
+This is not full event sourcing. Durable business transitions are stored;
+token deltas and high-frequency progress remain transient.
+
+## Goals
+
+- Deliver asynchronous results whether the session is idle or busy.
+- Recover pending delivery after a process or Runtime restart.
+- Preserve one ordered conversation and one consistent Strands state.
+- Use one event contract for research, long-running tools, OAuth completion,
+  artifact readiness, and future external callbacks.
+- Keep live rendering loosely coupled from agent execution.
+- Make retries explicit and idempotent.
+
+## Non-goals
+
+- Persist every token or progress update.
+- Replace AgentCore Memory with DynamoDB.
+- Reimplement Strands interrupt or conversation-manager persistence.
+- Interrupt an in-flight model token stream to inject an asynchronous result.
+- Retry arbitrary external side effects without a tool-level idempotency
+  contract.
+
+## Persistence Ownership
+
+| Data | Canonical owner | Notes |
+| --- | --- | --- |
+| User and assistant messages | AgentCore Memory | Includes toolUse/toolResult transcript |
+| Strands state | AgentCore Memory | Interrupt, model, conversation-manager, compaction |
+| Session mailbox and leases | DynamoDB orchestration table | Durable control plane |
+| Run/job state | DynamoDB orchestration table | Small records only |
+| Message UI metadata | DynamoDB orchestration table | One item per logical message |
+| Artifact catalog | DynamoDB orchestration table | Metadata, version, checksum, body reference |
+| Artifact bodies | S3 | Deterministic immutable or versioned keys |
+| Token deltas and live progress | SSE/WebSocket | Terminal milestones may be durable |
+| Session list projection | DynamoDB sessions table | Derived, repairable metadata |
+
+AgentCore Memory remains the source of truth for data required to recreate a
+Strands agent. DynamoDB must not contain a second canonical transcript.
+
+## Three Delivery Lanes
+
+### Ordered session mailbox
+
+Semantic inputs that may change the conversation:
+
+- `async_result.ready`
+- `interrupt.response.received`
+- `artifact.context.requested`
+
+These are serialized by the session coordinator.
+
+`user.message.received` may move into this lane later if the product needs
+server-side queued user turns across disconnected clients. It is not required
+for durable external completion delivery and is deliberately excluded from the
+current rollout.
+
+### Immediate control lane
+
+Signals that must bypass a busy mailbox:
+
+- stop/cancel
+- OAuth completion signal observed by a blocked tool
+- lease fencing and health state
+
+These use the same correlation identifiers but do not wait behind a long agent
+turn.
+
+### Transient stream lane
+
+Non-durable rendering data:
+
+- token deltas
+- reasoning deltas
+- tool progress
+- research step progress
+
+Loss is repaired by loading the durable transcript, artifact catalog, and
+terminal projections.
+
+## Mailbox Envelope
+
+```json
+{
+  "schemaVersion": 1,
+  "eventId": "stable producer-generated id",
+  "eventType": "async_result.ready",
+  "sessionId": "chat session id",
+  "userId": "authenticated owner id",
+  "createdAt": "ISO-8601",
+  "availableAt": "ISO-8601",
+  "source": {
+    "type": "research_job",
+    "id": "job id"
+  },
+  "correlation": {
+    "runId": "originating run id",
+    "toolUseId": "originating tool use id",
+    "artifactId": "artifact id"
+  },
+  "payload": {},
+  "payloadRef": null,
+  "visibility": "internal",
+  "status": "pending",
+  "attempts": 0
+}
+```
+
+`eventId` is an application ID, not an AgentCore Memory `eventId`. Producers
+must reuse it when retrying the same logical delivery.
+
+Large payloads are written to S3 first and represented by `payloadRef`.
+
+## DynamoDB Layout
+
+Use a dedicated orchestration table:
+
+```text
+PK sessionKey = USER#{userId}#SESSION#{sessionId}
+SK recordKey
+```
+
+Record families:
+
+```text
+STATE
+INBOX#{eventId}
+OUTBOX#{eventId}
+RUN#{runId}
+JOB#{jobId}
+ARTIFACT#{artifactId}
+MESSAGE_META#{logicalMessageId}
+```
+
+The table uses on-demand capacity, point-in-time recovery, encryption, TTL, and
+DynamoDB Streams. The existing users table remains profile-oriented. The
+existing sessions table remains a session-list projection.
+
+Mailbox insertion uses a conditional put on `INBOX#{eventId}`. Duplicate
+producer delivery is therefore success without creating a second command.
+
+## Coordinator Lease
+
+The `STATE` item contains:
+
+```text
+leaseOwner
+leaseEpoch
+leaseUntil
+version
+lastProcessedAt
+```
+
+Lease acquisition and renewal are conditional on `version` and `leaseEpoch`.
+Every mailbox acknowledgement is fenced by the active lease epoch. A stale
+coordinator may finish local work but cannot acknowledge or publish it.
+
+The initial implementation queries all `INBOX#` records for one session and
+sorts eligible events by `createdAt`, then `eventId`. Mailbox volume is expected
+to be small. A status GSI is added only if measurements show it is necessary.
+
+## Processing Protocol
+
+1. Producer writes a large body to a deterministic S3 key when required.
+2. Producer conditionally creates the mailbox event.
+3. A local notifier or external dispatcher requests a mailbox drain.
+4. Coordinator conditionally acquires the session lease.
+5. Coordinator claims the oldest eligible event.
+6. Coordinator loads AgentCore Memory state and materializes an internal input.
+7. Agent execution writes transcript/state using deterministic idempotency
+   tokens and stable logical message metadata.
+8. Coordinator transactionally marks the inbox event processed, updates small
+   projections, and creates durable outbox milestones.
+9. Live subscribers receive the outbox milestone and any available transient
+   stream.
+
+The acknowledgement occurs only after canonical AgentCore persistence
+succeeds.
+
+## Cross-store Recovery
+
+There is no transaction spanning S3, AgentCore Memory, and DynamoDB. Recovery
+therefore uses deterministic identifiers and ordered commits.
+
+### S3 before DynamoDB
+
+Artifact body upload occurs first. A crash may leave an orphaned S3 object.
+Lifecycle cleanup or reconciliation may remove unreferenced objects.
+
+When a producer owns both records, the artifact catalog and mailbox event
+should be written in one DynamoDB transaction. The current research adapter
+instead persists `JOB#{jobId}` before publishing `INBOX#{eventId}` because the
+job is also its migration-compatible status record. A failed or ambiguous
+INBOX write is reconciled with a strongly consistent read and recreated from
+the deterministic event ID on the next foreground invocation.
+
+### AgentCore Memory before mailbox acknowledgement
+
+Transcript writes use a deterministic AgentCore `clientToken` derived from:
+
+```text
+sessionId + mailbox eventId + transcript phase
+```
+
+AgentCore Memory event metadata also records:
+
+```text
+logicalMessageId
+originEventId
+visibility
+```
+
+If the process crashes after the Memory write, retrying the mailbox event does
+not append a duplicate message. Internal inputs use `extractionMode=SKIP` so
+background protocol messages do not pollute long-term memory.
+
+The pinned AgentCore SDK does not expose `clientToken` through the Strands
+session-manager method. The implemented adapter injects `clientToken` and
+`extractionMode=SKIP` through the botocore parameter-build event and is covered
+by session-manager contract tests. SDK upgrades must retain that contract or
+replace the adapter with a first-class parameter once one is available.
+
+### External tool side effects
+
+At-least-once mailbox handling does not make external tools idempotent.
+
+Tools are classified as:
+
+- `pure`: safe to retry.
+- `idempotent`: retry with a provider or application idempotency key.
+- `side_effecting`: do not replay automatically after an ambiguous result.
+
+Email send, repository writes, payments, and similar operations require a
+tool-side effect ledger or provider idempotency support before whole-turn
+automatic retry is enabled.
+
+The research completion continuation disables all tools, so the remaining
+ambiguous retry window can repeat a model inference but cannot repeat an
+external tool side effect. Deterministic Memory client tokens prevent duplicate
+transcript events. Exactly-once model execution is not claimed.
+
+## Busy and Idle Semantics
+
+### Idle session
+
+A pending mailbox event triggers a dispatcher invocation for the same Runtime
+session. The coordinator creates a separate assistant turn and publishes its
+terminal projection.
+
+DynamoDB Streams alone do not wake AgentCore Runtime. The dispatcher must
+obtain a service Cognito token, invoke `drain_mailbox`, and prove that the
+mailbox session belongs to the requested user. Runtime code must not trust an
+arbitrary `state.user_id` supplied by a general client.
+
+### Busy session
+
+The artifact/result projection may render immediately. Conversation mutation
+waits until a safe agent boundary:
+
+- after the current model response,
+- between tool/model cycles when a supported hook is available, or
+- after interrupt state has been durably synchronized.
+
+The coordinator never injects content into the middle of a token stream.
+
+## Frontend Projection
+
+The frontend consumes generic session events rather than research-specific
+delivery executions:
+
+- `run.started`
+- `tool.started`
+- `tool.progress`
+- `artifact.upserted`
+- `assistant.turn.completed`
+- `run.failed`
+
+Events carry `originEventId`, `runId`, `toolUseId`, and `artifactId` so the UI
+can map a background completion to its original tool card while rendering the
+assistant completion as a separate turn.
+
+Process-local SSE buffering remains an optimization. If it is unavailable
+after a restart, the frontend reloads AgentCore history and DynamoDB
+projections instead of treating replay failure as data loss.
+
+## Artifact Migration
+
+Current tools mutate the full `agent.state.artifacts` map. Migration uses a
+compatibility repository:
+
+1. Read existing full artifacts from agent state.
+2. Write new bodies to S3 and catalog records to DynamoDB.
+3. Dual-read catalog records and legacy agent state.
+4. Store only compact references in `agent.state.artifacts`.
+5. Update tools to use optimistic artifact versions instead of map replacement.
+6. Remove full-body fallback after old sessions have aged out or migrated.
+
+Parallel tools may update different artifacts. Updating the same artifact
+requires an expected version and returns a conflict rather than silently
+overwriting another result.
+
+## Message Identity Migration
+
+Introduce `logicalMessageId` while retaining AgentCore `eventId` as a storage
+locator.
+
+During migration:
+
+- history prefers `logicalMessageId` from event metadata;
+- old messages fall back to AgentCore `eventId`;
+- feedback/document metadata reads both keys;
+- new metadata is stored as `MESSAGE_META#{logicalMessageId}`;
+- redaction or event replacement preserves the logical ID.
+
+## Delete, Truncate, and Compaction
+
+The target workflows are:
+
+- Session delete writes a tombstone, blocks new mailbox work, cancels active
+  jobs, and asynchronously removes Memory events, catalog records, and S3 data.
+- Truncate tombstones affected logical messages and invalidates associated UI
+  metadata without deleting unrelated artifacts automatically.
+- Compaction changes LLM context but does not delete artifact bodies or
+  mailbox audit state.
+- Pending asynchronous results targeting a deleted session become cancelled,
+  not delivered to a recreated session with the same display title.
+
+The current rollout implements the delete tombstone and mailbox projection
+invalidation. It does not yet perform the full cross-store garbage collection
+described above.
+
+## Migration Plan
+
+### Phase 0: contracts and observability
+
+- Add this architecture decision.
+- Define typed envelopes and repository interfaces.
+- Pin AgentCore and Strands SDK versions.
+- Add correlation IDs to logs and metrics.
+
+Exit criteria:
+
+- Existing behavior is unchanged.
+- Event IDs and cross-store write failures are observable.
+
+### Phase 1: durable mailbox foundation
+
+- Provision the orchestration table and IAM.
+- Implement cloud and local mailbox repositories.
+- Add conditional enqueue, lease, claim, ack, retry, and dead-letter behavior.
+- Add unit tests for duplicates, stale leases, and ordering.
+
+Exit criteria:
+
+- Mailbox operations work without changing chat delivery.
+
+### Phase 2: coordinator and research adapter
+
+- Implement the single-writer coordinator.
+- Make research completion enqueue `async_result.ready`.
+- Keep the current delivery path behind a fallback flag.
+- Recover pending events on foreground invocation.
+
+Exit criteria:
+
+- Duplicate research completion creates one assistant turn.
+- A restart between completion and delivery is recoverable.
+- Parallel research jobs remain independent.
+
+### Phase 3: generic frontend projections
+
+- Add a generic session-events endpoint/subscription.
+- Render artifact updates and assistant completion turns from generic events.
+- Retain research job polling only for progress during migration.
+
+Exit criteria:
+
+- Delivery no longer depends on a process-local research execution buffer.
+- Refresh and live delivery produce the same UI state.
+
+### Phase 4: wake dispatcher
+
+- Add DynamoDB Stream to dispatcher integration.
+- Acquire a service Cognito token and invoke `drain_mailbox`.
+- Add ownership validation and wake coalescing.
+
+Exit criteria:
+
+- An idle session wakes after Runtime process loss.
+- Concurrent wake requests result in one active coordinator.
+
+### Phase 5: artifacts and message identity
+
+- Introduce the artifact repository and dual-read compatibility layer.
+- Move artifact bodies to S3 and metadata to the catalog.
+- Add stable logical message IDs and AgentCore idempotency tokens.
+- Move message UI metadata to individual records.
+
+Exit criteria:
+
+- Agent state contains artifact references, not large bodies.
+- Feedback survives message redaction/replacement.
+- Session items no longer grow with message count.
+
+### Phase 6: cleanup and control workflows
+
+- Convert delete/truncate/compaction to cross-store workflows.
+- Remove research-only delivery and polling code.
+- Retire legacy session metadata maps after migration.
+
+## Rollout and Rollback
+
+Feature flags:
+
+```text
+SESSION_MAILBOX_WRITE_ENABLED
+SESSION_MAILBOX_DELIVERY_ENABLED
+SESSION_EVENT_PROJECTION_ENABLED
+ARTIFACT_CATALOG_WRITE_ENABLED
+ARTIFACT_CATALOG_READ_ENABLED
+```
+
+The first two flags are implemented. The remaining names reserve later
+artifact-catalog rollout boundaries and are not active configuration yet.
+
+Rollout order is write-only, shadow verification, read enablement, delivery
+enablement, then legacy removal.
+
+Rollback disables new reads/delivery while retaining dual-written records.
+Rollback must not delete mailbox events or catalog entries.
+
+## Required Tests
+
+- Duplicate enqueue with the same event ID.
+- Two coordinators racing for one session lease.
+- Lease expiry and stale-owner acknowledgement.
+- Crash after S3 upload but before catalog commit.
+- Crash after AgentCore message write but before mailbox acknowledgement.
+- Busy user turn plus one or more asynchronous completions.
+- Interrupt waiting while an asynchronous result arrives.
+- Stop signal while mailbox work is queued.
+- Parallel research jobs completing in reverse order.
+- Runtime restart before frontend replay.
+- Artifact update version conflict.
+- Session delete while a worker is running.
+- Old event-ID feedback migration.
+- Internal message exclusion from UI and long-term-memory extraction.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -299,11 +299,13 @@ module "runtime_orchestrator" {
   gateway_url = module.gateway.gateway_url
   memory_id   = module.memory.memory_id
 
-  enable_ddb_policy      = true
-  user_data_table_arn    = module.data.users_table_arn
-  user_data_table_name   = module.data.users_table_name
-  global_data_table_arn  = ""
-  global_data_table_name = ""
+  enable_ddb_policy        = true
+  user_data_table_arn      = module.data.users_table_arn
+  user_data_table_name     = module.data.users_table_name
+  global_data_table_arn    = ""
+  global_data_table_name   = ""
+  orchestration_table_arn  = module.data.session_orchestration_table_arn
+  orchestration_table_name = module.data.session_orchestration_table_name
 
   artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
   artifact_bucket_name = aws_s3_bucket.artifacts.id
@@ -312,6 +314,9 @@ module "runtime_orchestrator" {
     {
       DYNAMODB_USERS_TABLE                  = module.data.users_table_name
       DYNAMODB_SESSIONS_TABLE               = module.data.sessions_table_name
+      M2M_CLIENT_ID                         = module.auth.m2m_client_id
+      SESSION_MAILBOX_DELIVERY_ENABLED      = "true"
+      SESSION_MAILBOX_WRITE_ENABLED         = "true"
       MEMORY_ARN                            = module.memory.memory_arn
       CODE_AGENT_RUNTIME_ARN                = module.runtime_code_agent.runtime_arn
       RESEARCH_AGENT_RUNTIME_ARN            = module.runtime_research_agent.runtime_arn
@@ -342,6 +347,28 @@ module "runtime_orchestrator" {
     module.runtime_mcp_3lo,
     module.agentcore_shared,
     aws_s3_bucket.artifacts,
+  ]
+}
+
+module "session_mailbox_dispatcher" {
+  source = "../../modules/session-mailbox-dispatcher"
+
+  project_name = var.project_name
+  environment  = var.environment
+  aws_region   = var.aws_region
+  account_id   = local.account_id
+  source_dir   = "${local.root_dir}/infra/lambda/session-mailbox-dispatcher"
+
+  orchestration_stream_arn = module.data.session_orchestration_stream_arn
+  agentcore_runtime_url    = module.runtime_orchestrator.runtime_invocation_url
+  cognito_domain_url       = module.auth.domain_url
+  m2m_client_id            = module.auth.m2m_client_id
+  m2m_client_secret        = module.auth.m2m_client_secret
+
+  depends_on = [
+    module.auth,
+    module.data,
+    module.runtime_orchestrator,
   ]
 }
 
@@ -435,10 +462,12 @@ module "chat" {
   cognito_user_pool_client_id = module.auth.web_client_id
   cognito_user_pool_domain    = module.auth.domain
 
-  users_table_name    = module.data.users_table_name
-  users_table_arn     = module.data.users_table_arn
-  sessions_table_name = module.data.sessions_table_name
-  sessions_table_arn  = module.data.sessions_table_arn
+  users_table_name                 = module.data.users_table_name
+  users_table_arn                  = module.data.users_table_arn
+  sessions_table_name              = module.data.sessions_table_name
+  sessions_table_arn               = module.data.sessions_table_arn
+  session_orchestration_table_name = module.data.session_orchestration_table_name
+  session_orchestration_table_arn  = module.data.session_orchestration_table_arn
 
   memory_id            = module.memory.memory_id
   gateway_url          = module.gateway.gateway_url

--- a/infra/lambda/session-mailbox-dispatcher/lambda_function.py
+++ b/infra/lambda/session-mailbox-dispatcher/lambda_function.py
@@ -1,0 +1,132 @@
+"""Wake AgentCore Runtime when a durable session mailbox receives work."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+import urllib.parse
+import urllib.request
+from typing import Any
+
+import boto3
+
+
+logger = logging.getLogger(__name__)
+
+_token: str | None = None
+_token_expires_at = 0.0
+
+
+def _secret() -> dict[str, str]:
+    response = boto3.client("secretsmanager").get_secret_value(
+        SecretId=os.environ["M2M_SECRET_ARN"],
+    )
+    return json.loads(response["SecretString"])
+
+
+def _access_token() -> str:
+    global _token, _token_expires_at
+    if _token and time.time() < _token_expires_at - 60:
+        return _token
+
+    credentials = _secret()
+    client_id = credentials["clientId"]
+    client_secret = credentials["clientSecret"]
+    form = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "scope": "agentcore/invoke",
+    }).encode()
+    basic = base64.b64encode(
+        f"{client_id}:{client_secret}".encode()
+    ).decode()
+    request = urllib.request.Request(
+        os.environ["COGNITO_TOKEN_URL"],
+        data=form,
+        headers={
+            "Authorization": f"Basic {basic}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.loads(response.read())
+
+    _token = payload["access_token"]
+    _token_expires_at = time.time() + int(payload.get("expires_in", 3600))
+    return _token
+
+
+def _wake(user_id: str, session_id: str) -> None:
+    payload = json.dumps({
+        "thread_id": session_id,
+        "run_id": f"mailbox-dispatch-{int(time.time() * 1000)}",
+        "messages": [],
+        "tools": [],
+        "context": [],
+        "state": {
+            "action": "drain_mailbox",
+            "user_id": user_id,
+        },
+    }).encode()
+    request = urllib.request.Request(
+        os.environ["AGENTCORE_RUNTIME_URL"],
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {_access_token()}",
+            "Content-Type": "application/json",
+            "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id,
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        result = json.loads(response.read())
+    if result.get("status") != "drained":
+        raise RuntimeError(
+            f"Mailbox remains pending for {user_id}/{session_id}: {result}"
+        )
+
+
+def _mailbox_target(record: dict[str, Any]) -> tuple[str, str] | None:
+    if record.get("eventName") != "INSERT":
+        return None
+    image = record.get("dynamodb", {}).get("NewImage", {})
+    if image.get("recordType", {}).get("S") != "INBOX":
+        return None
+    if image.get("status", {}).get("S") != "pending":
+        return None
+    user_id = image.get("userId", {}).get("S")
+    session_id = image.get("sessionId", {}).get("S")
+    if not user_id or not session_id:
+        return None
+    return user_id, session_id
+
+
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    records_by_target: dict[tuple[str, str], list[str]] = {}
+    for record in event.get("Records", []):
+        target = _mailbox_target(record)
+        if target:
+            records_by_target.setdefault(target, []).append(
+                record.get("eventID", ""),
+            )
+
+    failures = []
+    for (user_id, session_id), event_ids in records_by_target.items():
+        try:
+            _wake(user_id, session_id)
+        except Exception:
+            logger.exception(
+                "Failed to drain mailbox for %s/%s",
+                user_id,
+                session_id,
+            )
+            failures.extend(
+                {"itemIdentifier": event_id}
+                for event_id in event_ids
+                if event_id
+            )
+
+    return {"batchItemFailures": failures}

--- a/infra/lambda/session-mailbox-dispatcher/test_lambda_function.py
+++ b/infra/lambda/session-mailbox-dispatcher/test_lambda_function.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock
+
+import lambda_function
+
+
+def record(
+    event_id: str,
+    *,
+    user_id: str = "user-1",
+    session_id: str = "session-1",
+    event_name: str = "INSERT",
+    record_type: str = "INBOX",
+):
+    return {
+        "eventID": event_id,
+        "eventName": event_name,
+        "dynamodb": {
+            "NewImage": {
+                "recordType": {"S": record_type},
+                "status": {"S": "pending"},
+                "userId": {"S": user_id},
+                "sessionId": {"S": session_id},
+            }
+        },
+    }
+
+
+def test_coalesces_multiple_inserts_for_one_session(monkeypatch):
+    wake = MagicMock()
+    monkeypatch.setattr(lambda_function, "_wake", wake)
+
+    result = lambda_function.lambda_handler(
+        {"Records": [record("1"), record("2")]},
+        None,
+    )
+
+    assert result == {"batchItemFailures": []}
+    wake.assert_called_once_with("user-1", "session-1")
+
+
+def test_ignores_non_inbox_stream_records(monkeypatch):
+    wake = MagicMock()
+    monkeypatch.setattr(lambda_function, "_wake", wake)
+
+    result = lambda_function.lambda_handler(
+        {
+            "Records": [
+                record("1", event_name="MODIFY"),
+                record("2", record_type="JOB"),
+            ]
+        },
+        None,
+    )
+
+    assert result == {"batchItemFailures": []}
+    wake.assert_not_called()
+
+
+def test_reports_each_coalesced_record_when_wake_fails(monkeypatch):
+    monkeypatch.setattr(
+        lambda_function,
+        "_wake",
+        MagicMock(side_effect=RuntimeError("still pending")),
+    )
+
+    result = lambda_function.lambda_handler(
+        {"Records": [record("1"), record("2")]},
+        None,
+    )
+
+    assert result == {
+        "batchItemFailures": [
+            {"itemIdentifier": "1"},
+            {"itemIdentifier": "2"},
+        ]
+    }

--- a/infra/modules/chat/main.tf
+++ b/infra/modules/chat/main.tf
@@ -342,7 +342,12 @@ resource "aws_iam_role_policy" "ecs_task" {
           "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
           "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
         ]
-        Resource = [var.users_table_arn, var.sessions_table_arn, "${var.sessions_table_arn}/index/*"]
+        Resource = [
+          var.users_table_arn,
+          var.sessions_table_arn,
+          "${var.sessions_table_arn}/index/*",
+          var.session_orchestration_table_arn,
+        ]
       },
       {
         Effect   = "Allow"
@@ -388,6 +393,7 @@ resource "aws_ecs_task_definition" "frontend" {
       { name = "NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID", value = var.cognito_user_pool_client_id },
       { name = "DYNAMODB_USERS_TABLE", value = var.users_table_name },
       { name = "DYNAMODB_SESSIONS_TABLE", value = var.sessions_table_name },
+      { name = "SESSION_ORCHESTRATION_TABLE", value = var.session_orchestration_table_name },
       { name = "ARTIFACT_BUCKET", value = var.artifact_bucket_name },
       { name = "MEMORY_ID", value = var.memory_id },
       { name = "MCP_GATEWAY_URL", value = var.gateway_url },

--- a/infra/modules/chat/variables.tf
+++ b/infra/modules/chat/variables.tf
@@ -63,6 +63,14 @@ variable "sessions_table_arn" {
   type = string
 }
 
+variable "session_orchestration_table_arn" {
+  type = string
+}
+
+variable "session_orchestration_table_name" {
+  type = string
+}
+
 variable "memory_id" {
   type = string
 }

--- a/infra/modules/data/main.tf
+++ b/infra/modules/data/main.tf
@@ -84,3 +84,40 @@ resource "aws_dynamodb_table" "sessions" {
     Component = "data"
   }
 }
+
+resource "aws_dynamodb_table" "session_orchestration" {
+  name         = "${var.project_name}-session-orchestration"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "sessionKey"
+  range_key    = "recordKey"
+
+  attribute {
+    name = "sessionKey"
+    type = "S"
+  }
+
+  attribute {
+    name = "recordKey"
+    type = "S"
+  }
+
+  ttl {
+    enabled        = true
+    attribute_name = "ttl"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  stream_enabled   = true
+  stream_view_type = "NEW_IMAGE"
+
+  tags = {
+    Component = "session-orchestration"
+  }
+}

--- a/infra/modules/data/outputs.tf
+++ b/infra/modules/data/outputs.tf
@@ -13,3 +13,15 @@ output "sessions_table_name" {
 output "sessions_table_arn" {
   value = aws_dynamodb_table.sessions.arn
 }
+
+output "session_orchestration_table_name" {
+  value = aws_dynamodb_table.session_orchestration.name
+}
+
+output "session_orchestration_table_arn" {
+  value = aws_dynamodb_table.session_orchestration.arn
+}
+
+output "session_orchestration_stream_arn" {
+  value = aws_dynamodb_table.session_orchestration.stream_arn
+}

--- a/infra/modules/runtime/main.tf
+++ b/infra/modules/runtime/main.tf
@@ -354,6 +354,7 @@ resource "aws_iam_role_policy" "execution_ddb" {
         Action = [
           "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
           "dynamodb:DeleteItem", "dynamodb:TransactWriteItems",
+          "dynamodb:ConditionCheckItem",
           "dynamodb:Query",
         ]
         Resource = [var.orchestration_table_arn]

--- a/infra/modules/runtime/main.tf
+++ b/infra/modules/runtime/main.tf
@@ -349,6 +349,15 @@ resource "aws_iam_role_policy" "execution_ddb" {
         ]
         Resource = [var.user_data_table_arn]
       }] : [],
+      var.orchestration_table_arn != "" ? [{
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem", "dynamodb:TransactWriteItems",
+          "dynamodb:Query",
+        ]
+        Resource = [var.orchestration_table_arn]
+      }] : [],
     )
   })
 }
@@ -612,6 +621,9 @@ resource "aws_bedrockagentcore_agent_runtime" "this" {
     },
     var.user_data_table_name != "" ? { USER_DATA_TABLE = var.user_data_table_name } : {},
     var.global_data_table_name != "" ? { GLOBAL_DATA_TABLE = var.global_data_table_name } : {},
+    var.orchestration_table_name != "" ? {
+      SESSION_ORCHESTRATION_TABLE = var.orchestration_table_name
+    } : {},
     var.runtime_type == "orchestrator" ? {
       GATEWAY_URL = var.gateway_url
       REGISTRY_ID = var.registry_id

--- a/infra/modules/runtime/variables.tf
+++ b/infra/modules/runtime/variables.tf
@@ -83,6 +83,16 @@ variable "global_data_table_name" {
   default = ""
 }
 
+variable "orchestration_table_arn" {
+  type    = string
+  default = ""
+}
+
+variable "orchestration_table_name" {
+  type    = string
+  default = ""
+}
+
 variable "enable_ddb_policy" {
   description = "Attach DDB access policy to execution role. Set true when user_data_table_arn or global_data_table_arn is wired."
   type        = bool

--- a/infra/modules/session-mailbox-dispatcher/main.tf
+++ b/infra/modules/session-mailbox-dispatcher/main.tf
@@ -1,0 +1,114 @@
+locals {
+  function_name = "${var.project_name}-${var.environment}-session-mailbox-dispatcher"
+  zip_path      = "${path.module}/.build/session-mailbox-dispatcher.zip"
+}
+
+data "archive_file" "this" {
+  type        = "zip"
+  source_dir  = var.source_dir
+  output_path = local.zip_path
+  excludes    = ["test_*.py", "__pycache__/*"]
+}
+
+resource "aws_secretsmanager_secret" "m2m" {
+  name                    = "${var.project_name}/${var.environment}/session-mailbox-dispatcher/m2m"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "m2m" {
+  secret_id = aws_secretsmanager_secret.m2m.id
+  secret_string = jsonencode({
+    clientId     = var.m2m_client_id
+    clientSecret = var.m2m_client_secret
+  })
+}
+
+resource "aws_iam_role" "this" {
+  name = "${local.function_name}-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "this" {
+  name = "dispatcher"
+  role = aws_iam_role.this.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:${var.account_id}:*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = aws_secretsmanager_secret.m2m.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:DescribeStream",
+          "dynamodb:GetRecords",
+          "dynamodb:GetShardIterator",
+          "dynamodb:ListStreams",
+        ]
+        Resource = var.orchestration_stream_arn
+      },
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${local.function_name}"
+  retention_in_days = 14
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = local.function_name
+  role          = aws_iam_role.this.arn
+  handler       = "lambda_function.lambda_handler"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+  timeout       = 45
+  memory_size   = 256
+
+  filename         = data.archive_file.this.output_path
+  source_code_hash = data.archive_file.this.output_base64sha256
+
+  environment {
+    variables = {
+      AGENTCORE_RUNTIME_URL = var.agentcore_runtime_url
+      COGNITO_TOKEN_URL     = "${var.cognito_domain_url}/oauth2/token"
+      M2M_SECRET_ARN        = aws_secretsmanager_secret.m2m.arn
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+    aws_iam_role_policy.this,
+    aws_secretsmanager_secret_version.m2m,
+  ]
+}
+
+resource "aws_lambda_event_source_mapping" "this" {
+  event_source_arn                   = var.orchestration_stream_arn
+  function_name                      = aws_lambda_function.this.arn
+  starting_position                  = "TRIM_HORIZON"
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 1
+  maximum_record_age_in_seconds      = -1
+  maximum_retry_attempts             = -1
+  bisect_batch_on_function_error     = true
+  function_response_types            = ["ReportBatchItemFailures"]
+}

--- a/infra/modules/session-mailbox-dispatcher/outputs.tf
+++ b/infra/modules/session-mailbox-dispatcher/outputs.tf
@@ -1,0 +1,3 @@
+output "function_name" {
+  value = aws_lambda_function.this.function_name
+}

--- a/infra/modules/session-mailbox-dispatcher/variables.tf
+++ b/infra/modules/session-mailbox-dispatcher/variables.tf
@@ -1,0 +1,40 @@
+variable "project_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "account_id" {
+  type = string
+}
+
+variable "source_dir" {
+  type = string
+}
+
+variable "orchestration_stream_arn" {
+  type = string
+}
+
+variable "agentcore_runtime_url" {
+  type = string
+}
+
+variable "cognito_domain_url" {
+  type = string
+}
+
+variable "m2m_client_id" {
+  type = string
+}
+
+variable "m2m_client_secret" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## Summary
- add a durable per-session mailbox with leases, fencing, retry, dead-letter, and atomic frontend projections
- deliver research completions as separate assistant turns while keeping AgentCore Memory canonical and S3 as artifact-body storage
- add generic session-event polling, logical message identity, delete/truncate fencing, and a DynamoDB Streams wake dispatcher
- provision the orchestration table and wire runtime/frontend IAM and configuration

## Architecture
- foreground chat and synchronous tools remain on the low-latency AG-UI/Strands path
- asynchronous external completions enter the DynamoDB mailbox and are serialized at safe session boundaries
- AgentCore Memory owns transcript and Strands state; DynamoDB owns orchestration/projections; S3 owns report bodies
- delivery is at-least-once with deterministic Memory client tokens; exactly-once model inference is not claimed

## Verification
- backend: 676 passed, 15 deselected
- frontend: 619 passed; type-check and production build passed
- dispatcher: 3 passed
- backend source ruff passed
- Terraform fmt and dev validate passed
- targeted deploy plan: 13 add, 7 change, 5 expected source/task replacements; no unrelated destructive changes

## Follow-up boundaries
- full cross-store garbage collection for deleted sessions remains future work
- general non-research artifact catalog migration remains future work