### PR TITLE
feat(chat): harden queued interrupts and async delivery

### DIFF
--- a/chatbot-app/agentcore/src/agent/mailbox.py
+++ b/chatbot-app/agentcore/src/agent/mailbox.py
@@ -28,6 +28,7 @@ PENDING = "pending"
 PROCESSING = "processing"
 PROCESSED = "processed"
 DEAD = "dead"
+CANCELLED = "cancelled"
 TERMINAL_TTL_DAYS = 30
 SESSION_EVENT_TTL_DAYS = 7
 
@@ -48,8 +49,8 @@ def _event_key(event_id: str) -> str:
     return f"INBOX#{event_id}"
 
 
-def _session_event_key(event_id: str) -> str:
-    return f"OUTBOX#{event_id}"
+def _session_event_key(created_at: str, event_id: str) -> str:
+    return f"OUTBOX_V2#{created_at}#{event_id}"
 
 
 def _error_code(error: Exception) -> str:
@@ -72,10 +73,15 @@ class MailboxLease:
     owner: str
     epoch: int
     expires_at: int
+    conversation_epoch: int = 0
 
 
 class SessionDeletedError(RuntimeError):
     """Mailbox work cannot be added to a tombstoned session."""
+
+
+class SessionSupersededError(RuntimeError):
+    """Mailbox work belongs to a conversation state removed by truncation."""
 
 
 @dataclass
@@ -92,6 +98,7 @@ class MailboxEvent:
     payload_ref: Optional[Dict[str, str]] = None
     visibility: str = "internal"
     schema_version: int = SCHEMA_VERSION
+    conversation_epoch: int = 0
     status: str = PENDING
     attempts: int = 0
     lease_owner: Optional[str] = None
@@ -114,6 +121,7 @@ class MailboxEvent:
         payload: Optional[Dict[str, Any]] = None,
         payload_ref: Optional[Dict[str, str]] = None,
         visibility: str = "internal",
+        conversation_epoch: int = 0,
         now: Optional[datetime] = None,
     ) -> "MailboxEvent":
         timestamp = _iso(now or utc_now())
@@ -129,6 +137,7 @@ class MailboxEvent:
             payload=dict(payload or {}),
             payload_ref=dict(payload_ref) if payload_ref else None,
             visibility=visibility,
+            conversation_epoch=conversation_epoch,
         )
 
     def to_record(self) -> Dict[str, Any]:
@@ -148,6 +157,7 @@ class MailboxEvent:
             "payload": self.payload,
             "payloadRef": self.payload_ref,
             "visibility": self.visibility,
+            "conversationEpoch": self.conversation_epoch,
             "status": self.status,
             "attempts": self.attempts,
             "leaseOwner": self.lease_owner,
@@ -173,6 +183,7 @@ class MailboxEvent:
             payload=record.get("payload", {}),
             payload_ref=record.get("payloadRef"),
             visibility=record.get("visibility", "internal"),
+            conversation_epoch=int(record.get("conversationEpoch", 0)),
             status=record.get("status", PENDING),
             attempts=int(record.get("attempts", 0)),
             lease_owner=record.get("leaseOwner"),
@@ -200,6 +211,7 @@ class SessionEvent:
     correlation: Dict[str, str] = field(default_factory=dict)
     payload: Dict[str, Any] = field(default_factory=dict)
     schema_version: int = SCHEMA_VERSION
+    conversation_epoch: int = 0
 
     @classmethod
     def create(
@@ -212,6 +224,7 @@ class SessionEvent:
         origin_event_id: str,
         correlation: Optional[Dict[str, str]] = None,
         payload: Optional[Dict[str, Any]] = None,
+        conversation_epoch: int = 0,
         now: Optional[datetime] = None,
     ) -> "SessionEvent":
         return cls(
@@ -223,12 +236,13 @@ class SessionEvent:
             origin_event_id=origin_event_id,
             correlation=dict(correlation or {}),
             payload=dict(payload or {}),
+            conversation_epoch=conversation_epoch,
         )
 
     def to_record(self, *, ttl: Optional[int] = None) -> Dict[str, Any]:
         record = {
             "sessionKey": _session_key(self.user_id, self.session_id),
-            "recordKey": _session_event_key(self.event_id),
+            "recordKey": _session_event_key(self.created_at, self.event_id),
             "recordType": "OUTBOX",
             "schemaVersion": self.schema_version,
             "eventId": self.event_id,
@@ -239,6 +253,7 @@ class SessionEvent:
             "originEventId": self.origin_event_id,
             "correlation": self.correlation,
             "payload": self.payload,
+            "conversationEpoch": self.conversation_epoch,
             "ttl": ttl,
         }
         return {key: value for key, value in record.items() if value is not None}
@@ -255,6 +270,7 @@ class SessionEvent:
             origin_event_id=record["originEventId"],
             correlation=record.get("correlation", {}),
             payload=record.get("payload", {}),
+            conversation_epoch=int(record.get("conversationEpoch", 0)),
         )
 
 
@@ -276,6 +292,20 @@ class MailboxRepository(ABC):
     @abstractmethod
     def is_session_deleted(self, user_id: str, session_id: str) -> bool:
         """Return whether the orchestration state has a delete tombstone."""
+
+    @abstractmethod
+    def get_conversation_epoch(self, user_id: str, session_id: str) -> int:
+        """Return the fencing epoch for the current visible conversation."""
+
+    @abstractmethod
+    def advance_conversation_epoch(
+        self,
+        user_id: str,
+        session_id: str,
+        *,
+        now: Optional[datetime] = None,
+    ) -> int:
+        """Fence work created before a truncate and return the new epoch."""
 
     @abstractmethod
     def acquire_lease(
@@ -351,6 +381,15 @@ class MailboxRepository(ABC):
         """List mailbox events in deterministic creation order."""
 
     @abstractmethod
+    def get_event(
+        self,
+        user_id: str,
+        session_id: str,
+        event_id: str,
+    ) -> Optional[MailboxEvent]:
+        """Load one mailbox event by its deterministic identity."""
+
+    @abstractmethod
     def list_session_events(
         self,
         user_id: str,
@@ -399,6 +438,12 @@ class DynamoDBMailboxRepository(MailboxRepository):
         })
 
     def enqueue(self, event: MailboxEvent) -> bool:
+        epoch_condition = "conversationEpoch = :conversation_epoch"
+        if event.conversation_epoch == 0:
+            epoch_condition = (
+                "(attribute_not_exists(conversationEpoch) "
+                "OR conversationEpoch = :conversation_epoch)"
+            )
         try:
             self.client.transact_write_items(
                 TransactItems=[
@@ -410,7 +455,13 @@ class DynamoDBMailboxRepository(MailboxRepository):
                                 event.session_id,
                                 "STATE",
                             ),
-                            "ConditionExpression": "attribute_not_exists(deletedAt)",
+                            "ConditionExpression": (
+                                "attribute_not_exists(deletedAt) AND "
+                                f"{epoch_condition}"
+                            ),
+                            "ExpressionAttributeValues": self._serialize({
+                                ":conversation_epoch": event.conversation_epoch,
+                            }),
                         }
                     },
                     {
@@ -428,6 +479,21 @@ class DynamoDBMailboxRepository(MailboxRepository):
                 if self.is_session_deleted(event.user_id, event.session_id):
                     raise SessionDeletedError(
                         f"Session {event.session_id} has been deleted"
+                    ) from error
+                if self.get_event(
+                    event.user_id,
+                    event.session_id,
+                    event.event_id,
+                ) is not None:
+                    return False
+                current_epoch = self.get_conversation_epoch(
+                    event.user_id,
+                    event.session_id,
+                )
+                if current_epoch != event.conversation_epoch:
+                    raise SessionSupersededError(
+                        f"Session {event.session_id} advanced from conversation "
+                        f"epoch {event.conversation_epoch} to {current_epoch}"
                     ) from error
                 return False
             raise
@@ -464,6 +530,91 @@ class DynamoDBMailboxRepository(MailboxRepository):
         )
         return bool(response.get("Item"))
 
+    def get_conversation_epoch(self, user_id: str, session_id: str) -> int:
+        response = self.client.get_item(
+            TableName=self.table_name,
+            Key=self._key(user_id, session_id, "STATE"),
+            ConsistentRead=True,
+            ProjectionExpression="conversationEpoch",
+        )
+        item = response.get("Item")
+        if not item:
+            return 0
+        return int(self._deserialize(item).get("conversationEpoch", 0))
+
+    def advance_conversation_epoch(
+        self,
+        user_id: str,
+        session_id: str,
+        *,
+        now: Optional[datetime] = None,
+    ) -> int:
+        current = now or utc_now()
+        response = self.client.update_item(
+            TableName=self.table_name,
+            Key=self._key(user_id, session_id, "STATE"),
+            UpdateExpression=(
+                "SET conversationEpoch = if_not_exists(conversationEpoch, :zero) + :one, "
+                "leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, "
+                "truncatedAt = :updated, updatedAt = :updated "
+                "REMOVE leaseOwner, leaseUntil"
+            ),
+            ConditionExpression="attribute_not_exists(deletedAt)",
+            ExpressionAttributeValues=self._serialize({
+                ":zero": 0,
+                ":one": 1,
+                ":updated": _iso(current),
+            }),
+            ReturnValues="ALL_NEW",
+        )
+        attributes = self._deserialize(response["Attributes"])
+        next_epoch = int(attributes["conversationEpoch"])
+        terminal_ttl = int(
+            (current + timedelta(days=TERMINAL_TTL_DAYS)).timestamp()
+        )
+        for event in self.list_events(user_id, session_id):
+            if (
+                event.conversation_epoch >= next_epoch
+                or event.status not in (PENDING, PROCESSING)
+            ):
+                continue
+            try:
+                self.client.update_item(
+                    TableName=self.table_name,
+                    Key=self._key(
+                        user_id,
+                        session_id,
+                        _event_key(event.event_id),
+                    ),
+                    UpdateExpression=(
+                        "SET #status = :cancelled, processedAt = :updated, "
+                        "updatedAt = :updated, lastError = :reason, #ttl = :ttl "
+                        "REMOVE leaseOwner, leaseEpoch, eventLeaseUntil"
+                    ),
+                    ConditionExpression=(
+                        "(attribute_not_exists(conversationEpoch) "
+                        "OR conversationEpoch < :epoch) AND "
+                        "(#status = :pending OR #status = :processing)"
+                    ),
+                    ExpressionAttributeNames={
+                        "#status": "status",
+                        "#ttl": "ttl",
+                    },
+                    ExpressionAttributeValues=self._serialize({
+                        ":cancelled": CANCELLED,
+                        ":updated": _iso(current),
+                        ":reason": "Conversation truncated",
+                        ":ttl": terminal_ttl,
+                        ":epoch": next_epoch,
+                        ":pending": PENDING,
+                        ":processing": PROCESSING,
+                    }),
+                )
+            except Exception as error:
+                if not _is_condition_failure(error):
+                    raise
+        return next_epoch
+
     def acquire_lease(
         self,
         user_id: str,
@@ -483,6 +634,7 @@ class DynamoDBMailboxRepository(MailboxRepository):
                 UpdateExpression=(
                     "SET leaseOwner = :owner, leaseUntil = :until, "
                     "leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, "
+                    "conversationEpoch = if_not_exists(conversationEpoch, :zero), "
                     "#version = if_not_exists(#version, :zero) + :one, "
                     "updatedAt = :updated"
                 ),
@@ -511,6 +663,7 @@ class DynamoDBMailboxRepository(MailboxRepository):
             owner=owner,
             epoch=int(attributes["leaseEpoch"]),
             expires_at=expires_at,
+            conversation_epoch=int(attributes.get("conversationEpoch", 0)),
         )
 
     def release_lease(
@@ -569,6 +722,7 @@ class DynamoDBMailboxRepository(MailboxRepository):
                 owner=lease.owner,
                 epoch=lease.epoch,
                 expires_at=expires_at,
+                conversation_epoch=lease.conversation_epoch,
             )
         except Exception as error:
             if _is_condition_failure(error):
@@ -600,32 +754,52 @@ class DynamoDBMailboxRepository(MailboxRepository):
         events = [MailboxEvent.from_record(item) for item in items]
         return sorted(events, key=lambda item: (item.created_at, item.event_id))
 
+    def get_event(
+        self,
+        user_id: str,
+        session_id: str,
+        event_id: str,
+    ) -> Optional[MailboxEvent]:
+        response = self.client.get_item(
+            TableName=self.table_name,
+            Key=self._key(user_id, session_id, _event_key(event_id)),
+            ConsistentRead=True,
+        )
+        item = response.get("Item")
+        if not item:
+            return None
+        return MailboxEvent.from_record(self._deserialize(item))
+
     def list_session_events(
         self,
         user_id: str,
         session_id: str,
     ) -> list[SessionEvent]:
         items: list[Dict[str, Any]] = []
-        start_key = None
-        while True:
-            kwargs: Dict[str, Any] = {
-                "TableName": self.table_name,
-                "KeyConditionExpression": (
-                    "sessionKey = :session AND begins_with(recordKey, :prefix)"
-                ),
-                "ExpressionAttributeValues": self._serialize({
-                    ":session": _session_key(user_id, session_id),
-                    ":prefix": "OUTBOX#",
-                }),
-                "ConsistentRead": True,
-            }
-            if start_key:
-                kwargs["ExclusiveStartKey"] = start_key
-            response = self.client.query(**kwargs)
-            items.extend(self._deserialize(item) for item in response.get("Items", []))
-            start_key = response.get("LastEvaluatedKey")
-            if not start_key:
-                break
+        for prefix in ("OUTBOX_V2#", "OUTBOX#"):
+            start_key = None
+            while True:
+                kwargs: Dict[str, Any] = {
+                    "TableName": self.table_name,
+                    "KeyConditionExpression": (
+                        "sessionKey = :session AND begins_with(recordKey, :prefix)"
+                    ),
+                    "ExpressionAttributeValues": self._serialize({
+                        ":session": _session_key(user_id, session_id),
+                        ":prefix": prefix,
+                    }),
+                    "ConsistentRead": True,
+                }
+                if start_key:
+                    kwargs["ExclusiveStartKey"] = start_key
+                response = self.client.query(**kwargs)
+                items.extend(
+                    self._deserialize(item)
+                    for item in response.get("Items", [])
+                )
+                start_key = response.get("LastEvaluatedKey")
+                if not start_key:
+                    break
         events = [SessionEvent.from_record(item) for item in items]
         return sorted(events, key=lambda item: (item.created_at, item.event_id))
 
@@ -641,14 +815,21 @@ class DynamoDBMailboxRepository(MailboxRepository):
         current = now or utc_now()
         now_epoch = int(current.timestamp())
         now_iso = _iso(current)
+        lease_conversation_epoch = int(
+            getattr(lease, "conversation_epoch", 0)
+        )
         candidates = [
             event
             for event in self.list_events(user_id, session_id)
-            if (
-                event.status == PENDING and event.available_at <= now_iso
-            ) or (
-                event.status == PROCESSING
-                and (event.event_lease_until or 0) < now_epoch
+            if event.conversation_epoch == lease_conversation_epoch and (
+                (
+                    event.status == PENDING
+                    and event.available_at <= now_iso
+                )
+                or (
+                    event.status == PROCESSING
+                    and (event.event_lease_until or 0) < now_epoch
+                )
             )
         ]
         for event in candidates:
@@ -661,12 +842,14 @@ class DynamoDBMailboxRepository(MailboxRepository):
                                 "Key": self._key(user_id, session_id, "STATE"),
                                 "ConditionExpression": (
                                     "leaseOwner = :owner AND leaseEpoch = :epoch "
-                                    "AND leaseUntil >= :now_epoch"
+                                    "AND leaseUntil >= :now_epoch "
+                                    "AND conversationEpoch = :conversation_epoch"
                                 ),
                                 "ExpressionAttributeValues": self._serialize({
                                     ":owner": lease.owner,
                                     ":epoch": lease.epoch,
                                     ":now_epoch": now_epoch,
+                                    ":conversation_epoch": event.conversation_epoch,
                                 }),
                             }
                         },
@@ -833,6 +1016,7 @@ class DynamoDBMailboxRepository(MailboxRepository):
                         event.session_id,
                         lease,
                         int(current.timestamp()),
+                        conversation_epoch=event.conversation_epoch,
                     ),
                     {
                         "Update": {
@@ -865,19 +1049,28 @@ class DynamoDBMailboxRepository(MailboxRepository):
         session_id: str,
         lease: MailboxLease,
         now_epoch: int,
+        *,
+        conversation_epoch: Optional[int] = None,
     ) -> Dict[str, Any]:
+        expected_conversation_epoch = (
+            int(getattr(lease, "conversation_epoch", 0))
+            if conversation_epoch is None
+            else conversation_epoch
+        )
         return {
             "ConditionCheck": {
                 "TableName": self.table_name,
                 "Key": self._key(user_id, session_id, "STATE"),
                 "ConditionExpression": (
                     "leaseOwner = :owner AND leaseEpoch = :epoch "
-                    "AND leaseUntil >= :now"
+                    "AND leaseUntil >= :now "
+                    "AND conversationEpoch = :conversation_epoch"
                 ),
                 "ExpressionAttributeValues": self._serialize({
                     ":owner": lease.owner,
                     ":epoch": lease.epoch,
                     ":now": now_epoch,
+                    ":conversation_epoch": expected_conversation_epoch,
                 }),
             }
         }
@@ -904,6 +1097,8 @@ class FileMailboxRepository(MailboxRepository):
                 "sessionEvents": {},
             }
         data = json.loads(path.read_text(encoding="utf-8"))
+        data.setdefault("state", {})
+        data["state"].setdefault("conversationEpoch", 0)
         data.setdefault("sessionEvents", {})
         return data
 
@@ -923,12 +1118,19 @@ class FileMailboxRepository(MailboxRepository):
     def enqueue(self, event: MailboxEvent) -> bool:
         with self._lock:
             data = self._load(event.user_id, event.session_id)
-            if data["state"].get("deletedAt"):
+            state = data["state"]
+            if state.get("deletedAt"):
                 raise SessionDeletedError(
                     f"Session {event.session_id} has been deleted"
                 )
             if event.event_id in data["events"]:
                 return False
+            current_epoch = int(state.get("conversationEpoch", 0))
+            if event.conversation_epoch != current_epoch:
+                raise SessionSupersededError(
+                    f"Session {event.session_id} advanced from conversation "
+                    f"epoch {event.conversation_epoch} to {current_epoch}"
+                )
             data["events"][event.event_id] = event.to_record()
             self._save(event.user_id, event.session_id, data)
             return True
@@ -957,6 +1159,55 @@ class FileMailboxRepository(MailboxRepository):
             return bool(
                 self._load(user_id, session_id)["state"].get("deletedAt")
             )
+
+    def get_conversation_epoch(self, user_id: str, session_id: str) -> int:
+        with self._lock:
+            state = self._load(user_id, session_id)["state"]
+            return int(state.get("conversationEpoch", 0))
+
+    def advance_conversation_epoch(
+        self,
+        user_id: str,
+        session_id: str,
+        *,
+        now: Optional[datetime] = None,
+    ) -> int:
+        current = now or utc_now()
+        with self._lock:
+            data = self._load(user_id, session_id)
+            state = data["state"]
+            if state.get("deletedAt"):
+                raise SessionDeletedError(
+                    f"Session {session_id} has been deleted"
+                )
+            state["conversationEpoch"] = int(
+                state.get("conversationEpoch", 0)
+            ) + 1
+            state["leaseEpoch"] = int(state.get("leaseEpoch", 0)) + 1
+            state["truncatedAt"] = _iso(current)
+            state["updatedAt"] = _iso(current)
+            state.pop("leaseOwner", None)
+            state.pop("leaseUntil", None)
+            for record in data["events"].values():
+                if (
+                    int(record.get("conversationEpoch", 0))
+                    < state["conversationEpoch"]
+                    and record.get("status") in (PENDING, PROCESSING)
+                ):
+                    record.update({
+                        "status": CANCELLED,
+                        "updatedAt": _iso(current),
+                        "processedAt": _iso(current),
+                        "lastError": "Conversation truncated",
+                        "ttl": int(
+                            (
+                                current + timedelta(days=TERMINAL_TTL_DAYS)
+                            ).timestamp()
+                        ),
+                    })
+                    self._clear_event_lease(record)
+            self._save(user_id, session_id, data)
+            return state["conversationEpoch"]
 
     def acquire_lease(
         self,
@@ -989,6 +1240,7 @@ class FileMailboxRepository(MailboxRepository):
                 owner=owner,
                 epoch=state["leaseEpoch"],
                 expires_at=state["leaseUntil"],
+                conversation_epoch=int(state.get("conversationEpoch", 0)),
             )
 
     def release_lease(
@@ -1037,6 +1289,7 @@ class FileMailboxRepository(MailboxRepository):
                 owner=lease.owner,
                 epoch=lease.epoch,
                 expires_at=state["leaseUntil"],
+                conversation_epoch=lease.conversation_epoch,
             )
 
     def list_events(self, user_id: str, session_id: str) -> list[MailboxEvent]:
@@ -1047,6 +1300,16 @@ class FileMailboxRepository(MailboxRepository):
                 for record in data["events"].values()
             ]
         return sorted(events, key=lambda item: (item.created_at, item.event_id))
+
+    def get_event(
+        self,
+        user_id: str,
+        session_id: str,
+        event_id: str,
+    ) -> Optional[MailboxEvent]:
+        with self._lock:
+            record = self._load(user_id, session_id)["events"].get(event_id)
+            return MailboxEvent.from_record(record) if record else None
 
     def list_session_events(
         self,
@@ -1087,6 +1350,10 @@ class FileMailboxRepository(MailboxRepository):
                 key=lambda item: (item["createdAt"], item["eventId"]),
             )
             for record in records:
+                if int(record.get("conversationEpoch", 0)) != int(
+                    state.get("conversationEpoch", 0)
+                ):
+                    continue
                 eligible = (
                     record["status"] == PENDING
                     and record["availableAt"] <= now_iso
@@ -1199,6 +1466,9 @@ class FileMailboxRepository(MailboxRepository):
             and state.get("leaseOwner") == lease.owner
             and state.get("leaseEpoch") == lease.epoch
             and state.get("leaseUntil", 0) >= now_epoch
+            and int(record.get("conversationEpoch", 0))
+            == int(state.get("conversationEpoch", 0))
+            == int(getattr(lease, "conversation_epoch", 0))
         )
 
     @staticmethod

--- a/chatbot-app/agentcore/src/agent/mailbox_runtime.py
+++ b/chatbot-app/agentcore/src/agent/mailbox_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import threading
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 
 from agent.mailbox import get_mailbox_repository
 from agent.session_coordinator import (
@@ -24,10 +24,23 @@ def mailbox_delivery_enabled() -> bool:
     return os.environ.get("SESSION_MAILBOX_DELIVERY_ENABLED", "").lower() == "true"
 
 
+def mailbox_write_enabled() -> bool:
+    return os.environ.get("SESSION_MAILBOX_WRITE_ENABLED", "").lower() == "true"
+
+
+def validate_mailbox_configuration() -> None:
+    if mailbox_delivery_enabled() and not mailbox_write_enabled():
+        raise RuntimeError(
+            "SESSION_MAILBOX_DELIVERY_ENABLED requires "
+            "SESSION_MAILBOX_WRITE_ENABLED"
+        )
+
+
 def register_mailbox_runtime(
     loop: asyncio.AbstractEventLoop,
     handlers: Dict[str, MailboxEventHandler],
 ) -> None:
+    validate_mailbox_configuration()
     global _runtime_loop, _handlers
     with _runtime_lock:
         _runtime_loop = loop
@@ -47,19 +60,35 @@ async def drain_session_mailbox(
     *,
     owner: Optional[str] = None,
     max_events: int = 20,
+    reconcile_event_ids: Sequence[str] = (),
 ) -> DrainResult:
     with _runtime_lock:
         handlers = dict(_handlers)
     coordinator = SessionCoordinator(get_mailbox_repository(), handlers)
-    return await coordinator.drain(
+    result = await coordinator.drain(
         user_id,
         session_id,
         owner=owner,
         max_events=max_events,
     )
+    from agent.research_jobs import reconcile_processed_deliveries
+
+    if reconcile_event_ids:
+        await asyncio.to_thread(
+            reconcile_processed_deliveries,
+            user_id,
+            session_id,
+            list(reconcile_event_ids),
+        )
+    return result
 
 
-async def notify_session_mailbox(user_id: str, session_id: str) -> DrainResult:
+async def notify_session_mailbox(
+    user_id: str,
+    session_id: str,
+    *,
+    event_ids: Sequence[str] = (),
+) -> DrainResult:
     """Request a drain from any worker thread/event loop."""
     with _runtime_lock:
         loop = _runtime_loop
@@ -72,10 +101,18 @@ async def notify_session_mailbox(user_id: str, session_id: str) -> DrainResult:
         current_loop = None
 
     if current_loop is loop:
-        return await drain_session_mailbox(user_id, session_id)
+        return await drain_session_mailbox(
+            user_id,
+            session_id,
+            reconcile_event_ids=event_ids,
+        )
 
     future = asyncio.run_coroutine_threadsafe(
-        drain_session_mailbox(user_id, session_id),
+        drain_session_mailbox(
+            user_id,
+            session_id,
+            reconcile_event_ids=event_ids,
+        ),
         loop,
     )
     return await asyncio.wrap_future(future)

--- a/chatbot-app/agentcore/src/agent/research_jobs.py
+++ b/chatbot-app/agentcore/src/agent/research_jobs.py
@@ -14,7 +14,9 @@ import os
 import re
 import tempfile
 import threading
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
 from urllib.parse import quote
@@ -33,6 +35,20 @@ DeliveryHandler = Callable[[Dict[str, Any], Dict[str, Any]], Awaitable[None]]
 _delivery_loop: Optional[asyncio.AbstractEventLoop] = None
 _delivery_handler: Optional[DeliveryHandler] = None
 _delivery_lock = threading.Lock()
+
+
+class CompletionPublishStatus(str, Enum):
+    DISABLED = "disabled"
+    DURABLE = "durable"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class CompletionPublishResult:
+    status: CompletionPublishStatus
+    event_id: Optional[str] = None
+    error: Optional[str] = None
 
 
 def _now() -> str:
@@ -80,6 +96,16 @@ def _is_cloud_storage() -> bool:
     return bool(os.environ.get("DYNAMODB_USERS_TABLE"))
 
 
+def _legacy_job_reads_enabled() -> bool:
+    return (
+        not os.environ.get("SESSION_ORCHESTRATION_TABLE")
+        or os.environ.get(
+            "RESEARCH_JOB_LEGACY_READ_ENABLED",
+            "",
+        ).lower() == "true"
+    )
+
+
 def _save_job(record: Dict[str, Any]) -> None:
     if _is_cloud_storage():
         region = os.environ.get("AWS_REGION", "us-west-2")
@@ -108,6 +134,50 @@ def _save_job(record: Dict[str, Any]) -> None:
 
     path = _local_job_dir(record["sessionId"]) / f"{_safe_component(record['jobId'])}.json"
     _atomic_write(path, json.dumps(record, ensure_ascii=False, indent=2))
+
+
+def _get_job(
+    user_id: str,
+    session_id: str,
+    job_id: str,
+) -> Optional[Dict[str, Any]]:
+    if _is_cloud_storage():
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        dynamodb = boto3.resource("dynamodb", region_name=region)
+        orchestration_table = os.environ.get("SESSION_ORCHESTRATION_TABLE")
+        if orchestration_table:
+            response = dynamodb.Table(orchestration_table).get_item(
+                Key={
+                    "sessionKey": _orchestration_session_key(user_id, session_id),
+                    "recordKey": _orchestration_job_key(job_id),
+                },
+                ConsistentRead=True,
+            )
+            if response.get("Item"):
+                return response["Item"]
+
+        if not _legacy_job_reads_enabled():
+            return None
+        response = dynamodb.Table(os.environ["DYNAMODB_USERS_TABLE"]).get_item(
+            Key={
+                "userId": user_id,
+                "sk": _job_sk(session_id, job_id),
+            },
+            ConsistentRead=True,
+        )
+        return response.get("Item")
+
+    path = _local_job_dir(session_id) / f"{_safe_component(job_id)}.json"
+    if not path.exists():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.warning("[ResearchJob] Ignoring unreadable job file %s", path)
+        return None
+    if record.get("userId") != user_id or record.get("sessionId") != session_id:
+        return None
+    return record
 
 
 def _save_report(record: Dict[str, Any], report: str) -> Dict[str, str]:
@@ -182,8 +252,10 @@ def _list_jobs(user_id: str, session_id: str) -> list[Dict[str, Any]]:
                 if not start_key:
                     break
 
-        # Read legacy rows during migration. New writes use the orchestration
-        # table as soon as it is configured.
+        if not _legacy_job_reads_enabled():
+            return list(jobs_by_id.values())
+
+        # Explicit migration path. Disable after legacy rows have aged out.
         legacy_table = dynamodb.Table(os.environ["DYNAMODB_USERS_TABLE"])
         start_key = None
         while True:
@@ -295,6 +367,7 @@ def _enqueue_completion_event(record: Dict[str, Any]) -> Optional[str]:
             "artifact": record.get("artifact", {}),
         },
         payload_ref=payload_ref,
+        conversation_epoch=int(record.get("conversationEpoch", 0)),
     )
     inserted = get_mailbox_repository().enqueue(event)
     logger.info(
@@ -309,13 +382,59 @@ def _completion_event_exists(record: Dict[str, Any]) -> bool:
     event_id = record.get("mailboxEventId") or _completion_event_id(record)
     from agent.mailbox import get_mailbox_repository
 
-    return any(
-        event.event_id == event_id
-        for event in get_mailbox_repository().list_events(
-            record["userId"],
-            record["sessionId"],
+    return get_mailbox_repository().get_event(
+        record["userId"],
+        record["sessionId"],
+        event_id,
+    ) is not None
+
+
+def _publish_completion(record: Dict[str, Any]) -> CompletionPublishResult:
+    try:
+        event_id = _enqueue_completion_event(record)
+        if event_id is None:
+            return CompletionPublishResult(CompletionPublishStatus.DISABLED)
+        return CompletionPublishResult(
+            CompletionPublishStatus.DURABLE,
+            event_id=event_id,
         )
-    )
+    except Exception as exc:
+        from agent.mailbox import SessionDeletedError, SessionSupersededError
+
+        if isinstance(exc, (SessionDeletedError, SessionSupersededError)):
+            return CompletionPublishResult(
+                CompletionPublishStatus.CANCELLED,
+                error=str(exc),
+            )
+        try:
+            event_exists = _completion_event_exists(record)
+        except Exception:
+            logger.exception(
+                "[ResearchJob] Failed to reconcile mailbox write for %s",
+                record["jobId"],
+            )
+            return CompletionPublishResult(
+                CompletionPublishStatus.FAILED,
+                error=str(exc),
+            )
+        if event_exists:
+            logger.warning(
+                "[ResearchJob] Recovered ambiguous mailbox write for %s",
+                record["jobId"],
+            )
+            return CompletionPublishResult(
+                CompletionPublishStatus.DURABLE,
+                event_id=record.get("mailboxEventId")
+                or _completion_event_id(record),
+            )
+        logger.exception(
+            "[ResearchJob] Mailbox write failed for %s",
+            record["jobId"],
+        )
+        return CompletionPublishResult(
+            CompletionPublishStatus.FAILED,
+            error=str(exc),
+        )
 
 
 def load_pending_results(user_id: str, session_id: str) -> list[Dict[str, Any]]:
@@ -354,6 +473,23 @@ def recover_pending_mailbox_events(user_id: str, session_id: str) -> list[str]:
     recovered = []
     for item in load_pending_results(user_id, session_id):
         record = item["record"]
+        from agent.mailbox import PROCESSED, get_mailbox_repository
+
+        try:
+            existing = get_mailbox_repository().get_event(
+                user_id,
+                session_id,
+                record.get("mailboxEventId") or _completion_event_id(record),
+            )
+        except Exception:
+            logger.exception(
+                "[ResearchJob] Failed to inspect completion event for %s",
+                record["jobId"],
+            )
+            existing = None
+        if existing and existing.status == PROCESSED:
+            mark_delivered(record)
+            continue
         # Re-enqueue even when the job already has its deterministic ID. A
         # prior write may have failed after the job record was prepared but
         # before the INBOX transaction became durable.
@@ -365,6 +501,51 @@ def recover_pending_mailbox_events(user_id: str, session_id: str) -> list[str]:
         if event_id:
             recovered.append(event_id)
     return recovered
+
+
+def reconcile_processed_deliveries(
+    user_id: str,
+    session_id: str,
+    event_ids: Optional[list[str]] = None,
+) -> int:
+    """Project processed completion events back onto producer job rows."""
+    from agent.mailbox import PROCESSED, get_mailbox_repository
+
+    repository = get_mailbox_repository()
+    reconciled = 0
+    if event_ids:
+        records = []
+        for event_id in dict.fromkeys(event_ids):
+            event = repository.get_event(user_id, session_id, event_id)
+            if (
+                event is None
+                or event.status != PROCESSED
+                or event.source.get("type") != "research_job"
+            ):
+                continue
+            record = _get_job(
+                user_id,
+                session_id,
+                event.source["id"],
+            )
+            if record is not None:
+                records.append(record)
+    else:
+        records = _list_jobs(user_id, session_id)
+
+    for record in records:
+        if record.get("status") != "delivering":
+            continue
+        event = repository.get_event(
+            user_id,
+            session_id,
+            record.get("mailboxEventId") or _completion_event_id(record),
+        )
+        if event is None or event.status != PROCESSED:
+            continue
+        mark_delivered(record)
+        reconciled += 1
+    return reconciled
 
 
 def mark_delivered(record: Dict[str, Any]) -> None:
@@ -405,7 +586,11 @@ async def _deliver(record: Dict[str, Any], artifact: Dict[str, Any]) -> None:
 async def _notify_mailbox(record: Dict[str, Any]):
     from agent.mailbox_runtime import notify_session_mailbox
 
-    return await notify_session_mailbox(record["userId"], record["sessionId"])
+    return await notify_session_mailbox(
+        record["userId"],
+        record["sessionId"],
+        event_ids=[record["mailboxEventId"]],
+    )
 
 
 def _publish_progress(record: Dict[str, Any], event: Dict[str, Any]) -> None:
@@ -474,59 +659,41 @@ async def _run_job(record: Dict[str, Any], event_factory: EventFactory) -> None:
         # stale "completed" or "delivering" snapshot afterward.
         record.update(status="delivering", updatedAt=_now())
         _save_job(record)
-        try:
-            mailbox_event_id = _enqueue_completion_event(record)
-            if mailbox_event_id:
-                record["mailboxEventId"] = mailbox_event_id
-        except Exception as exc:
-            from agent.mailbox import SessionDeletedError
+        from agent.mailbox_runtime import mailbox_delivery_enabled
 
-            if isinstance(exc, SessionDeletedError):
-                record.update(
-                    status="cancelled",
-                    updatedAt=_now(),
-                    deliveryError=str(exc),
-                )
-                _save_job(record)
-                logger.info(
-                    "[ResearchJob] Cancelled delivery to deleted session %s",
-                    record["sessionId"],
-                )
-                return
-            try:
-                event_exists = _completion_event_exists(record)
-            except Exception:
-                logger.exception(
-                    "[ResearchJob] Failed to reconcile mailbox write for %s",
-                    record["jobId"],
-                )
+        publish = _publish_completion(record)
+        if publish.status == CompletionPublishStatus.CANCELLED:
+            record.update(
+                status="cancelled",
+                updatedAt=_now(),
+                deliveryError=publish.error,
+            )
+            _save_job(record)
+            logger.info(
+                "[ResearchJob] Cancelled delivery to fenced session %s",
+                record["sessionId"],
+            )
+            return
+        if publish.status == CompletionPublishStatus.DURABLE:
+            record["mailboxEventId"] = publish.event_id
+            record.pop("mailboxWriteError", None)
+        elif publish.status == CompletionPublishStatus.FAILED:
+            record.pop("mailboxEventId", None)
+            record["mailboxWriteError"] = publish.error
+            if mailbox_delivery_enabled():
                 record.update(
                     status="completed",
-                    deliveryError=str(exc),
-                    mailboxWriteError=str(exc),
+                    deliveryError=(
+                        "Mailbox delivery is enabled but completion enqueue failed"
+                    ),
                     updatedAt=_now(),
                 )
                 _save_job(record)
                 return
-            if event_exists:
-                # The enqueue response was ambiguous, but the strongly
-                # consistent mailbox read proves that delivery is durable.
-                logger.warning(
-                    "[ResearchJob] Recovered ambiguous mailbox write for %s",
-                    record["jobId"],
-                )
-            else:
-                record.pop("mailboxEventId", None)
-                record["mailboxWriteError"] = str(exc)
-                _save_job(record)
-                logger.exception(
-                    "[ResearchJob] Mailbox write failed for %s",
-                    record["jobId"],
-                )
+        elif publish.status == CompletionPublishStatus.DISABLED:
+            _save_job(record)
 
         try:
-            from agent.mailbox_runtime import mailbox_delivery_enabled
-
             if mailbox_delivery_enabled():
                 if not record.get("mailboxEventId"):
                     raise RuntimeError(
@@ -580,6 +747,14 @@ def start_research_job(
     """Persist and start one research job, returning its public start receipt."""
     job_id = uuid4().hex
     created_at = _now()
+    conversation_epoch = 0
+    if _mailbox_write_enabled():
+        from agent.mailbox import get_mailbox_repository
+
+        conversation_epoch = get_mailbox_repository().get_conversation_epoch(
+            user_id,
+            session_id,
+        )
     record: Dict[str, Any] = {
         "jobId": job_id,
         "sessionId": session_id,
@@ -591,6 +766,7 @@ def start_research_job(
         "updatedAt": created_at,
         "modelId": model_id or "",
         "requestType": request_type,
+        "conversationEpoch": conversation_epoch,
     }
     _save_job(record)
 

--- a/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
+++ b/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional, Dict, List
 
 from strands.types.session import SessionAgent, SessionMessage
+from strands.types.exceptions import SessionException
 from typing_extensions import override
 
 from bedrock_agentcore.memory.integrations.strands.session_manager import AgentCoreMemorySessionManager
@@ -57,6 +58,7 @@ class CompactionState:
 @dataclass
 class MailboxPersistenceScope:
     origin_event_id: str
+    conversation_epoch: int
     message_index: int = 0
 
 
@@ -182,12 +184,19 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
         self._api_call_total_ms += elapsed_ms
 
     @contextmanager
-    def mailbox_event_scope(self, origin_event_id: str):
+    def mailbox_event_scope(
+        self,
+        origin_event_id: str,
+        conversation_epoch: int = 0,
+    ):
         """Make message writes idempotent for one durable mailbox event."""
         with self._mailbox_scope_lock:
             if self._mailbox_scope is not None:
                 raise RuntimeError("Nested mailbox persistence scopes are not supported")
-            self._mailbox_scope = MailboxPersistenceScope(origin_event_id)
+            self._mailbox_scope = MailboxPersistenceScope(
+                origin_event_id,
+                conversation_epoch,
+            )
         try:
             yield
         finally:
@@ -210,7 +219,11 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
             else:
                 message_index = scope.message_index
                 scope.message_index += 1
-                scoped_message = (scope.origin_event_id, message_index)
+                scoped_message = (
+                    scope.origin_event_id,
+                    scope.conversation_epoch,
+                    message_index,
+                )
 
         if scoped_message is None:
             return super().create_message(
@@ -220,12 +233,13 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
                 **kwargs,
             )
 
-        origin_event_id, message_index = scoped_message
+        origin_event_id, conversation_epoch, message_index = scoped_message
         logical_message_id = f"mailbox:{origin_event_id}:{message_index}"
         role = session_message.message.get("role", "")
         metadata = dict(kwargs.pop("metadata", {}) or {})
         metadata.update({
             "originEventId": {"stringValue": origin_event_id},
+            "conversationEpoch": {"stringValue": str(conversation_epoch)},
             "logicalMessageId": {"stringValue": logical_message_id},
             "visibility": {
                 "stringValue": "internal" if role == "user" else "conversation"
@@ -256,6 +270,62 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
             )
         finally:
             emitter.unregister(event_name, unique_id=unique_id)
+
+    @staticmethod
+    def _event_conversation_epoch(event: Dict[str, Any]) -> Optional[int]:
+        value = (event.get("metadata") or {}).get("conversationEpoch")
+        if isinstance(value, dict):
+            value = value.get("stringValue") or value.get("numberValue")
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid conversationEpoch metadata: %r", value)
+            return None
+
+    @override
+    def list_messages(
+        self,
+        session_id: str,
+        agent_id: str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+        **kwargs: Any,
+    ) -> List[SessionMessage]:
+        """Restore messages while fencing stale mailbox continuations."""
+        if session_id != self.config.session_id:
+            raise SessionException(
+                f"Session ID mismatch: expected {self.config.session_id}, got {session_id}"
+            )
+
+        from agent.mailbox import get_mailbox_repository
+
+        current_epoch = get_mailbox_repository().get_conversation_epoch(
+            self.user_id or self.config.actor_id,
+            session_id,
+        )
+        max_results = (limit + offset) if limit else 10_000
+        events = self.memory_client.list_events(
+            memory_id=self.config.memory_id,
+            actor_id=self.config.actor_id,
+            session_id=session_id,
+            max_results=max_results,
+        )
+        events = [
+            event
+            for event in events
+            if (
+                (event_epoch := self._event_conversation_epoch(event)) is None
+                or event_epoch >= current_epoch
+            )
+        ]
+        messages = self.converter.events_to_messages(events)
+        if self.config.filter_restored_tool_context:
+            messages = self._filter_restored_tool_context(messages)
+        if limit is not None:
+            return messages[offset:offset + limit]
+        return messages[offset:]
 
     @override
     def sync_agent(self, agent: "Agent", **kwargs: Any) -> None:

--- a/chatbot-app/agentcore/src/agent/session_coordinator.py
+++ b/chatbot-app/agentcore/src/agent/session_coordinator.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Dict, Optional, Sequence
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 from uuid import uuid4
 
 from agent.mailbox import (
@@ -17,9 +18,27 @@ from agent.mailbox import (
 
 logger = logging.getLogger(__name__)
 
+PostAcknowledgeHook = Callable[[], Union[Awaitable[None], None]]
+
+
+@dataclass(frozen=True)
+class MailboxHandlerResult:
+    """Durable projections plus work that is safe only after acknowledgement."""
+
+    session_events: Sequence[SessionEvent] = ()
+    after_ack: Optional[PostAcknowledgeHook] = None
+
+
 MailboxEventHandler = Callable[
     [MailboxEvent],
-    Awaitable[Optional[Sequence[SessionEvent]]],
+    Awaitable[
+        Optional[
+            Union[
+                Sequence[SessionEvent],
+                MailboxHandlerResult,
+            ]
+        ]
+    ],
 ]
 
 
@@ -33,6 +52,7 @@ class DrainResult:
     processed: int = 0
     retried: int = 0
     dead: int = 0
+    post_ack_failed: int = 0
     lease_lost: bool = False
 
 
@@ -46,15 +66,19 @@ class SessionCoordinator:
         event_lease_seconds: int = 120,
         max_attempts: int = 5,
         retry_delay_seconds: int = 5,
+        post_ack_attempts: int = 3,
     ):
         if lease_seconds < 3:
             raise ValueError("lease_seconds must be at least 3")
+        if post_ack_attempts < 1:
+            raise ValueError("post_ack_attempts must be at least 1")
         self.repository = repository
         self.handlers = dict(handlers)
         self.lease_seconds = lease_seconds
         self.event_lease_seconds = event_lease_seconds
         self.max_attempts = max_attempts
         self.retry_delay_seconds = retry_delay_seconds
+        self.post_ack_attempts = post_ack_attempts
 
     async def drain(
         self,
@@ -104,7 +128,13 @@ class SessionCoordinator:
                         raise NonRetryableMailboxError(
                             f"No handler registered for {event.event_type}"
                         )
-                    session_events = await handler(event)
+                    handler_result = await handler(event)
+                    if isinstance(handler_result, MailboxHandlerResult):
+                        handled = handler_result
+                    else:
+                        handled = MailboxHandlerResult(
+                            session_events=tuple(handler_result or ())
+                        )
                 except asyncio.CancelledError:
                     # An ambiguous side effect must not be made pending
                     # immediately. The event lease expiry is the recovery gate.
@@ -147,12 +177,35 @@ class SessionCoordinator:
                     self.repository.acknowledge,
                     event,
                     active_lease[0],
-                    session_events=tuple(session_events or ()),
+                    session_events=tuple(handled.session_events),
                 )
                 if not acknowledged:
                     result.lease_lost = True
                     break
                 result.processed += 1
+                if handled.after_ack is not None:
+                    for attempt in range(1, self.post_ack_attempts + 1):
+                        try:
+                            if inspect.iscoroutinefunction(handled.after_ack):
+                                await handled.after_ack()
+                            else:
+                                hook_result = await asyncio.to_thread(
+                                    handled.after_ack
+                                )
+                                if inspect.isawaitable(hook_result):
+                                    await hook_result
+                            break
+                        except Exception:
+                            if attempt == self.post_ack_attempts:
+                                result.post_ack_failed += 1
+                                logger.exception(
+                                    "[SessionCoordinator] Post-ack hook failed "
+                                    "for event %s after %s attempts",
+                                    event.event_id,
+                                    attempt,
+                                )
+                            else:
+                                await asyncio.sleep(0.1 * attempt)
         finally:
             heartbeat.cancel()
             try:

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -237,6 +237,7 @@ async def invocations(http_request: Request):
         if not _is_mailbox_dispatcher_request(http_request):
             raise HTTPException(status_code=403, detail="Mailbox dispatcher token required")
         user_id = state.get("user_id")
+        event_ids = state.get("event_ids") or []
         if not user_id or not thread_id:
             raise HTTPException(
                 status_code=400,
@@ -246,9 +247,38 @@ async def invocations(http_request: Request):
         from agent.mailbox import PENDING, PROCESSING, get_mailbox_repository
         from agent.mailbox_runtime import drain_session_mailbox
 
-        result = await drain_session_mailbox(user_id, thread_id)
+        if not isinstance(event_ids, list):
+            raise HTTPException(status_code=400, detail="state.event_ids must be a list")
+        repository = get_mailbox_repository()
+        if await asyncio.to_thread(
+            repository.is_session_deleted,
+            user_id,
+            thread_id,
+        ):
+            return {
+                "status": "drained",
+                "processed": 0,
+                "retried": 0,
+                "dead": 0,
+                "acquired": False,
+                "pending": 0,
+                "deleted": True,
+            }
+        reconcile_event_ids = [
+            str(event_id)
+            for event_id in event_ids
+            if event_id
+        ]
+        if reconcile_event_ids:
+            result = await drain_session_mailbox(
+                user_id,
+                thread_id,
+                reconcile_event_ids=reconcile_event_ids,
+            )
+        else:
+            result = await drain_session_mailbox(user_id, thread_id)
         remaining = await asyncio.to_thread(
-            get_mailbox_repository().list_events,
+            repository.list_events,
             user_id,
             thread_id,
         )
@@ -468,8 +498,12 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
         # A foreground invocation is also a recovery signal. Recreate any
         # deterministic completion envelopes that predate mailbox delivery;
         # the coordinator will materialize them as separate assistant turns.
-        from agent.research_jobs import recover_pending_mailbox_events
+        from agent.research_jobs import (
+            reconcile_processed_deliveries,
+            recover_pending_mailbox_events,
+        )
 
+        reconcile_processed_deliveries(user_id, session_id)
         recover_pending_mailbox_events(user_id, session_id)
     else:
         # Legacy fallback while mailbox delivery is disabled.
@@ -657,6 +691,20 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
     session_id = record["sessionId"]
     user_id = record["userId"]
     run_id = f"research-delivery-{record['jobId']}"
+    conversation_epoch = int(record.get("conversationEpoch", 0))
+
+    def ensure_current_epoch() -> None:
+        from agent.mailbox import SessionSupersededError, get_mailbox_repository
+
+        current_epoch = get_mailbox_repository().get_conversation_epoch(
+            user_id,
+            session_id,
+        )
+        if current_epoch != conversation_epoch:
+            raise SessionSupersededError(
+                f"Conversation epoch changed from {conversation_epoch} "
+                f"to {current_epoch}"
+            )
 
     while True:
         execution = await registry.create_execution(
@@ -676,6 +724,7 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                 {"execution_id": execution.execution_id, "job_id": record["jobId"]},
             )
             try:
+                ensure_current_epoch()
                 agent = create_agent(
                     request_type=record.get("requestType") or "skill",
                     session_id=session_id,
@@ -698,10 +747,6 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                     artifact,
                 )
                 agent.agent.state.set("artifacts", artifacts)
-                # Delivery is not successful unless the canonical agent state is
-                # durable. Let sync failures propagate so the job remains ready
-                # for retry instead of being falsely marked delivered.
-                agent.session_manager.sync_agent(agent.agent)
 
                 commit_id = record.get("mailboxEventId") or run_id
                 existing_commits = dict(
@@ -727,7 +772,7 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                 }
                 scope = getattr(agent.session_manager, "mailbox_event_scope", None)
                 scope_context = (
-                    scope(commit_id)
+                    scope(commit_id, conversation_epoch)
                     if scope
                     else nullcontext()
                 )
@@ -745,6 +790,10 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                             _extract_event_type(sse_chunk),
                         )
 
+                # Truncate may race with generation. Messages written by the
+                # scoped session manager carry the old epoch and are excluded
+                # from future restores; do not commit stale agent state.
+                ensure_current_epoch()
                 commits = dict(agent.agent.state.get("mailbox_commits") or {})
                 commits[commit_id] = {
                     "completedAt": datetime.now(timezone.utc).isoformat(),
@@ -789,20 +838,14 @@ async def deliver_mailbox_event(event):
 
     from agent.research_jobs import (
         _build_artifact,
-        _list_jobs,
+        _get_job,
         _load_report,
         mark_delivered,
     )
+    from agent.session_coordinator import MailboxHandlerResult
 
     job_id = event.source["id"]
-    record = next(
-        (
-            item
-            for item in _list_jobs(event.user_id, event.session_id)
-            if item.get("jobId") == job_id
-        ),
-        None,
-    )
+    record = _get_job(event.user_id, event.session_id, job_id)
     if record is None:
         raise RuntimeError(f"Research job not found: {job_id}")
 
@@ -810,7 +853,6 @@ async def deliver_mailbox_event(event):
     report = _load_report(record)
     artifact = _build_artifact(record, report)
     await deliver_research_job(record, artifact)
-    mark_delivered(record)
 
     from agent.mailbox import SessionEvent
 
@@ -826,33 +868,39 @@ async def deliver_mailbox_event(event):
         for key, value in artifact.items()
         if key != "content"
     }
-    return [
-        SessionEvent.create(
-            event_id=f"{event.event_id}:artifact",
-            event_type="artifact.upserted",
-            session_id=event.session_id,
-            user_id=event.user_id,
-            origin_event_id=event.event_id,
-            correlation=correlation,
-            payload={
-                "artifact": artifact_metadata,
-                "payloadRef": event.payload_ref,
-            },
-        ),
-        SessionEvent.create(
-            event_id=f"{event.event_id}:assistant",
-            event_type="assistant.turn.completed",
-            session_id=event.session_id,
-            user_id=event.user_id,
-            origin_event_id=event.event_id,
-            correlation=correlation,
-            payload={
-                "executionId": f"{event.session_id}:{run_id}",
-                "logicalMessageId": f"mailbox:{event.event_id}:1",
-                "source": event.source,
-            },
-        ),
-    ]
+    event_epoch = int(getattr(event, "conversation_epoch", 0))
+    return MailboxHandlerResult(
+        session_events=[
+            SessionEvent.create(
+                event_id=f"{event.event_id}:artifact",
+                event_type="artifact.upserted",
+                session_id=event.session_id,
+                user_id=event.user_id,
+                origin_event_id=event.event_id,
+                correlation=correlation,
+                payload={
+                    "artifact": artifact_metadata,
+                    "payloadRef": event.payload_ref,
+                },
+                conversation_epoch=event_epoch,
+            ),
+            SessionEvent.create(
+                event_id=f"{event.event_id}:assistant",
+                event_type="assistant.turn.completed",
+                session_id=event.session_id,
+                user_id=event.user_id,
+                origin_event_id=event.event_id,
+                correlation=correlation,
+                payload={
+                    "executionId": f"{event.session_id}:{run_id}",
+                    "logicalMessageId": f"mailbox:{event.event_id}:1",
+                    "source": event.source,
+                },
+                conversation_epoch=event_epoch,
+            ),
+        ],
+        after_ack=lambda: mark_delivered(record),
+    )
 
 
 _cleanup_task: Optional[asyncio.Task] = None

--- a/chatbot-app/agentcore/src/streaming/agui_event_formatter.py
+++ b/chatbot-app/agentcore/src/streaming/agui_event_formatter.py
@@ -357,9 +357,9 @@ class AGUIStreamEventFormatter:
         self._run_id: Optional[str] = None
         self._current_message_id: Optional[str] = None
         self._message_open: bool = False
-        # tool_call_ids for which TOOL_CALL_START has already been emitted.
-        # Subsequent tool_use events with the same id stream args-only updates.
         self._started_tool_calls: set[str] = set()
+        self._ended_tool_calls: set[str] = set()
+        self._tool_call_names: Dict[str, str] = {}
 
     # ------------------------------------------------------------------ #
     # Internal helpers                                                     #
@@ -394,6 +394,10 @@ class AGUIStreamEventFormatter:
           response            -> TextMessageStartEvent + TextMessageContentEvent
           complete            -> (TextMessageEndEvent if message open, else TextMessage if message kwarg provided) + RunFinishedEvent
           tool_use            -> ToolCallStartEvent + ToolCallArgsEvent + ToolCallEndEvent
+          tool_call_start     -> ToolCallStartEvent
+          tool_call_args      -> ToolCallArgsEvent
+          tool_call_end       -> ToolCallEndEvent
+          tool_call_name_update -> CustomEvent(name='tool_call_name_update')
           tool_result         -> ToolCallResultEvent
           error               -> RunErrorEvent
           <all others>        -> CustomEvent(name=<original_type>, value=<payload>)
@@ -406,6 +410,10 @@ class AGUIStreamEventFormatter:
             "complete":    self._format_complete,
             "stop":        self._format_stop,
             "tool_use":    self._format_tool_use,
+            "tool_call_start": self._format_tool_call_start,
+            "tool_call_args": self._format_tool_call_args,
+            "tool_call_end": self._format_tool_call_end,
+            "tool_call_name_update": self._format_tool_call_name_update,
             "tool_result": self._format_tool_result,
             "error":       self._format_error,
         }
@@ -421,6 +429,9 @@ class AGUIStreamEventFormatter:
         self._initial_run_id = None  # consume once; subsequent calls (shouldn't happen) get a fresh uuid
         self._message_open = False
         self._current_message_id = None
+        self._started_tool_calls.clear()
+        self._ended_tool_calls.clear()
+        self._tool_call_names.clear()
         return self._encode(RunStartedEvent(
             type=EventType.RUN_STARTED,
             thread_id=self._thread_id,
@@ -512,8 +523,7 @@ class AGUIStreamEventFormatter:
         return result
 
     def _format_tool_use(self, event_type: str = "tool_use", **kwargs) -> str:
-        # Accept either format_event("tool_use", tool_use={...})
-        # or     format_event("tool_use", toolUseId=..., name=..., input=...)
+        """Format a complete tool call for non-streaming compatibility paths."""
         tool_use = kwargs.get("tool_use")
         if not isinstance(tool_use, dict):
             tool_use = kwargs
@@ -521,42 +531,118 @@ class AGUIStreamEventFormatter:
         tool_name: str = tool_use.get("name", "unknown")
         tool_input = tool_use.get("input", {})
 
-        # Unwrap skill_executor so SSE consumers see the effective tool name,
-        # not the Progressive Disclosure wrapper. Needs the populated
-        # tool_input, so only meaningful on the second emission.
         wire_tool_name = tool_name
         if tool_name == "skill_executor" and isinstance(tool_input, dict):
-            inner = tool_input.get("tool_name")
+            inner = (
+                tool_input.get("tool_name")
+                or tool_input.get("script_name")
+                or tool_input.get("skill_name")
+                or "skill"
+            )
             if isinstance(inner, str) and inner:
                 wire_tool_name = inner
 
-        # The processor calls us twice per tool_use: first on registration
-        # with empty input, then again once the model has streamed the
-        # arguments. Emit START only on the populated call so the wire
-        # carries the unwrapped name; emit ARGS and END on every call so
-        # consumers still see incremental state.
-        has_input = isinstance(tool_input, dict) and bool(tool_input)
         result = ""
-        if tool_use_id not in self._started_tool_calls:
-            if has_input or tool_name != "skill_executor":
-                result += self._close_open_message()
-                result += self._encode(ToolCallStartEvent(
-                    type=EventType.TOOL_CALL_START,
-                    tool_call_id=tool_use_id,
-                    tool_call_name=wire_tool_name,
-                    parent_message_id=None,
-                ))
-                self._started_tool_calls.add(tool_use_id)
-        result += self._encode(ToolCallArgsEvent(
-            type=EventType.TOOL_CALL_ARGS,
+        result += self._format_tool_call_start(
+            tool_call_id=tool_use_id,
+            tool_call_name=wire_tool_name,
+        )
+        result += self._format_tool_call_name_update(
+            tool_call_id=tool_use_id,
+            tool_call_name=wire_tool_name,
+        )
+        result += self._format_tool_call_args(
             tool_call_id=tool_use_id,
             delta=json.dumps(tool_input),
-        ))
-        result += self._encode(ToolCallEndEvent(
-            type=EventType.TOOL_CALL_END,
-            tool_call_id=tool_use_id,
-        ))
+        )
+        result += self._format_tool_call_end(tool_call_id=tool_use_id)
         return result
+
+    def _format_tool_call_start(
+        self,
+        event_type: str = "tool_call_start",
+        **kwargs,
+    ) -> str:
+        tool_call_id = kwargs.get("tool_call_id") or kwargs.get("toolCallId")
+        tool_call_name = (
+            kwargs.get("tool_call_name")
+            or kwargs.get("toolCallName")
+            or "unknown"
+        )
+        if not tool_call_id or tool_call_id in self._started_tool_calls:
+            return ""
+
+        self._started_tool_calls.add(tool_call_id)
+        self._tool_call_names[tool_call_id] = tool_call_name
+        self._ended_tool_calls.discard(tool_call_id)
+        return self._close_open_message() + self._encode(ToolCallStartEvent(
+            type=EventType.TOOL_CALL_START,
+            tool_call_id=tool_call_id,
+            tool_call_name=tool_call_name,
+            parent_message_id=None,
+        ))
+
+    def _format_tool_call_args(
+        self,
+        event_type: str = "tool_call_args",
+        **kwargs,
+    ) -> str:
+        tool_call_id = kwargs.get("tool_call_id") or kwargs.get("toolCallId")
+        delta = kwargs.get("delta", "")
+        if (
+            not tool_call_id
+            or tool_call_id not in self._started_tool_calls
+            or tool_call_id in self._ended_tool_calls
+            or not delta
+        ):
+            return ""
+        return self._encode(ToolCallArgsEvent(
+            type=EventType.TOOL_CALL_ARGS,
+            tool_call_id=tool_call_id,
+            delta=delta,
+        ))
+
+    def _format_tool_call_end(
+        self,
+        event_type: str = "tool_call_end",
+        **kwargs,
+    ) -> str:
+        tool_call_id = kwargs.get("tool_call_id") or kwargs.get("toolCallId")
+        if (
+            not tool_call_id
+            or tool_call_id not in self._started_tool_calls
+            or tool_call_id in self._ended_tool_calls
+        ):
+            return ""
+        self._ended_tool_calls.add(tool_call_id)
+        return self._encode(ToolCallEndEvent(
+            type=EventType.TOOL_CALL_END,
+            tool_call_id=tool_call_id,
+        ))
+
+    def _format_tool_call_name_update(
+        self,
+        event_type: str = "tool_call_name_update",
+        **kwargs,
+    ) -> str:
+        tool_call_id = kwargs.get("tool_call_id") or kwargs.get("toolCallId")
+        tool_call_name = kwargs.get("tool_call_name") or kwargs.get("toolCallName")
+        if (
+            not tool_call_id
+            or not tool_call_name
+            or tool_call_id not in self._started_tool_calls
+            or self._tool_call_names.get(tool_call_id) == tool_call_name
+        ):
+            return ""
+        self._tool_call_names[tool_call_id] = tool_call_name
+        return self._encode(CustomEvent(
+            type=EventType.CUSTOM,
+            name="tool_call_name_update",
+            value={
+                "toolCallId": tool_call_id,
+                "toolCallName": tool_call_name,
+            },
+        ))
 
     def _format_tool_result(self, event_type: str = "tool_result", **kwargs) -> str:
         # Accept either format_event("tool_result", tool_result={...})

--- a/chatbot-app/agentcore/src/streaming/agui_event_processor.py
+++ b/chatbot-app/agentcore/src/streaming/agui_event_processor.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import time
 import logging
@@ -30,6 +31,8 @@ class AGUIStreamEventProcessor:
         self.current_user_id = None
         self.current_run_id = run_id
         self.tool_use_registry = {}
+        self._streamed_tool_calls = {}
+        self._active_streamed_tool_id = None
         self.partial_response_text = ""  # Track partial response for graceful abort
         self.tool_use_started = False  # Track if tool_use has been emitted (to prevent duplicate assistant messages)
 
@@ -86,6 +89,169 @@ class AGUIStreamEventProcessor:
         """Get current timestamp in ISO format"""
         from datetime import datetime
         return datetime.now().isoformat()
+
+    @staticmethod
+    def _extract_partial_json_string_field(
+        serialized_input: str,
+        field_name: str,
+    ) -> str | None:
+        """Read a completed string field before the surrounding JSON is complete."""
+        key = json.dumps(field_name)
+        key_index = serialized_input.find(key)
+        if key_index < 0:
+            return None
+
+        colon_index = serialized_input.find(":", key_index + len(key))
+        if colon_index < 0:
+            return None
+
+        value_start = colon_index + 1
+        while (
+            value_start < len(serialized_input)
+            and serialized_input[value_start].isspace()
+        ):
+            value_start += 1
+
+        try:
+            value, _ = json.JSONDecoder().raw_decode(serialized_input[value_start:])
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return value if isinstance(value, str) and value else None
+
+    async def _ensure_streamed_tool_call(
+        self,
+        tool_use_id: str,
+        tool_name: str,
+        *,
+        emit_start: bool = True,
+    ) -> str:
+        """Register a tool call and emit its start event exactly once."""
+        if not tool_use_id or not tool_name:
+            return ""
+
+        call = self._streamed_tool_calls.get(tool_use_id)
+        if call is None:
+            call = {
+                "name": tool_name,
+                "input": "",
+                "effective_name": (
+                    None if tool_name == "skill_executor" else tool_name
+                ),
+                "forwarded_input": "",
+                "started": False,
+            }
+            self._streamed_tool_calls[tool_use_id] = call
+            self.seen_tool_uses.add(tool_use_id)
+            self.tool_use_registry[tool_use_id] = {
+                "tool_name": tool_name,
+                "tool_use_id": tool_use_id,
+                "session_id": self.current_session_id,
+                "input": {},
+            }
+
+            if self.current_session_id:
+                try:
+                    from utils.tool_execution_context import tool_context_manager
+
+                    await tool_context_manager.create_context(
+                        tool_use_id,
+                        tool_name,
+                        self.current_session_id,
+                    )
+                except ImportError:
+                    pass
+        else:
+            call["name"] = tool_name
+
+        self._active_streamed_tool_id = tool_use_id
+        self.tool_use_started = True
+        if not emit_start:
+            return ""
+
+        start_event = self.formatter.format_event(
+            "tool_call_start",
+            tool_call_id=tool_use_id,
+            tool_call_name=call["effective_name"] or tool_name,
+        )
+        if start_event:
+            call["started"] = True
+        return start_event
+
+    def _start_streamed_tool_call(
+        self,
+        tool_use_id: str,
+        effective_name: str,
+    ) -> str:
+        call = self._streamed_tool_calls.get(tool_use_id)
+        if call is None or call.get("started") or not effective_name:
+            return ""
+
+        call["effective_name"] = effective_name
+        start_event = self.formatter.format_event(
+            "tool_call_start",
+            tool_call_id=tool_use_id,
+            tool_call_name=effective_name,
+        )
+        if start_event:
+            call["started"] = True
+        return start_event
+
+    def _forward_streamed_tool_input(self, tool_use_id: str) -> str:
+        call = self._streamed_tool_calls.get(tool_use_id)
+        if call is None or not call.get("started"):
+            return ""
+
+        serialized_input = call.get("input", "")
+        forwarded_input = call.get("forwarded_input", "")
+        if not serialized_input or serialized_input == forwarded_input:
+            return ""
+
+        delta = (
+            serialized_input[len(forwarded_input):]
+            if serialized_input.startswith(forwarded_input)
+            else serialized_input
+        )
+        call["forwarded_input"] = serialized_input
+        return self.formatter.format_event(
+            "tool_call_args",
+            tool_call_id=tool_use_id,
+            delta=delta,
+        )
+
+    def _finish_streamed_tool_call(self, tool_use_id: str) -> str:
+        """Finalize input state and emit the matching end event."""
+        call = self._streamed_tool_calls.get(tool_use_id)
+        if call is None:
+            return ""
+
+        serialized_input = call.get("input", "")
+        try:
+            parsed_input = json.loads(serialized_input) if serialized_input else {}
+        except (json.JSONDecodeError, TypeError):
+            parsed_input = {}
+
+        if tool_use_id in self.tool_use_registry:
+            self.tool_use_registry[tool_use_id]["input"] = parsed_input
+
+        result = ""
+        if not call.get("started"):
+            effective_name = (
+                parsed_input.get("tool_name")
+                or parsed_input.get("script_name")
+                or parsed_input.get("skill_name")
+                or "skill"
+            )
+            result += self._start_streamed_tool_call(
+                tool_use_id,
+                effective_name,
+            )
+        result += self._forward_streamed_tool_input(tool_use_id)
+        self._active_streamed_tool_id = None
+        result += self.formatter.format_event(
+            "tool_call_end",
+            tool_call_id=tool_use_id,
+        )
+        return result
 
     @property
     def stop_signal_provider(self):
@@ -287,6 +453,9 @@ class AGUIStreamEventProcessor:
 
         # Reset seen tool uses for each new stream
         self.seen_tool_uses.clear()
+        self.tool_use_registry.clear()
+        self._streamed_tool_calls.clear()
+        self._active_streamed_tool_id = None
 
         # Reset partial response tracking for this stream
         self.partial_response_text = ""
@@ -602,96 +771,74 @@ class AGUIStreamEventProcessor:
                         # Small delay to allow progress events to be processed
                         await asyncio.sleep(0.02)
 
-                # Handle callback events - ignore current_tool_use from delta events
+                # Legacy callback wrapper. Current Strands releases emit typed
+                # current_tool_use events separately, so there is nothing to relay here.
                 elif event.get("callback"):
-                    # Ignore current_tool_use from callback since it's incomplete
-                    # We only want to process tool_use when it's fully completed
                     continue
 
-                # Handle tool use events - only process when input looks complete
+                # Stream tool arguments as the model writes them. Strands exposes
+                # both the exact delta and the cumulative serialized input.
                 elif event.get("current_tool_use"):
                     tool_use = event["current_tool_use"]
                     tool_use_id = tool_use.get("toolUseId")
                     tool_name = tool_use.get("name")
-                    tool_input = tool_use.get("input", "")
+                    if not tool_use_id or not tool_name:
+                        continue
 
-                    # Only process if input looks complete (valid JSON or empty for no-param tools)
-                    should_process = False
-                    processed_input = None
+                    start_event = await self._ensure_streamed_tool_call(
+                        tool_use_id,
+                        tool_name,
+                        emit_start=tool_name != "skill_executor",
+                    )
+                    if start_event:
+                        yield start_event
 
-                    # Handle empty input case
-                    if tool_input == "" or tool_input == "{}":
-                        # Empty string or empty JSON object
-                        # Emit to frontend so it can show "Preparing..." state
-                        logger.debug(f"[Tool Use Event] Empty input for {tool_name} - emitting for frontend to show preparing state")
-                        should_process = True
-                        processed_input = {}
-                    else:
-                        # Check if input is valid JSON (complete)
-                        try:
-                            import json
-                            # Handle case where input might already be parsed
-                            if isinstance(tool_input, str):
-                                parsed_input = json.loads(tool_input)
-                                should_process = True
-                                processed_input = parsed_input  # Use parsed input
-                                logger.debug(f"[Tool Use Event] Parsed input for {tool_name} - keys: {list(parsed_input.keys()) if isinstance(parsed_input, dict) else 'not a dict'}")
-                            elif isinstance(tool_input, dict):
-                                # Already parsed
-                                should_process = True
-                                processed_input = tool_input
-                                logger.debug(f"[Tool Use Event] Dict input received for {tool_name} - keys: {list(tool_input.keys())}")
-                            else:
-                                should_process = False
-                                logger.debug(f"[Tool Use Event] Unexpected input type: {type(tool_input).__name__}")
-                        except json.JSONDecodeError as e:
-                            # Input is still incomplete (streaming in progress) - this is normal, skip silently
-                            should_process = False
-                            logger.debug(f"[Tool Use Event] Incomplete input for {tool_name} (streaming): {str(e)[:100]}")
+                    call = self._streamed_tool_calls[tool_use_id]
+                    cumulative_input = tool_use.get("input", "")
+                    delta = (
+                        ((event.get("delta") or {}).get("toolUse") or {}).get("input")
+                    )
 
-                    if should_process and tool_use_id:
-                        # Check if this is a new tool or parameter update
-                        is_new_tool = tool_use_id not in self.seen_tool_uses
-                        is_parameter_update = (not is_new_tool and
-                                             processed_input is not None and
-                                             len(processed_input) > 0)
+                    if isinstance(cumulative_input, dict):
+                        cumulative_input = json.dumps(cumulative_input)
+                    if not isinstance(cumulative_input, str):
+                        cumulative_input = ""
 
-                        if is_new_tool or is_parameter_update:
-                            # Mark as seen for new tools
-                            if is_new_tool:
-                                self.seen_tool_uses.add(tool_use_id)
-                                logger.debug(f"[Tool Use Event] New tool use registered: {tool_name} ({tool_use_id})")
+                    previous_input = call.get("input", "")
+                    if not isinstance(delta, str):
+                        delta = (
+                            cumulative_input[len(previous_input):]
+                            if cumulative_input.startswith(previous_input)
+                            else cumulative_input
+                        )
+                    call["input"] = (
+                        cumulative_input
+                        if cumulative_input
+                        else previous_input + delta
+                    )
 
-                            # Create a copy of tool_use with processed input (don't modify original)
-                            tool_use_copy = {
-                                "toolUseId": tool_use_id,
-                                "name": tool_name,
-                                "input": processed_input
-                            }
+                    if tool_name == "skill_executor" and not call.get("started"):
+                        effective_name = (
+                            self._extract_partial_json_string_field(
+                                call["input"],
+                                "tool_name",
+                            )
+                            or self._extract_partial_json_string_field(
+                                call["input"],
+                                "script_name",
+                            )
+                        )
+                        if effective_name:
+                            start_event = self._start_streamed_tool_call(
+                                tool_use_id,
+                                effective_name,
+                            )
+                            if start_event:
+                                yield start_event
 
-                            # Create tool execution context for new tools
-                            if is_new_tool and tool_name and self.current_session_id:
-                                try:
-                                    from utils.tool_execution_context import tool_context_manager
-                                    await tool_context_manager.create_context(tool_use_id, tool_name, self.current_session_id)
-                                except ImportError:
-                                    pass
-
-                            # Register tool info for later result processing (for new tools)
-                            if is_new_tool and tool_name:
-                                self.tool_use_registry[tool_use_id] = {
-                                    'tool_name': tool_name,
-                                    'tool_use_id': tool_use_id,
-                                    'session_id': self.current_session_id,
-                                    'input': processed_input
-                                }
-
-                            # Yield event (new tool or parameter update)
-                            logger.debug(f"[Tool Use Event] Emitting tool_use event for {tool_name} with {len(processed_input)} parameter(s)")
-                            yield self.formatter.format_event("tool_use", tool_use=tool_use_copy)
-                            self.tool_use_started = True  # Mark that tool_use was emitted
-
-                            await asyncio.sleep(0.1)
+                    args_event = self._forward_streamed_tool_input(tool_use_id)
+                    if args_event:
+                        yield args_event
 
                 # Handle tool streaming events (from async generator tools)
                 elif event.get("tool_stream_event"):
@@ -785,7 +932,32 @@ class AGUIStreamEventProcessor:
                 # Format: {"event": {"metadata": {"usage": {"inputTokens": N, ...}, ...}}}
                 elif event.get("event") and isinstance(event.get("event"), dict):
                     raw_chunk = event["event"]
-                    if "metadata" in raw_chunk:
+                    content_start = (
+                        raw_chunk.get("contentBlockStart", {})
+                        .get("start", {})
+                        .get("toolUse")
+                    )
+                    if content_start:
+                        tool_use_id = content_start.get("toolUseId")
+                        tool_name = content_start.get("name")
+                        if tool_use_id and tool_name:
+                            start_event = await self._ensure_streamed_tool_call(
+                                tool_use_id,
+                                tool_name,
+                                emit_start=tool_name != "skill_executor",
+                            )
+                            if start_event:
+                                yield start_event
+                    elif (
+                        "contentBlockStop" in raw_chunk
+                        and self._active_streamed_tool_id
+                    ):
+                        end_event = self._finish_streamed_tool_call(
+                            self._active_streamed_tool_id
+                        )
+                        if end_event:
+                            yield end_event
+                    elif "metadata" in raw_chunk:
                         metadata = raw_chunk["metadata"]
                         usage = metadata.get("usage", {})
                         input_tokens = usage.get("inputTokens", 0)

--- a/chatbot-app/agentcore/tests/unit/test_agui_tool_input_streaming.py
+++ b/chatbot-app/agentcore/tests/unit/test_agui_tool_input_streaming.py
@@ -1,0 +1,220 @@
+"""Tool calls should reach the AG-UI stream before their input JSON completes."""
+
+import json
+
+import pytest
+
+from streaming.agui_event_processor import AGUIStreamEventProcessor
+
+
+def _parse_sse_events(chunks: list[str]) -> list[dict]:
+    events = []
+    for chunk in chunks:
+        for frame in chunk.split("\n\n"):
+            for line in frame.splitlines():
+                if line.startswith("data:"):
+                    events.append(json.loads(line[len("data:"):].strip()))
+    return events
+
+
+class FakeAgent:
+    def __init__(self, events):
+        self.events = events
+
+    async def stream_async(self, *_args, **_kwargs):
+        for event in self.events:
+            yield event
+
+
+async def _collect(events):
+    processor = AGUIStreamEventProcessor(thread_id="thread", run_id="run")
+    processor._check_stop_signal = lambda: False
+    chunks = [
+        chunk
+        async for chunk in processor.process_stream(
+            FakeAgent(events),
+            "hello",
+        )
+    ]
+    return processor, _parse_sse_events(chunks)
+
+
+@pytest.mark.asyncio
+async def test_streams_start_args_and_end_as_separate_events():
+    processor, events = await _collect([
+        {
+            "event": {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": "tool-1",
+                            "name": "search",
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "type": "tool_use_stream",
+            "delta": {"toolUse": {"input": '{"query":'}},
+            "current_tool_use": {
+                "toolUseId": "tool-1",
+                "name": "search",
+                "input": '{"query":',
+            },
+        },
+        {
+            "type": "tool_use_stream",
+            "delta": {"toolUse": {"input": '"mailbox"}'}},
+            "current_tool_use": {
+                "toolUseId": "tool-1",
+                "name": "search",
+                "input": '{"query":"mailbox"}',
+            },
+        },
+        {"event": {"contentBlockStop": {"contentBlockIndex": 0}}},
+    ])
+
+    tool_events = [
+        event for event in events
+        if event["type"].startswith("TOOL_CALL")
+    ]
+    assert [event["type"] for event in tool_events] == [
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+    ]
+    assert [event["delta"] for event in tool_events[1:3]] == [
+        '{"query":',
+        '"mailbox"}',
+    ]
+    assert processor.tool_use_registry["tool-1"]["input"] == {
+        "query": "mailbox",
+    }
+
+
+@pytest.mark.asyncio
+async def test_starts_skill_executor_with_inner_tool_name_before_input_completes():
+    _, events = await _collect([
+        {
+            "event": {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": "tool-2",
+                            "name": "skill_executor",
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "type": "tool_use_stream",
+            "delta": {
+                "toolUse": {
+                    "input": (
+                        '{"skill_name":"web-search",'
+                        '"tool_name":"tavily_search",'
+                    )
+                }
+            },
+            "current_tool_use": {
+                "toolUseId": "tool-2",
+                "name": "skill_executor",
+                "input": (
+                    '{"skill_name":"web-search",'
+                    '"tool_name":"tavily_search",'
+                ),
+            },
+        },
+        {
+            "type": "tool_use_stream",
+            "delta": {"toolUse": {"input": '"tool_input":"{}"}'}},
+            "current_tool_use": {
+                "toolUseId": "tool-2",
+                "name": "skill_executor",
+                "input": (
+                    '{"skill_name":"web-search",'
+                    '"tool_name":"tavily_search",'
+                    '"tool_input":"{}"}'
+                ),
+            },
+        },
+        {"event": {"contentBlockStop": {"contentBlockIndex": 0}}},
+    ])
+
+    tool_events = [
+        event for event in events
+        if event["type"].startswith("TOOL_CALL")
+    ]
+    assert [event["type"] for event in tool_events] == [
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+    ]
+    assert tool_events[0]["toolCallName"] == "tavily_search"
+    assert [event["delta"] for event in tool_events[1:3]] == [
+        '{"skill_name":"web-search","tool_name":"tavily_search",',
+        '"tool_input":"{}"}',
+    ]
+    assert not any(
+        event["type"] == "CUSTOM"
+        and event.get("name") == "tool_call_name_update"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_starts_skill_script_with_script_name():
+    _, events = await _collect([
+        {
+            "event": {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": "tool-script",
+                            "name": "skill_executor",
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "type": "tool_use_stream",
+            "delta": {
+                "toolUse": {
+                    "input": (
+                        '{"skill_name":"workspace",'
+                        '"script_name":"cleanup.py",'
+                    )
+                }
+            },
+            "current_tool_use": {
+                "toolUseId": "tool-script",
+                "name": "skill_executor",
+                "input": (
+                    '{"skill_name":"workspace",'
+                    '"script_name":"cleanup.py",'
+                ),
+            },
+        },
+        {
+            "type": "tool_use_stream",
+            "delta": {"toolUse": {"input": '"script_input":{}}'}},
+            "current_tool_use": {
+                "toolUseId": "tool-script",
+                "name": "skill_executor",
+                "input": (
+                    '{"skill_name":"workspace",'
+                    '"script_name":"cleanup.py",'
+                    '"script_input":{}}'
+                ),
+            },
+        },
+        {"event": {"contentBlockStop": {"contentBlockIndex": 0}}},
+    ])
+
+    start = next(event for event in events if event["type"] == "TOOL_CALL_START")
+    assert start["toolCallName"] == "cleanup.py"

--- a/chatbot-app/agentcore/tests/unit/test_agui_tool_use_unwrap.py
+++ b/chatbot-app/agentcore/tests/unit/test_agui_tool_use_unwrap.py
@@ -69,7 +69,7 @@ def test_regular_tool_passes_through(formatter):
     assert starts[0]["toolCallName"] == "create_visualization"
 
 
-def test_skill_executor_without_tool_name_falls_back(formatter):
+def test_skill_executor_without_tool_name_uses_skill_name(formatter):
     """Defensive: if tool_input is missing tool_name, emit the wrapper name
     rather than a blank/broken event."""
     blob = formatter.format_event(
@@ -81,46 +81,89 @@ def test_skill_executor_without_tool_name_falls_back(formatter):
         },
     )
     starts = [e for e in _parse_sse_events(blob) if e.get("type") == "TOOL_CALL_START"]
-    assert starts[0]["toolCallName"] == "skill_executor"
+    assert starts[0]["toolCallName"] == "arxiv-search"
 
 
-def test_skill_executor_two_call_emits_unwrapped_start_once(formatter):
-    """The processor calls _format_tool_use twice for skill_executor: first
-    with empty input, then with the populated payload. Exactly one
-    TOOL_CALL_START must reach the wire, and it must carry the inner name."""
-    empty_call = formatter.format_event(
-        "tool_use",
-        tool_use={"toolUseId": "tu-6", "name": "skill_executor", "input": {}},
+def test_streaming_skill_executor_starts_then_updates_name(formatter):
+    start = formatter.format_event(
+        "tool_call_start",
+        tool_call_id="tu-6",
+        tool_call_name="skill_executor",
     )
-    full_call = formatter.format_event(
-        "tool_use",
-        tool_use={
-            "toolUseId": "tu-6",
-            "name": "skill_executor",
-            "input": {
-                "skill_name": "arxiv-search",
-                "tool_name": "arxiv_search",
-                "tool_input": '{"query": "mamba"}',
-            },
-        },
+    args = formatter.format_event(
+        "tool_call_args",
+        tool_call_id="tu-6",
+        delta='{"skill_name":"arxiv-search",',
     )
-    events = _parse_sse_events(empty_call) + _parse_sse_events(full_call)
+    name_update = formatter.format_event(
+        "tool_call_name_update",
+        tool_call_id="tu-6",
+        tool_call_name="arxiv_search",
+    )
+    end = formatter.format_event("tool_call_end", tool_call_id="tu-6")
+
+    events = _parse_sse_events(start + args + name_update + end)
     starts = [e for e in events if e.get("type") == "TOOL_CALL_START"]
-    assert len(starts) == 1, f"expected one START, got {len(starts)}: {starts}"
-    assert starts[0]["toolCallName"] == "arxiv_search"
-
-
-def test_regular_tool_two_call_still_emits_start_on_first(formatter):
-    """Non-skill_executor tools keep the old behavior: START on first emission,
-    not held back. Prevents a regression where args-only updates suppress the
-    START for a regular tool whose params come in later."""
-    first = formatter.format_event(
-        "tool_use",
-        tool_use={"toolUseId": "tu-7", "name": "create_visualization", "input": {}},
-    )
-    starts = [e for e in _parse_sse_events(first) if e.get("type") == "TOOL_CALL_START"]
     assert len(starts) == 1
-    assert starts[0]["toolCallName"] == "create_visualization"
+    assert starts[0]["toolCallName"] == "skill_executor"
+    assert [
+        e["delta"] for e in events if e.get("type") == "TOOL_CALL_ARGS"
+    ] == ['{"skill_name":"arxiv-search",']
+    updates = [
+        e for e in events
+        if e.get("type") == "CUSTOM"
+        and e.get("name") == "tool_call_name_update"
+    ]
+    assert updates[0]["value"] == {
+        "toolCallId": "tu-6",
+        "toolCallName": "arxiv_search",
+    }
+    assert len([e for e in events if e.get("type") == "TOOL_CALL_END"]) == 1
+
+
+def test_streaming_tool_lifecycle_is_idempotent(formatter):
+    start = formatter.format_event(
+        "tool_call_start",
+        tool_call_id="tu-7",
+        tool_call_name="create_visualization",
+    )
+    duplicate_start = formatter.format_event(
+        "tool_call_start",
+        tool_call_id="tu-7",
+        tool_call_name="create_visualization",
+    )
+    first_args = formatter.format_event(
+        "tool_call_args",
+        tool_call_id="tu-7",
+        delta='{"title":',
+    )
+    second_args = formatter.format_event(
+        "tool_call_args",
+        tool_call_id="tu-7",
+        delta='"chart"}',
+    )
+    end = formatter.format_event("tool_call_end", tool_call_id="tu-7")
+    duplicate_end = formatter.format_event("tool_call_end", tool_call_id="tu-7")
+    late_args = formatter.format_event(
+        "tool_call_args",
+        tool_call_id="tu-7",
+        delta="ignored",
+    )
+
+    events = _parse_sse_events(
+        start
+        + duplicate_start
+        + first_args
+        + second_args
+        + end
+        + duplicate_end
+        + late_args
+    )
+    assert len([e for e in events if e.get("type") == "TOOL_CALL_START"]) == 1
+    assert [
+        e["delta"] for e in events if e.get("type") == "TOOL_CALL_ARGS"
+    ] == ['{"title":', '"chart"}']
+    assert len([e for e in events if e.get("type") == "TOOL_CALL_END"]) == 1
 
 
 def test_args_payload_still_contains_inner_fields(formatter):

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -259,7 +259,7 @@ class TestMailboxDelivery:
         }
         delivered = AsyncMock()
         marked = MagicMock()
-        monkeypatch.setattr(research_jobs, "_list_jobs", lambda *_: [record])
+        monkeypatch.setattr(research_jobs, "_get_job", lambda *_: record)
         monkeypatch.setattr(research_jobs, "_load_report", lambda _: "# Report")
         monkeypatch.setattr(
             research_jobs,
@@ -277,11 +277,12 @@ class TestMailboxDelivery:
             payload_ref={"bucket": "bucket", "key": "report.md"},
         )
 
-        projections = await chat.deliver_mailbox_event(event)
+        result = await chat.deliver_mailbox_event(event)
+        projections = result.session_events
 
         assert record["mailboxEventId"] == "research-result:job-1"
         delivered.assert_awaited_once()
-        marked.assert_called_once_with(record)
+        marked.assert_not_called()
         assert [item.event_type for item in projections] == [
             "artifact.upserted",
             "assistant.turn.completed",
@@ -292,6 +293,8 @@ class TestMailboxDelivery:
         assert projections[1].payload["logicalMessageId"] == (
             "mailbox:research-result:job-1:1"
         )
+        result.after_ack()
+        marked.assert_called_once_with(record)
 
     @pytest.mark.asyncio
     async def test_committed_event_skips_duplicate_agent_generation(
@@ -359,7 +362,7 @@ class TestMailboxDelivery:
             "id": "artifact-1",
             "content_ref": {"path": "/tmp/job-1.md"},
         }
-        assert session_manager.sync_agent.call_count == 1
+        session_manager.sync_agent.assert_not_called()
 
 
 # ============================================================
@@ -556,6 +559,7 @@ class TestLifecycleActions:
             )
         )
         repository = MagicMock()
+        repository.is_session_deleted.return_value = False
         repository.list_events.return_value = []
         monkeypatch.setattr(mailbox_runtime, "drain_session_mailbox", drain)
         monkeypatch.setattr(mailbox, "get_mailbox_repository", lambda: repository)
@@ -587,6 +591,50 @@ class TestLifecycleActions:
             "pending": 0,
         }
         drain.assert_awaited_once_with("user-1", "session-1")
+
+    def test_mailbox_drain_absorbs_deleted_session_wake(
+        self,
+        monkeypatch,
+    ):
+        from agent import mailbox, mailbox_runtime
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        monkeypatch.setenv("M2M_CLIENT_ID", "dispatcher-client")
+        drain = AsyncMock()
+        repository = MagicMock()
+        repository.is_session_deleted.return_value = True
+        monkeypatch.setattr(mailbox_runtime, "drain_session_mailbox", drain)
+        monkeypatch.setattr(mailbox, "get_mailbox_repository", lambda: repository)
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            headers={
+                "Authorization": (
+                    f"Bearer {_unsigned_test_token({'client_id': 'dispatcher-client'})}"
+                )
+            },
+            json={
+                "thread_id": "session-1",
+                "run_id": str(uuid.uuid4()),
+                "state": {"action": "drain_mailbox", "user_id": "user-1"},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "status": "drained",
+            "processed": 0,
+            "retried": 0,
+            "dead": 0,
+            "acquired": False,
+            "pending": 0,
+            "deleted": True,
+        }
+        drain.assert_not_awaited()
 
     @patch('agent.stop_signal.get_stop_signal_provider')
     def test_stop_sets_signal(self, mock_get_provider):

--- a/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
+++ b/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
@@ -103,12 +103,13 @@ class TestMailboxPersistenceScope:
             0,
         )
 
-        with manager.mailbox_event_scope("mailbox-event-1"):
+        with manager.mailbox_event_scope("mailbox-event-1", 7):
             result = manager.create_message("session-1", "default", message)
 
         assert result == {"eventId": "stored-1"}
         metadata = parent_create.call_args.kwargs["metadata"]
         assert metadata["originEventId"]["stringValue"] == "mailbox-event-1"
+        assert metadata["conversationEpoch"]["stringValue"] == "7"
         assert metadata["logicalMessageId"]["stringValue"] == (
             "mailbox:mailbox-event-1:0"
         )
@@ -146,6 +147,42 @@ class TestMailboxPersistenceScope:
             ":1"
         )
         assert calls[0].kwargs["metadata"]["visibility"]["stringValue"] == "conversation"
+
+    def test_list_messages_filters_stale_mailbox_epochs(self, manager):
+        repository = MagicMock()
+        repository.get_conversation_epoch.return_value = 3
+        manager.config.filter_restored_tool_context = False
+        manager.memory_client.list_events.return_value = [
+            {"eventId": "foreground"},
+            {
+                "eventId": "stale",
+                "metadata": {
+                    "conversationEpoch": {"stringValue": "2"},
+                },
+            },
+            {
+                "eventId": "current",
+                "metadata": {
+                    "conversationEpoch": {"stringValue": "3"},
+                },
+            },
+        ]
+        manager.converter = MagicMock()
+        manager.converter.events_to_messages.side_effect = (
+            lambda events: [event["eventId"] for event in events]
+        )
+
+        with patch(
+            "agent.mailbox.get_mailbox_repository",
+            return_value=repository,
+        ):
+            messages = manager.list_messages("session-1", "default")
+
+        assert messages == ["foreground", "current"]
+        repository.get_conversation_epoch.assert_called_once_with(
+            "user-1",
+            "session-1",
+        )
 
 class TestCompactionState:
     """Test CompactionState dataclass"""
@@ -1630,4 +1667,3 @@ class TestEndToEndScenarios:
 
         assert manager.compaction_state.checkpoint == 50
         assert manager.compaction_state.summary == "Previous summary"
-

--- a/chatbot-app/agentcore/tests/unit/test_mailbox.py
+++ b/chatbot-app/agentcore/tests/unit/test_mailbox.py
@@ -5,6 +5,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from agent.mailbox import (
+    CANCELLED,
     DEAD,
     PENDING,
     PROCESSED,
@@ -12,6 +13,7 @@ from agent.mailbox import (
     FileMailboxRepository,
     MailboxEvent,
     SessionDeletedError,
+    SessionSupersededError,
     SessionEvent,
 )
 
@@ -40,6 +42,8 @@ def test_enqueue_is_idempotent(tmp_path):
     assert [stored.event_id for stored in repository.list_events("user-1", "session-1")] == [
         "event-1"
     ]
+    assert repository.get_event("user-1", "session-1", "event-1") == item
+    assert repository.get_event("user-1", "session-1", "missing") is None
 
 
 def test_deleted_session_rejects_new_events_and_leases(tmp_path):
@@ -55,6 +59,59 @@ def test_deleted_session_rejects_new_events_and_leases(tmp_path):
         lease_seconds=30,
         now=NOW,
     ) is None
+
+
+def test_truncate_epoch_rejects_stale_events_and_accepts_current_work(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    stale = event("stale")
+
+    assert repository.advance_conversation_epoch(
+        "user-1",
+        "session-1",
+        now=NOW,
+    ) == 1
+    with pytest.raises(SessionSupersededError):
+        repository.enqueue(stale)
+
+    current = event("current")
+    current.conversation_epoch = 1
+    assert repository.enqueue(current) is True
+
+
+def test_truncate_epoch_fences_claimed_event_and_cancels_it(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+    lease = repository.acquire_lease(
+        "user-1",
+        "session-1",
+        "worker-1",
+        lease_seconds=30,
+        now=NOW,
+    )
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW,
+    )
+
+    repository.advance_conversation_epoch(
+        "user-1",
+        "session-1",
+        now=NOW + timedelta(seconds=1),
+    )
+
+    assert repository.acknowledge(
+        claimed,
+        lease,
+        now=NOW + timedelta(seconds=1),
+    ) is False
+    assert repository.get_event(
+        "user-1",
+        "session-1",
+        "event-1",
+    ).status == CANCELLED
 
 
 def test_tombstone_fences_claimed_event_acknowledgement(tmp_path):
@@ -329,6 +386,22 @@ def test_dynamodb_enqueue_uses_event_key_for_idempotency():
     assert repository.enqueue(item) is False
 
 
+def test_dynamodb_get_event_uses_direct_consistent_read():
+    client = MagicMock()
+    repository = DynamoDBMailboxRepository("mailbox-table", client=client)
+    item = event("event-1")
+    client.get_item.return_value = {
+        "Item": repository._serialize(item.to_record()),
+    }
+
+    assert repository.get_event("user-1", "session-1", "event-1") == item
+    client.get_item.assert_called_once_with(
+        TableName="mailbox-table",
+        Key=repository._key("user-1", "session-1", "INBOX#event-1"),
+        ConsistentRead=True,
+    )
+
+
 def test_dynamodb_enqueue_rejects_tombstoned_session():
     client = MagicMock()
     repository = DynamoDBMailboxRepository("mailbox-table", client=client)
@@ -408,5 +481,7 @@ def test_dynamodb_ack_writes_projections_in_fenced_transaction():
     transaction = client.transact_write_items.call_args.kwargs["TransactItems"]
     assert len(transaction) == 3
     stored = repository._deserialize(transaction[2]["Put"]["Item"])
-    assert stored["recordKey"] == "OUTBOX#event-1:assistant"
+    assert stored["recordKey"] == (
+        "OUTBOX_V2#2026-08-06T12:00:00+00:00#event-1:assistant"
+    )
     assert stored["originEventId"] == "event-1"

--- a/chatbot-app/agentcore/tests/unit/test_mailbox_runtime.py
+++ b/chatbot-app/agentcore/tests/unit/test_mailbox_runtime.py
@@ -1,10 +1,12 @@
 import asyncio
 import threading
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from agent import mailbox_runtime
 from agent.mailbox import FileMailboxRepository, MailboxEvent
+from agent.session_coordinator import DrainResult
 
 
 @pytest.fixture(autouse=True)
@@ -12,6 +14,24 @@ def clear_runtime():
     mailbox_runtime.clear_mailbox_runtime()
     yield
     mailbox_runtime.clear_mailbox_runtime()
+
+
+def test_delivery_requires_mailbox_writes(monkeypatch):
+    monkeypatch.setenv("SESSION_MAILBOX_DELIVERY_ENABLED", "true")
+    monkeypatch.setenv("SESSION_MAILBOX_WRITE_ENABLED", "false")
+
+    with pytest.raises(
+        RuntimeError,
+        match="SESSION_MAILBOX_WRITE_ENABLED",
+    ):
+        mailbox_runtime.validate_mailbox_configuration()
+
+
+def test_write_only_rollout_is_valid(monkeypatch):
+    monkeypatch.setenv("SESSION_MAILBOX_DELIVERY_ENABLED", "false")
+    monkeypatch.setenv("SESSION_MAILBOX_WRITE_ENABLED", "true")
+
+    mailbox_runtime.validate_mailbox_configuration()
 
 
 @pytest.mark.asyncio
@@ -67,3 +87,37 @@ async def test_notify_drains_on_registered_runtime_loop(monkeypatch, tmp_path):
 async def test_notify_fails_when_runtime_is_unavailable():
     with pytest.raises(RuntimeError, match="not available"):
         await mailbox_runtime.notify_session_mailbox("user-1", "session-1")
+
+
+@pytest.mark.asyncio
+async def test_drain_reconciles_processed_producer_jobs(monkeypatch):
+    reconciled = MagicMock(return_value=1)
+    monkeypatch.setattr(
+        "agent.research_jobs.reconcile_processed_deliveries",
+        reconciled,
+    )
+    coordinator = MagicMock()
+    coordinator.drain = AsyncMock(return_value=DrainResult(processed=1))
+    monkeypatch.setattr(
+        mailbox_runtime,
+        "SessionCoordinator",
+        lambda *_: coordinator,
+    )
+    monkeypatch.setattr(
+        mailbox_runtime,
+        "get_mailbox_repository",
+        MagicMock(),
+    )
+
+    result = await mailbox_runtime.drain_session_mailbox(
+        "user-1",
+        "session-1",
+        reconcile_event_ids=["event-1"],
+    )
+
+    assert result.processed == 1
+    reconciled.assert_called_once_with(
+        "user-1",
+        "session-1",
+        ["event-1"],
+    )

--- a/chatbot-app/agentcore/tests/unit/test_research_jobs.py
+++ b/chatbot-app/agentcore/tests/unit/test_research_jobs.py
@@ -1,5 +1,6 @@
 import asyncio
 from copy import deepcopy
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -198,6 +199,7 @@ def test_cloud_job_reads_merge_orchestration_and_legacy_rows(monkeypatch):
     )
     monkeypatch.setenv("DYNAMODB_USERS_TABLE", "users-table")
     monkeypatch.setenv("SESSION_ORCHESTRATION_TABLE", "orchestration-table")
+    monkeypatch.setenv("RESEARCH_JOB_LEGACY_READ_ENABLED", "true")
     monkeypatch.setattr(research_jobs.boto3, "resource", lambda *args, **kwargs: resource)
 
     jobs = research_jobs._list_jobs("user-1", "session-1")
@@ -210,6 +212,31 @@ def test_cloud_job_reads_merge_orchestration_and_legacy_rows(monkeypatch):
         ":session_key": "USER#user-1#SESSION#session-1",
         ":prefix": "JOB#",
     }
+
+
+def test_cloud_job_reads_skip_legacy_table_by_default(monkeypatch):
+    orchestration = MagicMock()
+    orchestration.query.return_value = {
+        "Items": [{
+            "jobId": "new-job",
+            "sessionId": "session-1",
+            "userId": "user-1",
+        }],
+    }
+    legacy = MagicMock()
+    resource = MagicMock()
+    resource.Table.side_effect = lambda name: (
+        orchestration if name == "orchestration-table" else legacy
+    )
+    monkeypatch.setenv("DYNAMODB_USERS_TABLE", "users-table")
+    monkeypatch.setenv("SESSION_ORCHESTRATION_TABLE", "orchestration-table")
+    monkeypatch.delenv("RESEARCH_JOB_LEGACY_READ_ENABLED", raising=False)
+    monkeypatch.setattr(research_jobs.boto3, "resource", lambda *args, **kwargs: resource)
+
+    jobs = research_jobs._list_jobs("user-1", "session-1")
+
+    assert [item["jobId"] for item in jobs] == ["new-job"]
+    legacy.query.assert_not_called()
 
 
 def test_completion_mailbox_event_is_small_and_idempotent(monkeypatch):
@@ -332,6 +359,46 @@ def test_recover_pending_job_reenqueues_existing_idempotency_key(monkeypatch):
     assert recovered == ["research-result:job-1"]
     enqueue.assert_called_once_with(record)
     save.assert_called_once_with(record)
+
+
+def test_reconcile_processed_delivery_marks_job_delivered(monkeypatch):
+    from agent.mailbox import MailboxEvent, PROCESSED
+
+    record = {
+        "jobId": "job-1",
+        "userId": "user-1",
+        "sessionId": "session-1",
+        "status": "delivering",
+        "mailboxEventId": "research-result:job-1",
+    }
+    event = replace(
+        MailboxEvent.create(
+            event_id="research-result:job-1",
+            event_type="async_result.ready",
+            session_id="session-1",
+            user_id="user-1",
+            source_type="research_job",
+            source_id="job-1",
+        ),
+        status=PROCESSED,
+    )
+    repository = MagicMock()
+    repository.get_event.return_value = event
+    delivered = MagicMock()
+    monkeypatch.setattr(research_jobs, "_list_jobs", lambda *_: [record])
+    monkeypatch.setattr(research_jobs, "mark_delivered", delivered)
+    monkeypatch.setattr(
+        "agent.mailbox.get_mailbox_repository",
+        lambda: repository,
+    )
+
+    reconciled = research_jobs.reconcile_processed_deliveries(
+        "user-1",
+        "session-1",
+    )
+
+    assert reconciled == 1
+    delivered.assert_called_once_with(record)
 
 
 @pytest.mark.asyncio

--- a/chatbot-app/agentcore/tests/unit/test_session_coordinator.py
+++ b/chatbot-app/agentcore/tests/unit/test_session_coordinator.py
@@ -9,7 +9,7 @@ from agent.mailbox import (
     MailboxEvent,
     SessionEvent,
 )
-from agent.session_coordinator import SessionCoordinator
+from agent.session_coordinator import MailboxHandlerResult, SessionCoordinator
 
 
 def mailbox_event(event_id: str, event_type: str = "test.ready") -> MailboxEvent:
@@ -72,6 +72,93 @@ async def test_handler_projections_are_committed_with_acknowledgement(tmp_path):
         item.event_id
         for item in repository.list_session_events("user-1", "session-1")
     ] == ["event-1:assistant"]
+
+
+@pytest.mark.asyncio
+async def test_post_ack_hook_runs_after_projections_are_durable(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1"))
+    observed = []
+
+    async def handler(event):
+        projection = SessionEvent.create(
+            event_id=f"{event.event_id}:assistant",
+            event_type="assistant.turn.completed",
+            session_id=event.session_id,
+            user_id=event.user_id,
+            origin_event_id=event.event_id,
+        )
+
+        def after_ack():
+            observed.extend(
+                item.event_id
+                for item in repository.list_session_events(
+                    event.user_id,
+                    event.session_id,
+                )
+            )
+
+        return MailboxHandlerResult(
+            session_events=[projection],
+            after_ack=after_ack,
+        )
+
+    result = await SessionCoordinator(
+        repository,
+        {"test.ready": handler},
+    ).drain("user-1", "session-1", owner="worker-1")
+
+    assert result.processed == 1
+    assert result.post_ack_failed == 0
+    assert observed == ["event-1:assistant"]
+
+
+@pytest.mark.asyncio
+async def test_post_ack_failure_does_not_retry_durable_delivery(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1"))
+
+    async def handler(event):
+        def after_ack():
+            raise RuntimeError("job status unavailable")
+
+        return MailboxHandlerResult(after_ack=after_ack)
+
+    result = await SessionCoordinator(
+        repository,
+        {"test.ready": handler},
+    ).drain("user-1", "session-1", owner="worker-1")
+
+    assert result.processed == 1
+    assert result.retried == 0
+    assert result.post_ack_failed == 1
+    assert repository.get_event("user-1", "session-1", "event-1").status == PROCESSED
+
+
+@pytest.mark.asyncio
+async def test_post_ack_hook_retries_projection_updates(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(mailbox_event("event-1"))
+    attempts = 0
+
+    async def handler(event):
+        def after_ack():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise RuntimeError("temporarily unavailable")
+
+        return MailboxHandlerResult(after_ack=after_ack)
+
+    result = await SessionCoordinator(
+        repository,
+        {"test.ready": handler},
+        post_ack_attempts=3,
+    ).drain("user-1", "session-1", owner="worker-1")
+
+    assert result.processed == 1
+    assert result.post_ack_failed == 0
+    assert attempts == 3
 
 
 @pytest.mark.asyncio

--- a/chatbot-app/frontend/__tests__/components/ChatInputArea.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInputArea.test.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  ChatInputArea,
+  LARGE_PASTE_ATTACHMENT_THRESHOLD,
+  MAX_PASTED_TEXT_BYTES,
+} from '@/components/chat/ChatInputArea'
+
+vi.mock('@/components/ModelConfigDialog', () => ({
+  ModelConfigDialog: () => null,
+}))
+
+function Harness() {
+  const [files, setFiles] = useState<File[]>([])
+
+  return (
+    <>
+      <ChatInputArea
+        selectedFiles={files}
+        setSelectedFiles={setFiles}
+        agentStatus="idle"
+        isBusy={false}
+        isVoiceActive={false}
+        isVoiceSupported={false}
+        isCanvasOpen={false}
+        sessionId="session-1"
+        onSendMessage={vi.fn().mockResolvedValue(undefined)}
+        onEnqueueMessage={vi.fn()}
+        conciseMode={false}
+        onToggleConciseMode={vi.fn()}
+        onStopGeneration={vi.fn()}
+        onConnectVoice={vi.fn().mockResolvedValue(undefined)}
+        onDisconnectVoice={vi.fn()}
+        onExportConversation={vi.fn()}
+        onNewChat={vi.fn().mockResolvedValue(undefined)}
+        onCompact={vi.fn()}
+      />
+      <output data-testid="attachment-count">{files.length}</output>
+      <output data-testid="attachment-name">{files[0]?.name}</output>
+      <output data-testid="attachment-size">{files[0]?.size}</output>
+    </>
+  )
+}
+
+describe('ChatInputArea large paste handling', () => {
+  it('converts a large text paste into a text attachment', () => {
+    render(<Harness />)
+    const pastedText = 'a'.repeat(LARGE_PASTE_ATTACHMENT_THRESHOLD)
+
+    fireEvent.paste(screen.getByRole('textbox'), {
+      clipboardData: {
+        items: [],
+        getData: (type: string) => type === 'text/plain' ? pastedText : '',
+      },
+    })
+
+    expect(screen.getByTestId('attachment-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('attachment-name')).toHaveTextContent(
+      /^pasted-text-.*\.txt$/,
+    )
+    expect(screen.getByTestId('attachment-size')).toHaveTextContent(
+      String(pastedText.length),
+    )
+  })
+
+  it('keeps ordinary text pastes in the textarea path', () => {
+    render(<Harness />)
+
+    fireEvent.paste(screen.getByRole('textbox'), {
+      clipboardData: {
+        items: [],
+        getData: () => 'short paste',
+      },
+    })
+
+    expect(screen.getByTestId('attachment-count')).toHaveTextContent('0')
+  })
+
+  it('rejects pasted text that would exceed the attachment payload limit', () => {
+    render(<Harness />)
+    const pastedText = 'a'.repeat(MAX_PASTED_TEXT_BYTES + 1)
+
+    fireEvent.paste(screen.getByRole('textbox'), {
+      clipboardData: {
+        items: [],
+        getData: () => pastedText,
+      },
+    })
+
+    expect(screen.getByTestId('attachment-count')).toHaveTextContent('0')
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Pasted text exceeds the 1 MB limit',
+    )
+  })
+})

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -322,6 +322,27 @@ describe('ChatInterface', () => {
       expect(mockUseChat.interruptWithQueuedMessage).toHaveBeenCalledWith('queued-2')
     })
 
+    it('keeps the interrupt action on the queued row while text is responding', () => {
+      mockUseChat.agentStatus = 'responding'
+      mockUseChat.isForegroundRunActive = false
+      mockUseChat.queuedMessages = [{
+        id: 'queued-stream',
+        text: 'interrupt streamed response',
+        files: [],
+        sessionId: 'session-1',
+      }]
+
+      render(<ChatInterface />)
+
+      const action = screen.getByRole('button', {
+        name: /interrupt with this message/i,
+      })
+      expect(action).toHaveTextContent('Interrupt')
+      fireEvent.click(action)
+      expect(mockUseChat.interruptWithQueuedMessage)
+        .toHaveBeenCalledWith('queued-stream')
+    })
+
     it('offers immediate send for a queued message while idle', () => {
       mockUseChat.agentStatus = 'idle'
       mockUseChat.queuedMessages = [{

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -34,6 +34,7 @@ const mockUseChat: {
   clearQueuedMessages: ReturnType<typeof vi.fn>
   releaseQueue: ReturnType<typeof vi.fn>
   interruptWithQueuedMessage: ReturnType<typeof vi.fn>
+  sendQueuedMessageNow: ReturnType<typeof vi.fn>
   conciseMode: boolean
   toggleConciseMode: ReturnType<typeof vi.fn>
   newChat: ReturnType<typeof vi.fn>
@@ -66,6 +67,7 @@ const mockUseChat: {
   clearQueuedMessages: vi.fn(),
   releaseQueue: vi.fn(),
   interruptWithQueuedMessage: vi.fn().mockResolvedValue(true),
+  sendQueuedMessageNow: vi.fn().mockResolvedValue(true),
   conciseMode: false,
   toggleConciseMode: vi.fn(),
   newChat: vi.fn().mockResolvedValue(undefined),
@@ -317,7 +319,7 @@ describe('ChatInterface', () => {
       expect(mockUseChat.interruptWithQueuedMessage).toHaveBeenCalledWith('queued-2')
     })
 
-    it('does not offer queue interruption while idle or awaiting approval', () => {
+    it('offers immediate send for a queued message while idle', () => {
       mockUseChat.agentStatus = 'idle'
       mockUseChat.queuedMessages = [{
         id: 'queued-1',
@@ -326,18 +328,29 @@ describe('ChatInterface', () => {
         sessionId: 'session-1',
       }]
 
-      const { rerender } = render(<ChatInterface />)
-      expect(screen.queryByRole('button', {
-        name: /interrupt with this message/i,
-      })).not.toBeInTheDocument()
+      render(<ChatInterface />)
+      fireEvent.click(screen.getByRole('button', {
+        name: /send this message now/i,
+      }))
 
+      expect(mockUseChat.sendQueuedMessageNow).toHaveBeenCalledWith('queued-1')
+    })
+
+    it('hides queued message actions while awaiting approval', () => {
       mockUseChat.agentStatus = 'thinking'
+      mockUseChat.queuedMessages = [{
+        id: 'queued-1',
+        text: 'wait',
+        files: [],
+        sessionId: 'session-1',
+      }]
+
       mockUseChat.currentInterrupt = {
         interrupts: [{ id: 'i1', name: 'approval', reason: {} }],
       }
-      rerender(<ChatInterface />)
+      render(<ChatInterface />)
       expect(screen.queryByRole('button', {
-        name: /interrupt with this message/i,
+        name: /this message/i,
       })).not.toBeInTheDocument()
     })
   })

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -20,6 +20,7 @@ const mockUseChat: {
   isConnected: boolean
   isTyping: boolean
   agentStatus: AgentStatus
+  isForegroundRunActive: boolean
   currentToolExecutions: any[]
   currentReasoning: any
   showProgressPanel: boolean
@@ -53,6 +54,7 @@ const mockUseChat: {
   isConnected: true,
   isTyping: false,
   agentStatus: 'idle',
+  isForegroundRunActive: false,
   currentToolExecutions: [],
   currentReasoning: null,
   showProgressPanel: false,
@@ -181,6 +183,7 @@ describe('ChatInterface', () => {
     mockUseChat.inputMessage = ''
     mockUseChat.isTyping = false
     mockUseChat.agentStatus = 'idle'
+    mockUseChat.isForegroundRunActive = false
     mockUseChat.currentInterrupt = null
     mockUseChat.pendingOAuth = null
     mockUseChat.queuedMessages = []
@@ -303,7 +306,7 @@ describe('ChatInterface', () => {
     })
 
     it('offers a queued message as an interrupt while the agent is running', () => {
-      mockUseChat.agentStatus = 'thinking'
+      mockUseChat.isForegroundRunActive = true
       mockUseChat.queuedMessages = [{
         id: 'queued-2',
         text: 'handle this now',
@@ -337,7 +340,7 @@ describe('ChatInterface', () => {
     })
 
     it('hides queued message actions while awaiting approval', () => {
-      mockUseChat.agentStatus = 'thinking'
+      mockUseChat.isForegroundRunActive = true
       mockUseChat.queuedMessages = [{
         id: 'queued-1',
         text: 'wait',

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -21,6 +21,11 @@ const mockUseChat: {
   isTyping: boolean
   agentStatus: AgentStatus
   isForegroundRunActive: boolean
+  turnControl: {
+    isBusy: boolean
+    isBlocked: boolean
+    canInterrupt: boolean
+  }
   currentToolExecutions: any[]
   currentReasoning: any
   showProgressPanel: boolean
@@ -55,6 +60,11 @@ const mockUseChat: {
   isTyping: false,
   agentStatus: 'idle',
   isForegroundRunActive: false,
+  turnControl: {
+    isBusy: false,
+    isBlocked: false,
+    canInterrupt: false,
+  },
   currentToolExecutions: [],
   currentReasoning: null,
   showProgressPanel: false,
@@ -184,6 +194,11 @@ describe('ChatInterface', () => {
     mockUseChat.isTyping = false
     mockUseChat.agentStatus = 'idle'
     mockUseChat.isForegroundRunActive = false
+    mockUseChat.turnControl = {
+      isBusy: false,
+      isBlocked: false,
+      canInterrupt: false,
+    }
     mockUseChat.currentInterrupt = null
     mockUseChat.pendingOAuth = null
     mockUseChat.queuedMessages = []
@@ -307,6 +322,11 @@ describe('ChatInterface', () => {
 
     it('offers a queued message as an interrupt while the agent is running', () => {
       mockUseChat.isForegroundRunActive = true
+      mockUseChat.turnControl = {
+        isBusy: true,
+        isBlocked: false,
+        canInterrupt: true,
+      }
       mockUseChat.queuedMessages = [{
         id: 'queued-2',
         text: 'handle this now',
@@ -325,6 +345,11 @@ describe('ChatInterface', () => {
     it('keeps the interrupt action on the queued row while text is responding', () => {
       mockUseChat.agentStatus = 'responding'
       mockUseChat.isForegroundRunActive = false
+      mockUseChat.turnControl = {
+        isBusy: true,
+        isBlocked: false,
+        canInterrupt: true,
+      }
       mockUseChat.queuedMessages = [{
         id: 'queued-stream',
         text: 'interrupt streamed response',
@@ -341,6 +366,28 @@ describe('ChatInterface', () => {
       fireEvent.click(action)
       expect(mockUseChat.interruptWithQueuedMessage)
         .toHaveBeenCalledWith('queued-stream')
+    })
+
+    it('does not let an empty interrupt envelope hide the queued action', () => {
+      mockUseChat.agentStatus = 'responding'
+      mockUseChat.currentInterrupt = { interrupts: [] }
+      mockUseChat.turnControl = {
+        isBusy: true,
+        isBlocked: false,
+        canInterrupt: true,
+      }
+      mockUseChat.queuedMessages = [{
+        id: 'queued-after-tool',
+        text: 'queued while the tool is running',
+        files: [],
+        sessionId: 'session-1',
+      }]
+
+      render(<ChatInterface />)
+
+      expect(screen.getByRole('button', {
+        name: /interrupt with this message/i,
+      })).toHaveTextContent('Interrupt')
     })
 
     it('offers immediate send for a queued message while idle', () => {
@@ -371,6 +418,11 @@ describe('ChatInterface', () => {
 
       mockUseChat.currentInterrupt = {
         interrupts: [{ id: 'i1', name: 'approval', reason: {} }],
+      }
+      mockUseChat.turnControl = {
+        isBusy: true,
+        isBlocked: true,
+        canInterrupt: false,
       }
       render(<ChatInterface />)
       expect(screen.queryByRole('button', {

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -336,7 +336,7 @@ describe('ChatInterface', () => {
 
       render(<ChatInterface />)
       fireEvent.click(screen.getByRole('button', {
-        name: /interrupt with this message/i,
+        name: 'Interrupt and send now',
       }))
 
       expect(mockUseChat.interruptWithQueuedMessage).toHaveBeenCalledWith('queued-2')
@@ -360,9 +360,9 @@ describe('ChatInterface', () => {
       render(<ChatInterface />)
 
       const action = screen.getByRole('button', {
-        name: /interrupt with this message/i,
+        name: 'Interrupt and send now',
       })
-      expect(action).toHaveTextContent('Interrupt')
+      expect(action).toHaveTextContent('')
       fireEvent.click(action)
       expect(mockUseChat.interruptWithQueuedMessage)
         .toHaveBeenCalledWith('queued-stream')
@@ -386,8 +386,8 @@ describe('ChatInterface', () => {
       render(<ChatInterface />)
 
       expect(screen.getByRole('button', {
-        name: /interrupt with this message/i,
-      })).toHaveTextContent('Interrupt')
+        name: 'Interrupt and send now',
+      })).toHaveTextContent('')
     })
 
     it('offers immediate send for a queued message while idle', () => {
@@ -401,7 +401,7 @@ describe('ChatInterface', () => {
 
       render(<ChatInterface />)
       fireEvent.click(screen.getByRole('button', {
-        name: /send this message now/i,
+        name: 'Send now',
       }))
 
       expect(mockUseChat.sendQueuedMessageNow).toHaveBeenCalledWith('queued-1')

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -33,6 +33,7 @@ const mockUseChat: {
   removeQueuedMessage: ReturnType<typeof vi.fn>
   clearQueuedMessages: ReturnType<typeof vi.fn>
   releaseQueue: ReturnType<typeof vi.fn>
+  interruptWithQueuedMessage: ReturnType<typeof vi.fn>
   conciseMode: boolean
   toggleConciseMode: ReturnType<typeof vi.fn>
   newChat: ReturnType<typeof vi.fn>
@@ -42,6 +43,7 @@ const mockUseChat: {
   browserProgress: any
   respondToInterrupt: ReturnType<typeof vi.fn>
   currentInterrupt: any
+  pendingOAuth: any
 } = {
   messages: [],
   groupedMessages: [],
@@ -63,6 +65,7 @@ const mockUseChat: {
   removeQueuedMessage: vi.fn(),
   clearQueuedMessages: vi.fn(),
   releaseQueue: vi.fn(),
+  interruptWithQueuedMessage: vi.fn().mockResolvedValue(true),
   conciseMode: false,
   toggleConciseMode: vi.fn(),
   newChat: vi.fn().mockResolvedValue(undefined),
@@ -71,7 +74,8 @@ const mockUseChat: {
   browserSession: null,
   browserProgress: undefined,
   respondToInterrupt: vi.fn().mockResolvedValue(undefined),
-  currentInterrupt: null
+  currentInterrupt: null,
+  pendingOAuth: null,
 }
 
 vi.mock('@/hooks/useChat', () => ({
@@ -176,6 +180,9 @@ describe('ChatInterface', () => {
     mockUseChat.isTyping = false
     mockUseChat.agentStatus = 'idle'
     mockUseChat.currentInterrupt = null
+    mockUseChat.pendingOAuth = null
+    mockUseChat.queuedMessages = []
+    mockUseChat.queueHoldReason = null
   })
 
   afterEach(() => {
@@ -291,6 +298,47 @@ describe('ChatInterface', () => {
 
       // Component should render without errors when agent is thinking
       expect(document.body).toBeInTheDocument()
+    })
+
+    it('offers a queued message as an interrupt while the agent is running', () => {
+      mockUseChat.agentStatus = 'thinking'
+      mockUseChat.queuedMessages = [{
+        id: 'queued-2',
+        text: 'handle this now',
+        files: [],
+        sessionId: 'session-1',
+      }]
+
+      render(<ChatInterface />)
+      fireEvent.click(screen.getByRole('button', {
+        name: /interrupt with this message/i,
+      }))
+
+      expect(mockUseChat.interruptWithQueuedMessage).toHaveBeenCalledWith('queued-2')
+    })
+
+    it('does not offer queue interruption while idle or awaiting approval', () => {
+      mockUseChat.agentStatus = 'idle'
+      mockUseChat.queuedMessages = [{
+        id: 'queued-1',
+        text: 'wait',
+        files: [],
+        sessionId: 'session-1',
+      }]
+
+      const { rerender } = render(<ChatInterface />)
+      expect(screen.queryByRole('button', {
+        name: /interrupt with this message/i,
+      })).not.toBeInTheDocument()
+
+      mockUseChat.agentStatus = 'thinking'
+      mockUseChat.currentInterrupt = {
+        interrupts: [{ id: 'i1', name: 'approval', reason: {} }],
+      }
+      rerender(<ChatInterface />)
+      expect(screen.queryByRole('button', {
+        name: /interrupt with this message/i,
+      })).not.toBeInTheDocument()
     })
   })
 

--- a/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
@@ -81,9 +81,11 @@ describe('QueuedMessages', () => {
   it('interrupts with the queued message that was clicked', () => {
     const { onInterrupt } = setup([msg('first'), msg('second')], null, 'interrupt')
     const buttons = screen.getAllByRole('button', {
-      name: /interrupt with this message/i,
+      name: 'Interrupt and send now',
     })
-    expect(screen.getAllByText('Interrupt')).toHaveLength(2)
+    expect(screen.queryByText('Interrupt')).not.toBeInTheDocument()
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0]).toHaveClass('h-7', 'w-7')
 
     fireEvent.click(buttons[1])
 
@@ -91,11 +93,24 @@ describe('QueuedMessages', () => {
     expect(onInterrupt).toHaveBeenCalledWith('id-second')
   })
 
+  it('explains the interrupt action on hover or keyboard focus', async () => {
+    setup([msg('queued')], null, 'interrupt')
+    const button = screen.getByRole('button', {
+      name: 'Interrupt and send now',
+    })
+
+    fireEvent.focus(button)
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Interrupt and send now',
+    )
+  })
+
   it('hides interrupt controls when the current state cannot be stopped', () => {
     setup([msg('queued')])
 
     expect(screen.queryByRole('button', {
-      name: /interrupt with this message/i,
+      name: 'Interrupt and send now',
     })).not.toBeInTheDocument()
   })
 
@@ -106,9 +121,10 @@ describe('QueuedMessages', () => {
       'send',
     )
     const buttons = screen.getAllByRole('button', {
-      name: /send this message now/i,
+      name: 'Send now',
     })
-    expect(screen.getAllByText('Send now')).toHaveLength(2)
+    expect(screen.queryByText('Send now')).not.toBeInTheDocument()
+    expect(buttons).toHaveLength(2)
 
     fireEvent.click(buttons[1])
 

--- a/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
@@ -10,19 +10,20 @@ function msg(text: string, files: File[] = []): QueuedMessage {
 function setup(
   queue: QueuedMessage[],
   holdReason: any = null,
-  canInterrupt = false,
+  actionMode: "interrupt" | "send" | null = null,
 ) {
   const handlers = {
     onRemove: vi.fn(),
     onSendNow: vi.fn(),
     onDiscardAll: vi.fn(),
     onInterrupt: vi.fn().mockResolvedValue(true),
+    onSendMessageNow: vi.fn().mockResolvedValue(true),
   }
   render(
     <QueuedMessages
       queue={queue}
       holdReason={holdReason}
-      canInterrupt={canInterrupt}
+      actionMode={actionMode}
       {...handlers}
     />,
   )
@@ -41,8 +42,9 @@ describe('QueuedMessages', () => {
         onRemove={vi.fn()}
         onSendNow={vi.fn()}
         onDiscardAll={vi.fn()}
-        canInterrupt={false}
+        actionMode={null}
         onInterrupt={vi.fn()}
+        onSendMessageNow={vi.fn()}
       />,
     )
     expect(container).toBeEmptyDOMElement()
@@ -77,7 +79,7 @@ describe('QueuedMessages', () => {
   })
 
   it('interrupts with the queued message that was clicked', () => {
-    const { onInterrupt } = setup([msg('first'), msg('second')], null, true)
+    const { onInterrupt } = setup([msg('first'), msg('second')], null, 'interrupt')
     const buttons = screen.getAllByRole('button', {
       name: /interrupt with this message/i,
     })
@@ -89,11 +91,27 @@ describe('QueuedMessages', () => {
   })
 
   it('hides interrupt controls when the current state cannot be stopped', () => {
-    setup([msg('queued')], null, false)
+    setup([msg('queued')])
 
     expect(screen.queryByRole('button', {
       name: /interrupt with this message/i,
     })).not.toBeInTheDocument()
+  })
+
+  it('sends the selected queued message immediately in send mode', () => {
+    const { onSendMessageNow } = setup(
+      [msg('first'), msg('second')],
+      null,
+      'send',
+    )
+    const buttons = screen.getAllByRole('button', {
+      name: /send this message now/i,
+    })
+
+    fireEvent.click(buttons[1])
+
+    expect(onSendMessageNow).toHaveBeenCalledTimes(1)
+    expect(onSendMessageNow).toHaveBeenCalledWith('id-second')
   })
 
   it('labels each remove button with its message so they are distinguishable', () => {

--- a/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
@@ -7,13 +7,25 @@ function msg(text: string, files: File[] = []): QueuedMessage {
   return { id: `id-${text}`, text, files, sessionId: 's1' }
 }
 
-function setup(queue: QueuedMessage[], holdReason: any = null) {
+function setup(
+  queue: QueuedMessage[],
+  holdReason: any = null,
+  canInterrupt = false,
+) {
   const handlers = {
     onRemove: vi.fn(),
     onSendNow: vi.fn(),
     onDiscardAll: vi.fn(),
+    onInterrupt: vi.fn().mockResolvedValue(true),
   }
-  render(<QueuedMessages queue={queue} holdReason={holdReason} {...handlers} />)
+  render(
+    <QueuedMessages
+      queue={queue}
+      holdReason={holdReason}
+      canInterrupt={canInterrupt}
+      {...handlers}
+    />,
+  )
   return handlers
 }
 
@@ -29,6 +41,8 @@ describe('QueuedMessages', () => {
         onRemove={vi.fn()}
         onSendNow={vi.fn()}
         onDiscardAll={vi.fn()}
+        canInterrupt={false}
+        onInterrupt={vi.fn()}
       />,
     )
     expect(container).toBeEmptyDOMElement()
@@ -60,6 +74,26 @@ describe('QueuedMessages', () => {
 
     expect(onRemove).toHaveBeenCalledTimes(1)
     expect(onRemove).toHaveBeenCalledWith('id-second')
+  })
+
+  it('interrupts with the queued message that was clicked', () => {
+    const { onInterrupt } = setup([msg('first'), msg('second')], null, true)
+    const buttons = screen.getAllByRole('button', {
+      name: /interrupt with this message/i,
+    })
+
+    fireEvent.click(buttons[1])
+
+    expect(onInterrupt).toHaveBeenCalledTimes(1)
+    expect(onInterrupt).toHaveBeenCalledWith('id-second')
+  })
+
+  it('hides interrupt controls when the current state cannot be stopped', () => {
+    setup([msg('queued')], null, false)
+
+    expect(screen.queryByRole('button', {
+      name: /interrupt with this message/i,
+    })).not.toBeInTheDocument()
   })
 
   it('labels each remove button with its message so they are distinguishable', () => {

--- a/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/QueuedMessages.test.tsx
@@ -83,6 +83,7 @@ describe('QueuedMessages', () => {
     const buttons = screen.getAllByRole('button', {
       name: /interrupt with this message/i,
     })
+    expect(screen.getAllByText('Interrupt')).toHaveLength(2)
 
     fireEvent.click(buttons[1])
 
@@ -107,6 +108,7 @@ describe('QueuedMessages', () => {
     const buttons = screen.getAllByRole('button', {
       name: /send this message now/i,
     })
+    expect(screen.getAllByText('Send now')).toHaveLength(2)
 
     fireEvent.click(buttons[1])
 

--- a/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
+++ b/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
@@ -53,7 +53,8 @@ describe('durable research completion replay', () => {
       source.indexOf('// Keep reloadFromStorage ref'),
     )
 
-    expect(source).toContain('useSessionEvents(sessionId)')
+    expect(source).toContain('useSessionEvents(')
+    expect(source).toContain('hasPendingSessionDelivery')
     expect(effect).toContain("event.eventType === 'assistant.turn.completed'")
     expect(effect).toContain('event.payload.executionId,')
     expect(effect).toContain('event.payload.logicalMessageId')

--- a/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
+++ b/chatbot-app/frontend/__tests__/components/ResearchCompletionReplay.test.ts
@@ -54,7 +54,8 @@ describe('durable research completion replay', () => {
     )
 
     expect(source).toContain('useSessionEvents(')
-    expect(source).toContain('hasPendingSessionDelivery')
+    expect(source).toContain('hasPendingDelivery')
+    expect(source).toContain('deliveryVersion')
     expect(effect).toContain("event.eventType === 'assistant.turn.completed'")
     expect(effect).toContain('event.payload.executionId,')
     expect(effect).toContain('event.payload.logicalMessageId')

--- a/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
@@ -252,8 +252,8 @@ describe('useChat message queue wiring', () => {
     expect(interrupted).toBe(false)
     expect(sentTexts()).toEqual([])
     expect(result.current.queuedMessages.map(m => m.text)).toEqual([
-      'selected',
       'first queued',
+      'selected',
     ])
     expect(result.current.queueHoldReason).toBeNull()
   })

--- a/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
@@ -234,6 +234,27 @@ describe('useChat message queue wiring', () => {
     expect(result.current.queueHoldReason).toBeNull()
   })
 
+  it('sends a selected queued message immediately while idle', async () => {
+    const { result } = await mount()
+
+    act(() => { result.current.enqueueMessage('first queued') })
+    act(() => { result.current.enqueueMessage('send this now') })
+    const selectedId = result.current.queuedMessages[1].id
+
+    let sent = false
+    await act(async () => {
+      sent = await result.current.sendQueuedMessageNow(selectedId)
+    })
+
+    expect(sent).toBe(true)
+    expect(sendStopSignal).not.toHaveBeenCalled()
+    expect(sentTexts()[0]).toBe('send this now')
+    await waitFor(() => {
+      expect(sentTexts()).toEqual(['send this now', 'first queued'])
+    })
+    expect(result.current.queuedMessages).toEqual([])
+  })
+
   it('does not send the selected message after a session switch', async () => {
     let acceptStop: (accepted: boolean) => void = () => {}
     sendStopSignal.mockReturnValueOnce(

--- a/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
@@ -117,6 +117,30 @@ describe('useChat message queue wiring', () => {
     expect(sentTexts()).toEqual([])
   })
 
+  it('keeps the foreground run active while a text stream is open', async () => {
+    let finishStream: () => void = () => {}
+    apiSendMessage.mockImplementationOnce(async (...args: SendArgs) => {
+      sendCalls.push(args)
+      await new Promise<void>(resolve => { finishStream = resolve })
+      args[2]?.()
+    })
+    const { result } = await mount()
+
+    let sendPromise: Promise<void>
+    act(() => {
+      sendPromise = result.current.sendMessage('stream a response')
+    })
+
+    await waitFor(() => expect(result.current.isForegroundRunActive).toBe(true))
+
+    await act(async () => {
+      finishStream()
+      await sendPromise!
+    })
+
+    expect(result.current.isForegroundRunActive).toBe(false)
+  })
+
   it('flushes the queue after a turn finishes normally', async () => {
     const { result } = await mount()
 

--- a/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
@@ -189,6 +189,74 @@ describe('useChat message queue wiring', () => {
     expect(sentTexts()).toEqual([])
   })
 
+  it('stops before sending the selected queued message', async () => {
+    const { result } = await mount()
+
+    act(() => { result.current.enqueueMessage('first queued') })
+    act(() => { result.current.enqueueMessage('send this now') })
+    const selectedId = result.current.queuedMessages[1].id
+
+    let interrupted = false
+    await act(async () => {
+      interrupted = await result.current.interruptWithQueuedMessage(selectedId)
+    })
+
+    expect(interrupted).toBe(true)
+    expect(sendStopSignal).toHaveBeenCalledTimes(1)
+    expect(sendStopSignal.mock.invocationCallOrder[0])
+      .toBeLessThan(apiSendMessage.mock.invocationCallOrder[0])
+    expect(sentTexts()[0]).toBe('send this now')
+    await waitFor(() => {
+      expect(sentTexts()).toEqual(['send this now', 'first queued'])
+    })
+    expect(result.current.queuedMessages).toEqual([])
+  })
+
+  it('keeps the selected message queued when the stop request fails', async () => {
+    sendStopSignal.mockResolvedValueOnce(false)
+    const { result } = await mount()
+
+    act(() => { result.current.enqueueMessage('first queued') })
+    act(() => { result.current.enqueueMessage('selected') })
+    const selectedId = result.current.queuedMessages[1].id
+
+    let interrupted = true
+    await act(async () => {
+      interrupted = await result.current.interruptWithQueuedMessage(selectedId)
+    })
+
+    expect(interrupted).toBe(false)
+    expect(sentTexts()).toEqual([])
+    expect(result.current.queuedMessages.map(m => m.text)).toEqual([
+      'selected',
+      'first queued',
+    ])
+    expect(result.current.queueHoldReason).toBeNull()
+  })
+
+  it('does not send the selected message after a session switch', async () => {
+    let acceptStop: (accepted: boolean) => void = () => {}
+    sendStopSignal.mockReturnValueOnce(
+      new Promise<boolean>(resolve => { acceptStop = resolve }),
+    )
+    const { result } = await mount()
+
+    act(() => { result.current.enqueueMessage('selected') })
+    const selectedId = result.current.queuedMessages[0].id
+
+    let interruptPromise: Promise<boolean>
+    act(() => {
+      interruptPromise = result.current.interruptWithQueuedMessage(selectedId)
+    })
+    await act(async () => {
+      await result.current.loadSession('different-session')
+      acceptStop(true)
+    })
+
+    await expect(interruptPromise!).resolves.toBe(false)
+    expect(sentTexts()).toEqual([])
+  })
+
   it('sends the held message once the user confirms', async () => {
     const { result } = await mount()
 

--- a/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
@@ -120,10 +120,12 @@ describe('useChatAPI — stopping a turn that parked at an interrupt', () => {
     const { hook } = setup()
     await runTurn(hook, [INTERRUPT])
 
+    expect(hook.result.current.hasStoppableRun).toBe(true)
     const { requested, accepted } = await tryStop(hook)
 
     expect(requested).toBe(true)
     expect(accepted).toBe(true)
+    expect(hook.result.current.hasStoppableRun).toBe(false)
   })
 
   it('targets the run that was interrupted', async () => {
@@ -147,6 +149,7 @@ describe('useChatAPI — stopping a turn that parked at an interrupt', () => {
     const { hook } = setup()
     await runTurn(hook, [RUN_FINISHED])
 
+    expect(hook.result.current.hasStoppableRun).toBe(false)
     const { requested, accepted } = await tryStop(hook)
 
     expect(requested).toBe(false)
@@ -210,6 +213,7 @@ describe('useChatAPI — background execution replay', () => {
       await Promise.resolve()
     })
     expect(replayed).toBe(false)
+    expect(hook.result.current.hasStoppableRun).toBe(false)
 
     await act(async () => {
       finishCleanup?.()

--- a/chatbot-app/frontend/__tests__/hooks/useMessageQueue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useMessageQueue.test.ts
@@ -206,7 +206,30 @@ describe('useMessageQueue', () => {
     expect(send).toHaveBeenCalledTimes(1)
   })
 
-  it('retains and holds a message whose send failed', async () => {
+  it('removes a dispatched message before its response completes', async () => {
+    let finish: () => void = () => {}
+    const send = vi.fn(
+      () => new Promise<void>(resolve => { finish = resolve }),
+    )
+    const { hook } = setup(send)
+    enqueue(hook, 'dispatched')
+    enqueue(hook, 'still waiting')
+
+    let flushPromise: Promise<boolean>
+    act(() => {
+      flushPromise = hook.result.current.flushNext(SESSION, CLEAR)
+    })
+
+    expect(send).toHaveBeenCalledWith('dispatched', [], undefined, undefined)
+    expect(hook.result.current.queue.map(m => m.text)).toEqual(['still waiting'])
+
+    await act(async () => {
+      finish()
+      await flushPromise!
+    })
+  })
+
+  it('does not requeue an accepted message when its response fails', async () => {
     const send = vi.fn().mockRejectedValue(new Error('network'))
     const { hook } = setup(send)
     enqueue(hook, 'doomed')
@@ -214,7 +237,19 @@ describe('useMessageQueue', () => {
     const sent = await act(async () => hook.result.current.flushNext(SESSION, CLEAR))
 
     expect(sent).toBe(false)
-    expect(hook.result.current.queue.map(m => m.text)).toEqual(['doomed'])
+    expect(hook.result.current.queue).toEqual([])
+    expect(hook.result.current.holdReason).toBeNull()
+  })
+
+  it('holds messages still waiting behind a failed dispatched turn', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('network'))
+    const { hook } = setup(send)
+    enqueue(hook, 'doomed')
+    enqueue(hook, 'still queued')
+
+    await act(async () => hook.result.current.flushNext(SESSION, CLEAR))
+
+    expect(hook.result.current.queue.map(m => m.text)).toEqual(['still queued'])
     expect(hook.result.current.holdReason).toBe('error')
   })
 

--- a/chatbot-app/frontend/__tests__/hooks/useMessageQueue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useMessageQueue.test.ts
@@ -41,6 +41,43 @@ describe('useMessageQueue', () => {
     expect(hook.result.current.queue).toHaveLength(0)
   })
 
+  it('moves a selected message to the front for the next flush', async () => {
+    const { hook, send } = setup()
+    enqueue(hook, 'first')
+    enqueue(hook, 'selected')
+    enqueue(hook, 'third')
+    const selectedId = hook.result.current.queue[1].id
+
+    let prioritized = false
+    act(() => {
+      prioritized = hook.result.current.prioritize(selectedId, SESSION)
+    })
+
+    expect(prioritized).toBe(true)
+    expect(hook.result.current.queue.map(m => m.text)).toEqual([
+      'selected',
+      'first',
+      'third',
+    ])
+
+    await act(async () => { await hook.result.current.flushNext(SESSION, CLEAR) })
+    expect(send).toHaveBeenCalledWith('selected', [], undefined, undefined)
+  })
+
+  it('does not prioritize a message from another session', () => {
+    const { hook } = setup()
+    enqueue(hook, 'foreign', OTHER_SESSION)
+    const id = hook.result.current.queue[0].id
+
+    let prioritized = true
+    act(() => {
+      prioritized = hook.result.current.prioritize(id, SESSION)
+    })
+
+    expect(prioritized).toBe(false)
+    expect(hook.result.current.queue.map(m => m.text)).toEqual(['foreign'])
+  })
+
   it('ignores empty submissions but keeps attachment-only ones', () => {
     const { hook } = setup()
     enqueue(hook, '   ')

--- a/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
@@ -50,6 +50,17 @@ const deliveredJob = {
   },
 }
 
+const completedJob = {
+  ...runningJob,
+  status: 'completed',
+  updatedAt: '2026-08-06T00:00:02Z',
+  artifact: {
+    id: 'research-tool-1',
+    type: 'research',
+    title: 'Report',
+  },
+}
+
 describe('useResearchJobs', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -186,6 +197,32 @@ describe('useResearchJobs', () => {
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('hydrates a completed job without keeping fast polling active', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([completedJob]))
+      .mockImplementationOnce(() => response([{
+        ...completedJob,
+        artifact: {
+          ...completedJob.artifact,
+          content: '# Finished report',
+        },
+      }]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(() => useResearchJobs('session-1', 1))
+    await flushAsyncWork()
+
+    expect(hook.result.current.jobs[0]?.artifact?.content).toBe('# Finished report')
+    expect(hook.result.current.isActive).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('hides the previous session snapshot immediately when switching sessions', async () => {

--- a/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
@@ -81,11 +81,13 @@ describe('useResearchJobs', () => {
 
     await flushAsyncWork()
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(hook.result.current.isActive).toBe(false)
 
     hook.rerender({ invocationCount: 1 })
     await flushAsyncWork()
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(hook.result.current.jobs[0]?.status).toBe('running')
+    expect(hook.result.current.isActive).toBe(true)
 
     await act(async () => {
       vi.advanceTimersByTime(2000)
@@ -105,6 +107,7 @@ describe('useResearchJobs', () => {
     )
     expect(hook.result.current.jobs[0]?.artifact?.content).toBe('# Finished report')
     expect(hook.result.current.deliveredJobIds).toEqual(['job-1'])
+    expect(hook.result.current.isActive).toBe(false)
   })
 
   it('keeps polling during invocation discovery when the first lookup is empty', async () => {
@@ -124,6 +127,7 @@ describe('useResearchJobs', () => {
     hook.rerender({ invocationCount: 1 })
     await flushAsyncWork()
     expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(hook.result.current.isActive).toBe(true)
 
     await act(async () => {
       vi.advanceTimersByTime(2000)
@@ -133,6 +137,55 @@ describe('useResearchJobs', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(hook.result.current.jobs[0]?.status).toBe('running')
+  })
+
+  it('ends discovery polling when a new invocation never gets a job row', async () => {
+    const fetchMock = vi.fn(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ invocationCount }) => useResearchJobs('session-1', invocationCount),
+      { initialProps: { invocationCount: 0 } },
+    )
+    await flushAsyncWork()
+
+    hook.rerender({ invocationCount: 1 })
+    await flushAsyncWork()
+    expect(hook.result.current.isActive).toBe(true)
+
+    for (let tick = 0; tick < 8; tick += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(2000)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+    }
+
+    expect(hook.result.current.isActive).toBe(false)
+    const callsAfterDiscovery = fetchMock.mock.calls.length
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterDiscovery)
+  })
+
+  it('treats invocations present at session load as a historical baseline', async () => {
+    const fetchMock = vi.fn(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(() => useResearchJobs('session-1', 3))
+    await flushAsyncWork()
+
+    expect(hook.result.current.isActive).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000)
+      await Promise.resolve()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('hides the previous session snapshot immediately when switching sessions', async () => {
@@ -152,5 +205,6 @@ describe('useResearchJobs', () => {
 
     expect(hook.result.current.jobs).toEqual([])
     expect(hook.result.current.deliveredJobIds).toEqual([])
+    expect(hook.result.current.isActive).toBe(false)
   })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
@@ -20,6 +20,13 @@ function response(jobs: unknown[]) {
   } as Response)
 }
 
+function jobResponse(job: unknown) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ job }),
+  } as Response)
+}
+
 async function flushAsyncWork() {
   await act(async () => {
     await Promise.resolve()
@@ -76,13 +83,13 @@ describe('useResearchJobs', () => {
       .mockImplementationOnce(() => response([]))
       .mockImplementationOnce(() => response([runningJob]))
       .mockImplementationOnce(() => response([deliveredJob]))
-      .mockImplementationOnce(() => response([{
+      .mockImplementationOnce(() => jobResponse({
         ...deliveredJob,
         artifact: {
           ...deliveredJob.artifact,
           content: '# Finished report',
         },
-      }]))
+      }))
     vi.stubGlobal('fetch', fetchMock)
 
     const hook = renderHook(
@@ -116,6 +123,14 @@ describe('useResearchJobs', () => {
           Authorization: 'Bearer research-access-token',
         }),
       }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/research/jobs?session_id=session-1&job_ids=job-1',
+      expect.any(Object),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/research/jobs?session_id=session-1&job_id=job-1&include_content=true',
+      expect.any(Object),
     )
     expect(hook.result.current.jobs[0]?.artifact?.content).toBe('# Finished report')
     expect(hook.result.current.deliveredJobIds).toEqual(['job-1'])
@@ -206,13 +221,13 @@ describe('useResearchJobs', () => {
   it('hydrates a completed job without keeping fast polling active', async () => {
     const fetchMock = vi.fn()
       .mockImplementationOnce(() => response([completedJob]))
-      .mockImplementationOnce(() => response([{
+      .mockImplementationOnce(() => jobResponse({
         ...completedJob,
         artifact: {
           ...completedJob.artifact,
           content: '# Finished report',
         },
-      }]))
+      }))
     vi.stubGlobal('fetch', fetchMock)
 
     const hook = renderHook(() => useResearchJobs('session-1', 1))

--- a/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useResearchJobs.test.ts
@@ -99,6 +99,7 @@ describe('useResearchJobs', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(hook.result.current.jobs[0]?.status).toBe('running')
     expect(hook.result.current.isActive).toBe(true)
+    expect(hook.result.current.hasPendingDelivery).toBe(false)
 
     await act(async () => {
       vi.advanceTimersByTime(2000)
@@ -119,6 +120,8 @@ describe('useResearchJobs', () => {
     expect(hook.result.current.jobs[0]?.artifact?.content).toBe('# Finished report')
     expect(hook.result.current.deliveredJobIds).toEqual(['job-1'])
     expect(hook.result.current.isActive).toBe(false)
+    expect(hook.result.current.hasPendingDelivery).toBe(false)
+    expect(hook.result.current.deliveryVersion).toBe(1)
   })
 
   it('keeps polling during invocation discovery when the first lookup is empty', async () => {
@@ -173,6 +176,7 @@ describe('useResearchJobs', () => {
     }
 
     expect(hook.result.current.isActive).toBe(false)
+    expect(hook.result.current.hasPendingDelivery).toBe(false)
     const callsAfterDiscovery = fetchMock.mock.calls.length
     await act(async () => {
       vi.advanceTimersByTime(10000)

--- a/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
@@ -13,10 +13,22 @@ vi.mock('aws-amplify/auth', () => ({
   }),
 }))
 
-function response(events: unknown[]) {
+function response(
+  events: unknown[],
+  options: {
+    cursor?: string
+    conversationEpoch?: number
+    hasMore?: boolean
+  } = {},
+) {
   return Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ events }),
+    json: () => Promise.resolve({
+      events,
+      cursor: options.cursor ?? 'OUTBOX_V2#',
+      conversationEpoch: options.conversationEpoch ?? 0,
+      hasMore: options.hasMore ?? false,
+    }),
   } as Response)
 }
 
@@ -79,7 +91,7 @@ describe('useSessionEvents', () => {
 
     expect(hook.result.current.events).toEqual([completion])
     expect(fetchMock).toHaveBeenLastCalledWith(
-      '/api/session/events?session_id=session-1',
+      '/api/session/events?session_id=session-1&cursor=OUTBOX_V2%23&epoch=0',
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: 'Bearer session-event-token',
@@ -100,7 +112,9 @@ describe('useSessionEvents', () => {
   it('removes a projection after truncate deletes it from durable storage', async () => {
     const fetchMock = vi.fn()
       .mockImplementationOnce(() => response([completion]))
-      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response([], {
+        conversationEpoch: 1,
+      }))
     vi.stubGlobal('fetch', fetchMock)
 
     const hook = renderHook(() => useSessionEvents('session-1', true))
@@ -109,6 +123,28 @@ describe('useSessionEvents', () => {
 
     await advance(2000)
 
+    expect(hook.result.current.events).toEqual([])
+  })
+
+  it('refreshes immediately after a truncate mutation version changes', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response([completion]))
+      .mockImplementationOnce(() => response([], {
+        conversationEpoch: 1,
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ version }) => useSessionEvents('session-1', false, 0, version),
+      { initialProps: { version: 0 } },
+    )
+    await flushAsyncWork()
+    expect(hook.result.current.events).toEqual([completion])
+
+    hook.rerender({ version: 1 })
+    await flushAsyncWork()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(hook.result.current.events).toEqual([])
   })
 

--- a/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
@@ -142,6 +142,20 @@ describe('useSessionEvents', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('does not refresh an idle session on window focus', async () => {
+    const fetchMock = vi.fn(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderHook(() => useSessionEvents('session-1'))
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    window.dispatchEvent(new Event('focus'))
+    await flushAsyncWork()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('polls immediately when pending delivery becomes active', async () => {
     const fetchMock = vi.fn(() => response([]))
     vi.stubGlobal('fetch', fetchMock)

--- a/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
@@ -28,6 +28,15 @@ async function flushAsyncWork() {
   })
 }
 
+async function advance(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
 const completion = {
   schemaVersion: 1,
   eventId: 'research-result:job-1:assistant',
@@ -62,16 +71,11 @@ describe('useSessionEvents', () => {
       .mockImplementationOnce(() => response([completion]))
     vi.stubGlobal('fetch', fetchMock)
 
-    const hook = renderHook(() => useSessionEvents('session-1'))
+    const hook = renderHook(() => useSessionEvents('session-1', true))
     await flushAsyncWork()
     expect(hook.result.current.events).toEqual([])
 
-    await act(async () => {
-      vi.advanceTimersByTime(2000)
-      await Promise.resolve()
-      await Promise.resolve()
-      await Promise.resolve()
-    })
+    await advance(2000)
 
     expect(hook.result.current.events).toEqual([completion])
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -87,7 +91,7 @@ describe('useSessionEvents', () => {
   it('surfaces initial projections so the consumer can close the history race', async () => {
     vi.stubGlobal('fetch', vi.fn(() => response([completion])))
 
-    const hook = renderHook(() => useSessionEvents('session-1'))
+    const hook = renderHook(() => useSessionEvents('session-1', true))
     await flushAsyncWork()
 
     expect(hook.result.current.events).toEqual([completion])
@@ -99,16 +103,11 @@ describe('useSessionEvents', () => {
       .mockImplementationOnce(() => response([]))
     vi.stubGlobal('fetch', fetchMock)
 
-    const hook = renderHook(() => useSessionEvents('session-1'))
+    const hook = renderHook(() => useSessionEvents('session-1', true))
     await flushAsyncWork()
     expect(hook.result.current.events).toEqual([completion])
 
-    await act(async () => {
-      vi.advanceTimersByTime(2000)
-      await Promise.resolve()
-      await Promise.resolve()
-      await Promise.resolve()
-    })
+    await advance(2000)
 
     expect(hook.result.current.events).toEqual([])
   })
@@ -129,5 +128,73 @@ describe('useSessionEvents', () => {
     hook.rerender({ sessionId: 'session-2' })
 
     expect(hook.result.current.events).toEqual([])
+  })
+
+  it('backs idle polling off from 5 seconds to 10 and then 30', async () => {
+    const fetchMock = vi.fn(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderHook(() => useSessionEvents('session-1'))
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await advance(4999)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await advance(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await advance(9999)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    await advance(1)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    await advance(29999)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    await advance(1)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('polls immediately when pending delivery becomes active', async () => {
+    const fetchMock = vi.fn(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ active }) => useSessionEvents('session-1', active),
+      { initialProps: { active: false } },
+    )
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    hook.rerender({ active: true })
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await advance(2000)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('pauses while hidden and refreshes immediately when visible again', async () => {
+    const fetchMock = vi.fn(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderHook(() => useSessionEvents('session-1'))
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await advance(60000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSessionEvents.test.ts
@@ -130,7 +130,7 @@ describe('useSessionEvents', () => {
     expect(hook.result.current.events).toEqual([])
   })
 
-  it('backs idle polling off from 5 seconds to 10 and then 30', async () => {
+  it('does not poll periodically without a pending delivery', async () => {
     const fetchMock = vi.fn(() => response([]))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -138,20 +138,8 @@ describe('useSessionEvents', () => {
     await flushAsyncWork()
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    await advance(4999)
+    await advance(60000)
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    await advance(1)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-
-    await advance(9999)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    await advance(1)
-    expect(fetchMock).toHaveBeenCalledTimes(3)
-
-    await advance(29999)
-    expect(fetchMock).toHaveBeenCalledTimes(3)
-    await advance(1)
-    expect(fetchMock).toHaveBeenCalledTimes(4)
   })
 
   it('polls immediately when pending delivery becomes active', async () => {
@@ -171,6 +159,25 @@ describe('useSessionEvents', () => {
 
     await advance(2000)
     expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('refreshes once when a delivery completes between job polls', async () => {
+    const fetchMock = vi.fn(() => response([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const hook = renderHook(
+      ({ version }) => useSessionEvents('session-1', false, version),
+      { initialProps: { version: 0 } },
+    )
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    hook.rerender({ version: 1 })
+    await flushAsyncWork()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await advance(60000)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('pauses while hidden and refreshes immediately when visible again', async () => {

--- a/chatbot-app/frontend/__tests__/hooks/useStreamEvents-tool-input.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useStreamEvents-tool-input.test.ts
@@ -1,0 +1,116 @@
+import { useRef, useState } from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useStreamEvents } from '@/hooks/useStreamEvents'
+import type { Message, ToolExecution } from '@/types/chat'
+
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: vi.fn(),
+}))
+
+function setup() {
+  return renderHook(() => {
+    const [messages, setMessages] = useState<Message[]>([])
+    const [sessionState, setSessionState] = useState<any>({
+      toolExecutions: [],
+      interrupt: null,
+      pendingOAuth: null,
+    })
+    const [uiState, setUIState] = useState<any>({
+      agentStatus: 'thinking',
+      isTyping: true,
+      latencyMetrics: {},
+    })
+    const currentToolExecutionsRef = useRef<ToolExecution[]>([])
+    const currentTurnIdRef = useRef<string | null>('turn-1')
+    const startPollingRef = useRef<((sessionId: string) => void) | null>(null)
+    const stopPollingRef = useRef<(() => void) | null>(null)
+
+    const stream = useStreamEvents({
+      sessionState,
+      setSessionState,
+      setMessages,
+      setUIState,
+      uiState,
+      currentToolExecutionsRef,
+      currentTurnIdRef,
+      startPollingRef,
+      stopPollingRef,
+      sessionId: 'session-1',
+    })
+
+    return {
+      ...stream,
+      messages,
+      sessionState,
+      uiState,
+      currentToolExecutionsRef,
+    }
+  })
+}
+
+describe('useStreamEvents tool input streaming', () => {
+  it('renders the tool at start and fills its input as deltas arrive', () => {
+    const hook = setup()
+
+    act(() => {
+      hook.result.current.handleStreamEvent({
+        type: 'TOOL_CALL_START',
+        toolCallId: 'tool-1',
+        toolCallName: 'skill_executor',
+      } as any)
+    })
+
+    expect(hook.result.current.messages[0].toolExecutions?.[0]).toMatchObject({
+      id: 'tool-1',
+      toolName: 'skill_executor',
+      toolInputRaw: '',
+      toolInputState: 'streaming',
+    })
+
+    act(() => {
+      hook.result.current.handleStreamEvent({
+        type: 'TOOL_CALL_ARGS',
+        toolCallId: 'tool-1',
+        delta: '{"query":',
+      } as any)
+    })
+
+    expect(hook.result.current.messages[0].toolExecutions?.[0]).toMatchObject({
+      toolInputRaw: '{"query":',
+      toolInputState: 'streaming',
+    })
+
+    act(() => {
+      hook.result.current.handleStreamEvent({
+        type: 'CUSTOM',
+        name: 'tool_call_name_update',
+        value: {
+          toolCallId: 'tool-1',
+          toolCallName: 'tavily_search',
+        },
+      } as any)
+      hook.result.current.handleStreamEvent({
+        type: 'TOOL_CALL_ARGS',
+        toolCallId: 'tool-1',
+        delta: '"mailbox"}',
+      } as any)
+      hook.result.current.handleStreamEvent({
+        type: 'TOOL_CALL_END',
+        toolCallId: 'tool-1',
+      } as any)
+    })
+
+    expect(hook.result.current.messages[0].toolExecutions?.[0]).toMatchObject({
+      toolName: 'tavily_search',
+      toolInput: { query: 'mailbox' },
+      toolInputRaw: '{"query":"mailbox"}',
+      toolInputState: 'complete',
+    })
+    expect(hook.result.current.currentToolExecutionsRef.current[0]).toMatchObject({
+      toolName: 'tavily_search',
+      toolInput: { query: 'mailbox' },
+      toolInputState: 'complete',
+    })
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/base64.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/base64.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { arrayBufferToBase64 } from '@/lib/base64'
+
+describe('arrayBufferToBase64', () => {
+  it('encodes binary data across chunk boundaries', () => {
+    const bytes = new Uint8Array(70_000)
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = index % 256
+    }
+
+    expect(arrayBufferToBase64(bytes.buffer)).toBe(
+      Buffer.from(bytes).toString('base64'),
+    )
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/turn-control.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/turn-control.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveTurnControl } from '@/lib/turn-control'
+import type { AgentStatus } from '@/types/events'
+
+const base = {
+  agentStatus: 'idle' as AgentStatus,
+  isForegroundRunActive: false,
+  isCompacting: false,
+  interruptCount: 0,
+  hasPendingOAuth: false,
+}
+
+describe('deriveTurnControl', () => {
+  it.each<AgentStatus>([
+    'thinking',
+    'responding',
+    'researching',
+    'swarm',
+  ])('makes %s activity interruptible without a foreground flag', agentStatus => {
+    expect(deriveTurnControl({ ...base, agentStatus })).toEqual({
+      isBusy: true,
+      isBlocked: false,
+      canInterrupt: true,
+    })
+  })
+
+  it('treats an empty interrupt envelope as non-blocking', () => {
+    expect(deriveTurnControl({
+      ...base,
+      agentStatus: 'responding',
+      interruptCount: 0,
+    }).canInterrupt).toBe(true)
+  })
+
+  it.each([
+    { interruptCount: 1, hasPendingOAuth: false },
+    { interruptCount: 0, hasPendingOAuth: true },
+  ])('blocks actions for a real approval or OAuth wait', blocked => {
+    expect(deriveTurnControl({
+      ...base,
+      agentStatus: 'responding',
+      ...blocked,
+    })).toEqual({
+      isBusy: true,
+      isBlocked: true,
+      canInterrupt: false,
+    })
+  })
+
+  it.each<AgentStatus>(['stopping', 'compacting'])(
+    'keeps %s busy without offering another interrupt',
+    agentStatus => {
+      expect(deriveTurnControl({ ...base, agentStatus })).toEqual({
+        isBusy: true,
+        isBlocked: false,
+        canInterrupt: false,
+      })
+    },
+  )
+})

--- a/chatbot-app/frontend/__tests__/lib/turn-control.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/turn-control.test.ts
@@ -6,6 +6,7 @@ import type { AgentStatus } from '@/types/events'
 const base = {
   agentStatus: 'idle' as AgentStatus,
   isForegroundRunActive: false,
+  hasStoppableRun: false,
   isCompacting: false,
   interruptCount: 0,
   hasPendingOAuth: false,
@@ -17,8 +18,12 @@ describe('deriveTurnControl', () => {
     'responding',
     'researching',
     'swarm',
-  ])('makes %s activity interruptible without a foreground flag', agentStatus => {
-    expect(deriveTurnControl({ ...base, agentStatus })).toEqual({
+  ])('makes %s activity interruptible when an active run can be stopped', agentStatus => {
+    expect(deriveTurnControl({
+      ...base,
+      agentStatus,
+      hasStoppableRun: true,
+    })).toEqual({
       isBusy: true,
       isBlocked: false,
       canInterrupt: true,
@@ -29,6 +34,7 @@ describe('deriveTurnControl', () => {
     expect(deriveTurnControl({
       ...base,
       agentStatus: 'responding',
+      hasStoppableRun: true,
       interruptCount: 0,
     }).canInterrupt).toBe(true)
   })
@@ -40,6 +46,7 @@ describe('deriveTurnControl', () => {
     expect(deriveTurnControl({
       ...base,
       agentStatus: 'responding',
+      hasStoppableRun: true,
       ...blocked,
     })).toEqual({
       isBusy: true,
@@ -58,4 +65,16 @@ describe('deriveTurnControl', () => {
       })
     },
   )
+
+  it('keeps replay-only activity busy without offering a no-op interrupt', () => {
+    expect(deriveTurnControl({
+      ...base,
+      agentStatus: 'thinking',
+      hasStoppableRun: false,
+    })).toEqual({
+      isBusy: true,
+      isBlocked: false,
+      canInterrupt: false,
+    })
+  })
 })

--- a/chatbot-app/frontend/src/app/api/conversation/history/route.ts
+++ b/chatbot-app/frontend/src/app/api/conversation/history/route.ts
@@ -150,7 +150,14 @@ export async function GET(request: NextRequest) {
         console.log(`[API] Retrieved ${pageEvents.length} events (total: ${allEvents.length})${nextToken ? ', fetching more...' : ''}`)
       } while (nextToken)
 
-      const events = allEvents
+      const { getSessionConversationEpoch } = await import('@/lib/session-events')
+      const conversationEpoch = await getSessionConversationEpoch(userId, sessionId)
+      const events = allEvents.filter(event => {
+        const rawEpoch = eventMetadataString(event, 'conversationEpoch')
+        if (rawEpoch === undefined) return true
+        const eventEpoch = Number(rawEpoch)
+        return Number.isFinite(eventEpoch) && eventEpoch >= conversationEpoch
+      })
       console.log(`[API] Retrieved ${events.length} total events from AgentCore Memory`)
 
       // Convert AgentCore Memory events to chat messages

--- a/chatbot-app/frontend/src/app/api/research/jobs/route.ts
+++ b/chatbot-app/frontend/src/app/api/research/jobs/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { extractUserFromRequest } from '@/lib/auth-utils'
-import { listResearchJobs } from '@/lib/research-jobs'
+import {
+  getResearchJob,
+  getResearchJobs,
+  listResearchJobs,
+} from '@/lib/research-jobs'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -14,6 +18,35 @@ export async function GET(request: NextRequest) {
 
     const user = await extractUserFromRequest(request)
     const includeContent = request.nextUrl.searchParams.get('include_content') === 'true'
+    const jobId = request.nextUrl.searchParams.get('job_id')
+    const jobIds = request.nextUrl.searchParams.get('job_ids')
+    if (jobId) {
+      const job = await getResearchJob(user.userId, sessionId, jobId, {
+        includeContent,
+      })
+      if (!job) {
+        return NextResponse.json({ error: 'Research job not found' }, { status: 404 })
+      }
+      return NextResponse.json({ job })
+    }
+    if (jobIds) {
+      const requestedIds = Array.from(new Set(
+        jobIds.split(',').map(value => value.trim()).filter(Boolean),
+      ))
+      if (requestedIds.length > 100) {
+        return NextResponse.json(
+          { error: 'At most 100 job_ids may be requested' },
+          { status: 400 },
+        )
+      }
+      const jobs = await getResearchJobs(
+        user.userId,
+        sessionId,
+        requestedIds,
+        { includeContent },
+      )
+      return NextResponse.json({ jobs })
+    }
     const jobs = await listResearchJobs(user.userId, sessionId, { includeContent })
     return NextResponse.json({ jobs })
   } catch (error) {

--- a/chatbot-app/frontend/src/app/api/session/events/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/events/route.ts
@@ -16,8 +16,17 @@ export async function GET(request: NextRequest) {
     }
 
     const user = await extractUserFromRequest(request)
-    const events = await listSessionEvents(user.userId, sessionId)
-    return NextResponse.json({ events })
+    const cursor = request.nextUrl.searchParams.get('cursor') || undefined
+    const rawEpoch = request.nextUrl.searchParams.get('epoch')
+    const knownEpoch =
+      rawEpoch !== null && Number.isFinite(Number(rawEpoch))
+        ? Number(rawEpoch)
+        : undefined
+    const page = await listSessionEvents(user.userId, sessionId, {
+      cursor,
+      knownEpoch,
+    })
+    return NextResponse.json(page)
   } catch (error) {
     console.error('[SessionEvents] Failed to list events:', error)
     return NextResponse.json(

--- a/chatbot-app/frontend/src/app/api/session/truncate/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/truncate/route.ts
@@ -45,7 +45,6 @@ export async function POST(request: NextRequest) {
       sessionId,
       fromEventId,
       fromTimestamp,
-      originEventId,
     } = await request.json()
     if (!sessionId) {
       return NextResponse.json({ success: false, error: 'sessionId is required' }, { status: 400 })
@@ -61,18 +60,28 @@ export async function POST(request: NextRequest) {
 
     if (userId === 'anonymous' || IS_LOCAL) {
       if (typeof fromTimestamp === 'number') {
-        const { truncateSessionMessages } = await import('@/lib/local-session-store')
-        const deleted = truncateSessionMessages(userId, sessionId, fromTimestamp)
-        if (originEventId) {
-          const { deleteSessionEventProjection } = await import('@/lib/session-events')
-          await deleteSessionEventProjection(
-            userId,
-            sessionId,
-            `${originEventId}:assistant`,
+        if (!Number.isFinite(fromTimestamp)) {
+          return NextResponse.json(
+            { success: false, error: 'fromTimestamp must be finite' },
+            { status: 400 },
           )
         }
+        const { advanceSessionConversationEpoch } =
+          await import('@/lib/session-lifecycle')
+        const conversationEpoch = await advanceSessionConversationEpoch(
+          userId,
+          sessionId,
+          new Date(fromTimestamp).toISOString(),
+        )
+        const { truncateSessionMessages } = await import('@/lib/local-session-store')
+        const deleted = truncateSessionMessages(userId, sessionId, fromTimestamp)
         console.log(`[truncate] LOCAL - Deleted ${deleted} messages`)
-        return NextResponse.json({ success: true, sessionId, deleted })
+        return NextResponse.json({
+          success: true,
+          sessionId,
+          deleted,
+          conversationEpoch,
+        })
       }
       // Local mode has no eventId concept — nothing to do
       return NextResponse.json({ success: true, sessionId, deleted: 0 })
@@ -110,20 +119,39 @@ export async function POST(request: NextRequest) {
     console.log(`[truncate] Listed ${chronologicalEvents.length} events total`)
 
     let toDelete: { eventId: string; actorId: string }[] = []
+    let cutoffMs: number
 
     if (fromEventId) {
       // Positional approach: find the event and delete it + everything after
       const fromIndex = chronologicalEvents.findIndex((e: any) => e.eventId === fromEventId)
       if (fromIndex >= 0) {
+        const cutoffEventTime = chronologicalEvents[fromIndex]?.eventTime
+        cutoffMs = cutoffEventTime ? new Date(cutoffEventTime).getTime() : NaN
+        if (!Number.isFinite(cutoffMs)) {
+          return NextResponse.json(
+            { success: false, error: 'Target event has no usable eventTime' },
+            { status: 409 },
+          )
+        }
         toDelete = chronologicalEvents
           .slice(fromIndex)
           .filter((e: any) => e.eventId)
           .map((e: any) => ({ eventId: e.eventId, actorId: userId }))
         console.log(`[truncate] fromEventId found at index ${fromIndex}, deleting ${toDelete.length} events`)
       } else {
-        console.warn(`[truncate] fromEventId ${fromEventId} not found in ${chronologicalEvents.length} events`)
+        return NextResponse.json(
+          { success: false, error: `Event ${fromEventId} was not found` },
+          { status: 404 },
+        )
       }
     } else {
+      cutoffMs = fromTimestamp
+      if (!Number.isFinite(cutoffMs)) {
+        return NextResponse.json(
+          { success: false, error: 'fromTimestamp must be finite' },
+          { status: 400 },
+        )
+      }
       // Timestamp fallback: delete events with eventTime >= fromTimestamp
       for (const event of chronologicalEvents) {
         if (!event.eventId) continue
@@ -134,6 +162,14 @@ export async function POST(request: NextRequest) {
       }
       console.log(`[truncate] Timestamp approach: ${toDelete.length} events >= ${fromTimestamp}`)
     }
+
+    const { advanceSessionConversationEpoch } =
+      await import('@/lib/session-lifecycle')
+    const conversationEpoch = await advanceSessionConversationEpoch(
+      userId,
+      sessionId,
+      new Date(cutoffMs).toISOString(),
+    )
 
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -167,17 +203,13 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    if (originEventId) {
-      const { deleteSessionEventProjection } = await import('@/lib/session-events')
-      await deleteSessionEventProjection(
-        userId,
-        sessionId,
-        `${originEventId}:assistant`,
-      )
-    }
-
     console.log(`[truncate] Deleted ${toDelete.length} events from session ${sessionId}`)
-    return NextResponse.json({ success: true, sessionId, deleted: toDelete.length })
+    return NextResponse.json({
+      success: true,
+      sessionId,
+      deleted: toDelete.length,
+      conversationEpoch,
+    })
   } catch (error) {
     console.error('[truncate] Error:', error)
     return NextResponse.json(

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -243,14 +243,16 @@ export function ChatInterface() {
   }, [groupedMessages])
   const {
     jobs: researchJobs,
-    isActive: hasPendingSessionDelivery,
+    hasPendingDelivery,
+    deliveryVersion,
   } = useResearchJobs(
     sessionId,
     researchInvocationCount,
   )
   const { events: sessionEvents } = useSessionEvents(
     sessionId,
-    hasPendingSessionDelivery,
+    hasPendingDelivery,
+    deliveryVersion,
   )
   const representedOriginEventIds = useMemo(() => {
     const ids = new Set<string>()
@@ -1002,12 +1004,17 @@ export function ChatInterface() {
             !isCompacting &&
             !currentInterrupt &&
             !pendingOAuth &&
-            isForegroundRunActive
+            (
+              isForegroundRunActive ||
+              agentStatus === 'thinking' ||
+              agentStatus === 'responding' ||
+              agentStatus === 'researching' ||
+              agentStatus === 'swarm'
+            )
               ? 'interrupt'
               : !isCompacting &&
                   !currentInterrupt &&
                   !pendingOAuth &&
-                  !isForegroundRunActive &&
                   agentStatus === 'idle'
                 ? 'send'
                 : null

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -152,7 +152,7 @@ export function ChatInterface() {
     isConnected,
     isTyping,
     agentStatus,
-    isForegroundRunActive,
+    turnControl,
     currentReasoning,
     sendMessage,
     replayExecution,
@@ -1001,21 +1001,9 @@ export function ChatInterface() {
           onSendNow={releaseQueue}
           onDiscardAll={clearQueuedMessages}
           actionMode={
-            !isCompacting &&
-            !currentInterrupt &&
-            !pendingOAuth &&
-            (
-              isForegroundRunActive ||
-              agentStatus === 'thinking' ||
-              agentStatus === 'responding' ||
-              agentStatus === 'researching' ||
-              agentStatus === 'swarm'
-            )
+            turnControl.canInterrupt
               ? 'interrupt'
-              : !isCompacting &&
-                  !currentInterrupt &&
-                  !pendingOAuth &&
-                  agentStatus === 'idle'
+              : !turnControl.isBusy
                 ? 'send'
                 : null
           }
@@ -1028,6 +1016,7 @@ export function ChatInterface() {
           selectedFiles={selectedFiles}
           setSelectedFiles={setSelectedFiles}
           agentStatus={isCompacting ? 'compacting' : agentStatus}
+          isBusy={turnControl.isBusy}
           isVoiceActive={isVoiceActive}
           isVoiceSupported={isVoiceSupported}
           isCanvasOpen={isCanvasOpen}

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -162,6 +162,7 @@ export function ChatInterface() {
     removeQueuedMessage,
     clearQueuedMessages,
     releaseQueue,
+    interruptWithQueuedMessage,
     newChat,
     compactSession,
     truncateFromMessage,
@@ -989,6 +990,18 @@ export function ChatInterface() {
           onRemove={removeQueuedMessage}
           onSendNow={releaseQueue}
           onDiscardAll={clearQueuedMessages}
+          canInterrupt={
+            !isCompacting &&
+            !currentInterrupt &&
+            !pendingOAuth &&
+            (
+              agentStatus === 'thinking' ||
+              agentStatus === 'responding' ||
+              agentStatus === 'researching' ||
+              agentStatus === 'swarm'
+            )
+          }
+          onInterrupt={interruptWithQueuedMessage}
         />
 
         {/* Chat Input Area */}

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -243,7 +243,15 @@ export function ChatInterface() {
     sessionId,
     researchInvocationCount,
   )
-  const { events: sessionEvents } = useSessionEvents(sessionId)
+  const hasPendingSessionDelivery =
+    researchInvocationCount > researchJobs.length ||
+    researchJobs.some(job =>
+      ['queued', 'running', 'completed', 'delivering'].includes(job.status)
+    )
+  const { events: sessionEvents } = useSessionEvents(
+    sessionId,
+    hasPendingSessionDelivery,
+  )
   const representedOriginEventIds = useMemo(() => {
     const ids = new Set<string>()
     for (const group of groupedMessages) {

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -163,6 +163,7 @@ export function ChatInterface() {
     clearQueuedMessages,
     releaseQueue,
     interruptWithQueuedMessage,
+    sendQueuedMessageNow,
     newChat,
     compactSession,
     truncateFromMessage,
@@ -998,7 +999,7 @@ export function ChatInterface() {
           onRemove={removeQueuedMessage}
           onSendNow={releaseQueue}
           onDiscardAll={clearQueuedMessages}
-          canInterrupt={
+          actionMode={
             !isCompacting &&
             !currentInterrupt &&
             !pendingOAuth &&
@@ -1008,8 +1009,16 @@ export function ChatInterface() {
               agentStatus === 'researching' ||
               agentStatus === 'swarm'
             )
+              ? 'interrupt'
+              : !isCompacting &&
+                  !currentInterrupt &&
+                  !pendingOAuth &&
+                  agentStatus === 'idle'
+                ? 'send'
+                : null
           }
           onInterrupt={interruptWithQueuedMessage}
+          onSendMessageNow={sendQueuedMessageNow}
         />
 
         {/* Chat Input Area */}

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -168,6 +168,7 @@ export function ChatInterface() {
     newChat,
     compactSession,
     truncateFromMessage,
+    sessionEventRefreshVersion,
     sessionId,
     isLoadingMessages,
     isCompacting,
@@ -253,6 +254,7 @@ export function ChatInterface() {
     sessionId,
     hasPendingDelivery,
     deliveryVersion,
+    sessionEventRefreshVersion,
   )
   const representedOriginEventIds = useMemo(() => {
     const ids = new Set<string>()

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -240,15 +240,13 @@ export function ChatInterface() {
     }
     return invocationIds.size
   }, [groupedMessages])
-  const { jobs: researchJobs } = useResearchJobs(
+  const {
+    jobs: researchJobs,
+    isActive: hasPendingSessionDelivery,
+  } = useResearchJobs(
     sessionId,
     researchInvocationCount,
   )
-  const hasPendingSessionDelivery =
-    researchInvocationCount > researchJobs.length ||
-    researchJobs.some(job =>
-      ['queued', 'running', 'completed', 'delivering'].includes(job.status)
-    )
   const { events: sessionEvents } = useSessionEvents(
     sessionId,
     hasPendingSessionDelivery,

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -152,6 +152,7 @@ export function ChatInterface() {
     isConnected,
     isTyping,
     agentStatus,
+    isForegroundRunActive,
     currentReasoning,
     sendMessage,
     replayExecution,
@@ -1001,16 +1002,12 @@ export function ChatInterface() {
             !isCompacting &&
             !currentInterrupt &&
             !pendingOAuth &&
-            (
-              agentStatus === 'thinking' ||
-              agentStatus === 'responding' ||
-              agentStatus === 'researching' ||
-              agentStatus === 'swarm'
-            )
+            isForegroundRunActive
               ? 'interrupt'
               : !isCompacting &&
                   !currentInterrupt &&
                   !pendingOAuth &&
+                  !isForegroundRunActive &&
                   agentStatus === 'idle'
                 ? 'send'
                 : null

--- a/chatbot-app/frontend/src/components/chat/ChatInputArea.tsx
+++ b/chatbot-app/frontend/src/components/chat/ChatInputArea.tsx
@@ -44,13 +44,12 @@ interface ChatInputAreaProps {
   onPrefillConsumed?: () => void
 }
 
-function useDebounce<T extends (...args: any[]) => any>(callback: T, delay: number): T {
-  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
-  return useCallback((...args: Parameters<T>) => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => callback(...args), delay)
-  }, [callback, delay]) as T
-}
+export const LARGE_PASTE_ATTACHMENT_THRESHOLD = 20_000
+export const MAX_PASTED_TEXT_BYTES = 1_000_000
+
+const MAX_AUTO_RESIZE_CHARS = 4_000
+const TEXTAREA_MAX_HEIGHT_PX = 128
+const MAX_SLASH_COMMAND_LENGTH = 64
 
 export function ChatInputArea({
   selectedFiles,
@@ -77,6 +76,7 @@ export function ChatInputArea({
   onPrefillConsumed,
 }: ChatInputAreaProps) {
   const [inputMessage, setInputMessage] = useState('')
+  const [inputError, setInputError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const isComposingRef = useRef(false)
 
@@ -86,7 +86,10 @@ export function ChatInputArea({
 
   // Slash command autocomplete
   useEffect(() => {
-    const trimmed = inputMessage.trim()
+    const isShortSingleLine =
+      inputMessage.length <= MAX_SLASH_COMMAND_LENGTH &&
+      !inputMessage.includes('\n')
+    const trimmed = isShortSingleLine ? inputMessage.trim() : ''
     if (trimmed.startsWith('/')) {
       const filtered = filterCommands(trimmed)
       setSlashCommands(filtered)
@@ -95,13 +98,16 @@ export function ChatInputArea({
         setInputRect(textareaRef.current.getBoundingClientRect())
       }
     } else {
-      setSlashCommands([])
+      setSlashCommands(current => current.length === 0 ? current : [])
     }
   }, [inputMessage])
 
+  const closeSlashCommands = useCallback(() => {
+    setSlashCommands(current => current.length === 0 ? current : [])
+  }, [])
 
   const handleSlashCommand = useCallback((command: SlashCommand) => {
-    setSlashCommands([])
+    closeSlashCommands()
     setInputMessage('')
 
     switch (command.name) {
@@ -115,17 +121,17 @@ export function ChatInputArea({
         onCompact()
         break
     }
-  }, [onExportConversation, onNewChat, onCompact, setInputMessage])
+  }, [closeSlashCommands, onExportConversation, onNewChat, onCompact])
 
   // Single submit path shared by Enter, the form, and the send button.
   // While the agent is busy the composer stays open and the turn is queued
   // instead of sent; the parent decides when it is safe to dispatch it.
-  const hasContent = inputMessage.trim().length > 0 || selectedFiles.length > 0
+  const hasContent = /\S/.test(inputMessage) || selectedFiles.length > 0
 
   const submit = useCallback(() => {
     if (!hasContent || isVoiceActive) return
     // Slash commands are handled in handleKeyDown.
-    if (inputMessage.trim().startsWith('/')) return
+    if (/^\s*\//.test(inputMessage)) return
 
     if (isBusy) {
       onEnqueueMessage(inputMessage, selectedFiles)
@@ -141,6 +147,7 @@ export function ChatInputArea({
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files || [])
+    setInputError(null)
     setSelectedFiles(prev => [...prev, ...files])
     event.target.value = ""
   }
@@ -169,7 +176,7 @@ export function ChatInputArea({
       }
       if (e.key === "Escape") {
         e.preventDefault()
-        setSlashCommands([])
+        closeSlashCommands()
         return
       }
     }
@@ -206,25 +213,45 @@ export function ChatInputArea({
 
     if (imageFiles.length > 0) {
       e.preventDefault()
+      setInputError(null)
       setSelectedFiles(prev => [...prev, ...imageFiles])
+      return
+    }
+
+    const pastedText = e.clipboardData.getData('text/plain')
+    if (pastedText.length >= LARGE_PASTE_ATTACHMENT_THRESHOLD) {
+      e.preventDefault()
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+      const pastedFile = new File(
+        [pastedText],
+        `pasted-text-${timestamp}.txt`,
+        { type: 'text/plain' },
+      )
+      if (pastedFile.size > MAX_PASTED_TEXT_BYTES) {
+        setInputError('Pasted text exceeds the 1 MB limit. Split it into smaller sections.')
+        return
+      }
+      setInputError(null)
+      setSelectedFiles(prev => [...prev, pastedFile])
     }
   }
 
-  const adjustTextareaHeightImmediate = useCallback(() => {
+  useEffect(() => {
     const textarea = textareaRef.current
-    if (textarea) {
+    if (!textarea) return
+
+    if (inputMessage.length > MAX_AUTO_RESIZE_CHARS) {
+      textarea.style.height = `${TEXTAREA_MAX_HEIGHT_PX}px`
+      return
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
       textarea.style.height = "auto"
       const scrollHeight = textarea.scrollHeight
-      const maxHeight = 128
-      textarea.style.height = `${Math.min(scrollHeight, maxHeight)}px`
-    }
-  }, [])
-
-  const adjustTextareaHeight = useDebounce(adjustTextareaHeightImmediate, 100)
-
-  useEffect(() => {
-    adjustTextareaHeight()
-  }, [inputMessage, adjustTextareaHeight])
+      textarea.style.height = `${Math.min(scrollHeight, TEXTAREA_MAX_HEIGHT_PX)}px`
+    })
+    return () => window.cancelAnimationFrame(frameId)
+  }, [inputMessage])
 
   useEffect(() => {
     if (prefillMessage) {
@@ -276,7 +303,10 @@ export function ChatInputArea({
               <Textarea
                 ref={textareaRef}
                 value={inputMessage}
-                onChange={(e) => setInputMessage(e.target.value)}
+                onChange={(e) => {
+                  setInputError(null)
+                  setInputMessage(e.target.value)
+                }}
                 onKeyDown={handleKeyDown}
                 onPaste={handlePaste}
                 onCompositionStart={() => { isComposingRef.current = true }}
@@ -288,7 +318,7 @@ export function ChatInputArea({
                     ? "Send a follow-up — it'll go next"
                     : "Ask me anything..."
                 }
-                className="flex-1 min-h-[52px] max-h-36 border-0 focus:ring-0 focus:ring-offset-0 ring-0 ring-offset-0 resize-none py-2 px-1 leading-relaxed overflow-y-auto bg-transparent transition-all duration-200 placeholder:text-muted-foreground/60 shadow-none"
+                className="flex-1 min-h-[52px] max-h-36 border-0 focus:ring-0 focus:ring-offset-0 ring-0 ring-offset-0 resize-none py-2 px-1 leading-relaxed overflow-y-auto bg-transparent transition-colors duration-200 placeholder:text-muted-foreground/60 shadow-none"
                 // Stays enabled while the agent runs so follow-ups can be queued.
                 // Voice mode still owns the composer exclusively.
                 disabled={isVoiceActive}
@@ -377,6 +407,11 @@ export function ChatInputArea({
                 )}
               </div>
             </div>
+            {inputError && (
+              <p role="alert" className="mt-2 text-caption text-destructive">
+                {inputError}
+              </p>
+            )}
           </form>
 
           {/* Bottom Options Bar */}
@@ -438,13 +473,15 @@ export function ChatInputArea({
       </div>
 
       {/* Slash Command Autocomplete */}
-      <SlashCommandPopover
-        commands={slashCommands}
-        selectedIndex={selectedCommandIndex}
-        onSelect={handleSlashCommand}
-        onClose={() => setSlashCommands([])}
-        anchorRect={inputRect}
-      />
+      {slashCommands.length > 0 && inputRect && (
+        <SlashCommandPopover
+          commands={slashCommands}
+          selectedIndex={selectedCommandIndex}
+          onSelect={handleSlashCommand}
+          onClose={closeSlashCommands}
+          anchorRect={inputRect}
+        />
+      )}
     </>
   )
 }

--- a/chatbot-app/frontend/src/components/chat/ChatInputArea.tsx
+++ b/chatbot-app/frontend/src/components/chat/ChatInputArea.tsx
@@ -18,6 +18,7 @@ interface ChatInputAreaProps {
   selectedFiles: File[]
   setSelectedFiles: React.Dispatch<React.SetStateAction<File[]>>
   agentStatus: AgentStatus
+  isBusy: boolean
   isVoiceActive: boolean
   isVoiceSupported: boolean
   isCanvasOpen: boolean
@@ -55,6 +56,7 @@ export function ChatInputArea({
   selectedFiles,
   setSelectedFiles,
   agentStatus,
+  isBusy,
   isVoiceActive,
   isVoiceSupported,
   isCanvasOpen,
@@ -118,7 +120,6 @@ export function ChatInputArea({
   // Single submit path shared by Enter, the form, and the send button.
   // While the agent is busy the composer stays open and the turn is queued
   // instead of sent; the parent decides when it is safe to dispatch it.
-  const isBusy = agentStatus !== 'idle'
   const hasContent = inputMessage.trim().length > 0 || selectedFiles.length > 0
 
   const submit = useCallback(() => {

--- a/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
+++ b/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
@@ -11,8 +11,9 @@
 
 import React from "react"
 import { motion } from "framer-motion"
-import { Clock3, X } from "lucide-react"
+import { Clock3, SendHorizontal, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import type { QueuedMessage, QueueHoldReason } from "@/hooks/useMessageQueue"
 
 const HOLD_MESSAGE: Record<QueueHoldReason, string> = {
@@ -28,6 +29,8 @@ interface QueuedMessagesProps {
   onRemove: (id: string) => void
   onSendNow: () => void
   onDiscardAll: () => void
+  canInterrupt: boolean
+  onInterrupt: (id: string) => Promise<boolean>
 }
 
 export function QueuedMessages({
@@ -36,6 +39,8 @@ export function QueuedMessages({
   onRemove,
   onSendNow,
   onDiscardAll,
+  canInterrupt,
+  onInterrupt,
 }: QueuedMessagesProps) {
   if (queue.length === 0) return null
 
@@ -66,40 +71,60 @@ export function QueuedMessages({
         </div>
       )}
 
-      <div className="flex flex-col gap-1.5">
-        {queue.map(message => (
-          <motion.div
-            key={message.id}
-            layout
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 4 }}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/60 bg-muted/50 text-sm"
-          >
-            <Clock3 className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="flex-1 truncate text-foreground/80">
-              {message.text || `${message.files.length} attachment(s)`}
-            </span>
-            {message.files.length > 0 && message.text && (
-              <span className="shrink-0 text-xs text-muted-foreground">
-                +{message.files.length}
-              </span>
-            )}
-            {/* Always visible: a hover-only control is unreachable on touch and
-                reads as "no way to cancel this" everywhere else. Matches the
-                attachment chips, which also keep their remove button on show. */}
-            <button
-              type="button"
-              onClick={() => onRemove(message.id)}
-              aria-label={`Remove queued message: ${message.text || 'attachments'}`}
-              title="Remove from queue"
-              className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
-          </motion.div>
-        ))}
-      </div>
+      <TooltipProvider delayDuration={300}>
+        <div className="flex flex-col gap-1.5">
+          {queue.map(message => {
+            const label = message.text || "attachments"
+            return (
+              <motion.div
+                key={message.id}
+                layout
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 4 }}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/60 bg-muted/50 text-sm"
+              >
+                <Clock3 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate text-foreground/80">
+                  {message.text || `${message.files.length} attachment(s)`}
+                </span>
+                {message.files.length > 0 && message.text && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    +{message.files.length}
+                  </span>
+                )}
+                {canInterrupt && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => void onInterrupt(message.id)}
+                        aria-label={`Interrupt with this message: ${label}`}
+                        className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                      >
+                        <SendHorizontal className="h-3.5 w-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">Interrupt with this message</TooltipContent>
+                  </Tooltip>
+                )}
+                {/* Always visible: a hover-only control is unreachable on touch and
+                    reads as "no way to cancel this" everywhere else. Matches the
+                    attachment chips, which also keep their remove button on show. */}
+                <button
+                  type="button"
+                  onClick={() => onRemove(message.id)}
+                  aria-label={`Remove queued message: ${label}`}
+                  title="Remove from queue"
+                  className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </motion.div>
+            )
+          })}
+        </div>
+      </TooltipProvider>
     </div>
   )
 }

--- a/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
+++ b/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
@@ -11,8 +11,14 @@
 
 import React from "react"
 import { motion } from "framer-motion"
-import { Clock3, SendHorizontal, X } from "lucide-react"
+import { Clock3, Send, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { QueuedMessage, QueueHoldReason } from "@/hooks/useMessageQueue"
 
 const HOLD_MESSAGE: Record<QueueHoldReason, string> = {
@@ -46,92 +52,113 @@ export function QueuedMessages({
   if (queue.length === 0) return null
 
   return (
-    <div className="mx-auto px-4 w-full md:max-w-4xl mb-2">
-      {holdReason && (
-        <div className="flex items-center justify-between gap-3 mb-2 px-3 py-2 rounded-lg border border-amber-500/40 bg-amber-500/5 text-sm">
-          <span className="text-muted-foreground">
-            {HOLD_MESSAGE[holdReason]}{" "}
-            {queue.length === 1 ? "1 message is" : `${queue.length} messages are`} still queued.
-          </span>
-          <div className="flex items-center gap-1 shrink-0">
-            <Button type="button" variant="ghost" size="sm" className="h-7 px-2" onClick={onSendNow}>
-              Send
-            </Button>
-            {/* Says how many it drops: "Discard" next to a list of chips does
-                not make clear whether it clears one or all of them. */}
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-muted-foreground"
-              onClick={onDiscardAll}
-            >
-              {queue.length === 1 ? "Discard" : `Discard all ${queue.length}`}
-            </Button>
-          </div>
-        </div>
-      )}
-
-      <div className="flex flex-col gap-1.5">
-        {queue.map(message => {
-          const label = message.text || "attachments"
-          return (
-            <motion.div
-              key={message.id}
-              layout
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 4 }}
-              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/60 bg-muted/50 text-sm"
-            >
-              <Clock3 className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 flex-1 truncate text-foreground/80">
-                {message.text || `${message.files.length} attachment(s)`}
-              </span>
-              {message.files.length > 0 && message.text && (
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  +{message.files.length}
-                </span>
-              )}
-              {actionMode && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    void (
-                      actionMode === "interrupt"
-                        ? onInterrupt(message.id)
-                        : onSendMessageNow(message.id)
-                    )
-                  }}
-                  aria-label={
-                    actionMode === "interrupt"
-                      ? `Interrupt with this message: ${label}`
-                      : `Send this message now: ${label}`
-                  }
-                  className="h-7 shrink-0 gap-1 rounded-md border border-border/60 bg-background px-2 text-xs font-normal text-muted-foreground hover:border-primary/40 hover:text-foreground"
-                >
-                  <SendHorizontal className="h-3.5 w-3.5" />
-                  {actionMode === "interrupt" ? "Interrupt" : "Send now"}
-                </Button>
-              )}
-              {/* Always visible: a hover-only control is unreachable on touch and
-                  reads as "no way to cancel this" everywhere else. Matches the
-                  attachment chips, which also keep their remove button on show. */}
-              <button
+    <TooltipProvider delayDuration={300}>
+      <div className="mx-auto px-4 w-full md:max-w-4xl mb-2">
+        {holdReason && (
+          <div className="flex items-center justify-between gap-3 mb-2 px-3 py-2 rounded-lg border border-amber-500/40 bg-amber-500/5 text-sm">
+            <span className="text-muted-foreground">
+              {HOLD_MESSAGE[holdReason]}{" "}
+              {queue.length === 1
+                ? "1 message is"
+                : `${queue.length} messages are`}{" "}
+              still queued.
+            </span>
+            <div className="flex items-center gap-1 shrink-0">
+              <Button
                 type="button"
-                onClick={() => onRemove(message.id)}
-                aria-label={`Remove queued message: ${label}`}
-                title="Remove from queue"
-                className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2"
+                onClick={onSendNow}
               >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            </motion.div>
-          )
-        })}
+                Send
+              </Button>
+              {/* Says how many it drops: "Discard" next to a list of chips does
+                  not make clear whether it clears one or all of them. */}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-muted-foreground"
+                onClick={onDiscardAll}
+              >
+                {queue.length === 1
+                  ? "Discard"
+                  : `Discard all ${queue.length}`}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1.5">
+          {queue.map(message => {
+            const label = message.text || "attachments"
+            return (
+              <motion.div
+                key={message.id}
+                layout
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 4 }}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/60 bg-muted/50 text-sm"
+              >
+                <Clock3 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate text-foreground/80">
+                  {message.text || `${message.files.length} attachment(s)`}
+                </span>
+                {message.files.length > 0 && message.text && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    +{message.files.length}
+                  </span>
+                )}
+                {actionMode && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => {
+                          void (
+                            actionMode === "interrupt"
+                              ? onInterrupt(message.id)
+                              : onSendMessageNow(message.id)
+                          )
+                        }}
+                        aria-label={
+                          actionMode === "interrupt"
+                            ? "Interrupt and send now"
+                            : "Send now"
+                        }
+                        className="h-7 w-7 shrink-0 rounded-md border border-border/60 bg-background text-muted-foreground hover:border-primary/40 hover:text-foreground"
+                      >
+                        <Send className="h-3.5 w-3.5" aria-hidden="true" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {actionMode === "interrupt"
+                        ? "Interrupt and send now"
+                        : "Send now"}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                {/* Always visible: a hover-only control is unreachable on touch and
+                    reads as "no way to cancel this" everywhere else. Matches the
+                    attachment chips, which also keep their remove button on show. */}
+                <button
+                  type="button"
+                  onClick={() => onRemove(message.id)}
+                  aria-label={`Remove queued message: ${label}`}
+                  title="Remove from queue"
+                  className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </motion.div>
+            )
+          })}
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   )
 }

--- a/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
+++ b/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
@@ -13,7 +13,6 @@ import React from "react"
 import { motion } from "framer-motion"
 import { Clock3, SendHorizontal, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import type { QueuedMessage, QueueHoldReason } from "@/hooks/useMessageQueue"
 
 const HOLD_MESSAGE: Record<QueueHoldReason, string> = {
@@ -73,74 +72,66 @@ export function QueuedMessages({
         </div>
       )}
 
-      <TooltipProvider delayDuration={300}>
-        <div className="flex flex-col gap-1.5">
-          {queue.map(message => {
-            const label = message.text || "attachments"
-            return (
-              <motion.div
-                key={message.id}
-                layout
-                initial={{ opacity: 0, y: 4 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 4 }}
-                className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/60 bg-muted/50 text-sm"
-              >
-                <Clock3 className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="flex-1 truncate text-foreground/80">
-                  {message.text || `${message.files.length} attachment(s)`}
+      <div className="flex flex-col gap-1.5">
+        {queue.map(message => {
+          const label = message.text || "attachments"
+          return (
+            <motion.div
+              key={message.id}
+              layout
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 4 }}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/60 bg-muted/50 text-sm"
+            >
+              <Clock3 className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate text-foreground/80">
+                {message.text || `${message.files.length} attachment(s)`}
+              </span>
+              {message.files.length > 0 && message.text && (
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  +{message.files.length}
                 </span>
-                {message.files.length > 0 && message.text && (
-                  <span className="shrink-0 text-xs text-muted-foreground">
-                    +{message.files.length}
-                  </span>
-                )}
-                {actionMode && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void (
-                            actionMode === "interrupt"
-                              ? onInterrupt(message.id)
-                              : onSendMessageNow(message.id)
-                          )
-                        }}
-                        aria-label={
-                          actionMode === "interrupt"
-                            ? `Interrupt with this message: ${label}`
-                            : `Send this message now: ${label}`
-                        }
-                        className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:border-primary/40 hover:bg-accent hover:text-foreground transition-colors"
-                      >
-                        <SendHorizontal className="h-3.5 w-3.5" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">
-                      {actionMode === "interrupt"
-                        ? "Interrupt with this message"
-                        : "Send this message now"}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-                {/* Always visible: a hover-only control is unreachable on touch and
-                    reads as "no way to cancel this" everywhere else. Matches the
-                    attachment chips, which also keep their remove button on show. */}
-                <button
+              )}
+              {actionMode && (
+                <Button
                   type="button"
-                  onClick={() => onRemove(message.id)}
-                  aria-label={`Remove queued message: ${label}`}
-                  title="Remove from queue"
-                  className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    void (
+                      actionMode === "interrupt"
+                        ? onInterrupt(message.id)
+                        : onSendMessageNow(message.id)
+                    )
+                  }}
+                  aria-label={
+                    actionMode === "interrupt"
+                      ? `Interrupt with this message: ${label}`
+                      : `Send this message now: ${label}`
+                  }
+                  className="h-7 shrink-0 gap-1 rounded-md border border-border/60 bg-background px-2 text-xs font-normal text-muted-foreground hover:border-primary/40 hover:text-foreground"
                 >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </motion.div>
-            )
-          })}
-        </div>
-      </TooltipProvider>
+                  <SendHorizontal className="h-3.5 w-3.5" />
+                  {actionMode === "interrupt" ? "Interrupt" : "Send now"}
+                </Button>
+              )}
+              {/* Always visible: a hover-only control is unreachable on touch and
+                  reads as "no way to cancel this" everywhere else. Matches the
+                  attachment chips, which also keep their remove button on show. */}
+              <button
+                type="button"
+                onClick={() => onRemove(message.id)}
+                aria-label={`Remove queued message: ${label}`}
+                title="Remove from queue"
+                className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </motion.div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
+++ b/chatbot-app/frontend/src/components/chat/QueuedMessages.tsx
@@ -29,8 +29,9 @@ interface QueuedMessagesProps {
   onRemove: (id: string) => void
   onSendNow: () => void
   onDiscardAll: () => void
-  canInterrupt: boolean
+  actionMode: "interrupt" | "send" | null
   onInterrupt: (id: string) => Promise<boolean>
+  onSendMessageNow: (id: string) => Promise<boolean>
 }
 
 export function QueuedMessages({
@@ -39,8 +40,9 @@ export function QueuedMessages({
   onRemove,
   onSendNow,
   onDiscardAll,
-  canInterrupt,
+  actionMode,
   onInterrupt,
+  onSendMessageNow,
 }: QueuedMessagesProps) {
   if (queue.length === 0) return null
 
@@ -93,19 +95,33 @@ export function QueuedMessages({
                     +{message.files.length}
                   </span>
                 )}
-                {canInterrupt && (
+                {actionMode && (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button
                         type="button"
-                        onClick={() => void onInterrupt(message.id)}
-                        aria-label={`Interrupt with this message: ${label}`}
-                        className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                        onClick={() => {
+                          void (
+                            actionMode === "interrupt"
+                              ? onInterrupt(message.id)
+                              : onSendMessageNow(message.id)
+                          )
+                        }}
+                        aria-label={
+                          actionMode === "interrupt"
+                            ? `Interrupt with this message: ${label}`
+                            : `Send this message now: ${label}`
+                        }
+                        className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground hover:border-primary/40 hover:bg-accent hover:text-foreground transition-colors"
                       >
                         <SendHorizontal className="h-3.5 w-3.5" />
                       </button>
                     </TooltipTrigger>
-                    <TooltipContent side="top">Interrupt with this message</TooltipContent>
+                    <TooltipContent side="top">
+                      {actionMode === "interrupt"
+                        ? "Interrupt with this message"
+                        : "Send this message now"}
+                    </TooltipContent>
                   </Tooltip>
                 )}
                 {/* Always visible: a hover-only control is unreachable on touch and

--- a/chatbot-app/frontend/src/components/chat/ToolExecutionContainer.tsx
+++ b/chatbot-app/frontend/src/components/chat/ToolExecutionContainer.tsx
@@ -681,7 +681,20 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
   // Helper: render expanded detail for a single tool execution
   const renderExpandedDetail = (toolExecution: ToolExecution) => (
     <div className="ml-4 mt-1 mb-2 border-l-2 border-muted pl-3 space-y-2 animate-fade-in">
-      {toolExecution.toolInput && Object.keys(toolExecution.toolInput).length > 0 && (
+      {toolExecution.toolInputState === 'streaming' && !toolExecution.toolInputRaw && (
+        <div className="flex items-center gap-2 py-1 text-caption text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <span>Preparing parameters...</span>
+        </div>
+      )}
+      {toolExecution.toolInputState === 'streaming' && toolExecution.toolInputRaw && (
+        <div className="text-label">
+          <JsonDisplay data={toolExecution.toolInputRaw} maxLines={4} label="Input" />
+        </div>
+      )}
+      {toolExecution.toolInputState !== 'streaming' &&
+        toolExecution.toolInput &&
+        Object.keys(toolExecution.toolInput).length > 0 && (
         <div className="text-label">
           <JsonDisplay data={toolExecution.toolInput} maxLines={4} label="Input" />
         </div>
@@ -943,8 +956,11 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
     if (!nextTool) return false
 
     if (tool.id !== nextTool.id) return false
+    if (tool.toolName !== nextTool.toolName) return false
     if (tool.isComplete !== nextTool.isComplete) return false
     if (tool.toolResult !== nextTool.toolResult) return false
+    if (tool.toolInputState !== nextTool.toolInputState) return false
+    if (tool.toolInputRaw !== nextTool.toolInputRaw) return false
 
     const prevInput = JSON.stringify(tool.toolInput || {})
     const nextInput = JSON.stringify(nextTool.toolInput || {})

--- a/chatbot-app/frontend/src/components/ui/file-preview.tsx
+++ b/chatbot-app/frontend/src/components/ui/file-preview.tsx
@@ -154,9 +154,9 @@ const TextFilePreview = React.forwardRef<HTMLDivElement, FilePreviewProps>(
       const reader = new FileReader()
       reader.onload = (e) => {
         const text = e.target?.result as string
-        setPreview(text.slice(0, 50) + (text.length > 50 ? "..." : ""))
+        setPreview(text.slice(0, 50) + (file.size > 50 ? "..." : ""))
       }
-      reader.readAsText(file)
+      reader.readAsText(file.slice(0, 64))
     }, [file])
 
     if (compact) {

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -68,6 +68,7 @@ interface UseChatReturn {
   newChat: () => Promise<void>
   compactSession: () => Promise<void>
   truncateFromMessage: (message: Message) => Promise<void>
+  sessionEventRefreshVersion: number
   sessionId: string
   isLoadingMessages: boolean
   isCompacting: boolean
@@ -181,6 +182,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     }
   })
   const [isForegroundRunActive, setIsForegroundRunActive] = useState(false)
+  const [sessionEventRefreshVersion, setSessionEventRefreshVersion] = useState(0)
 
   // ==================== REFS ====================
   const currentToolExecutionsRef = useRef<ToolExecution[]>([])
@@ -871,6 +873,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
     try {
       await apiTruncateSession(params)
+      setSessionEventRefreshVersion(version => version + 1)
       console.log('[truncate] Backend truncation complete')
     } catch (error) {
       console.error('[truncate] Error truncating session:', error)
@@ -1211,6 +1214,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     newChat,
     compactSession,
     truncateFromMessage,
+    sessionEventRefreshVersion,
     sessionId,
     isLoadingMessages,
     isCompacting: isCurrentSessionCompacting,

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -47,7 +47,7 @@ interface UseChatReturn {
     executionId: string,
     messageIdentity?: ReplayMessageIdentity,
   ) => Promise<boolean>
-  stopGeneration: () => Promise<void>
+  stopGeneration: () => Promise<boolean>
   // Queue for turns composed while the agent is busy
   queuedMessages: QueuedMessage[]
   queueHoldReason: QueueHoldReason | null
@@ -56,6 +56,8 @@ interface UseChatReturn {
   clearQueuedMessages: () => void
   /** User confirmed a held queue: resume and send the next message now. */
   releaseQueue: () => void
+  /** Stop the current turn and immediately dispatch the selected queued turn. */
+  interruptWithQueuedMessage: (id: string) => Promise<boolean>
   newChat: () => Promise<void>
   compactSession: () => Promise<void>
   truncateFromMessage: (message: Message) => Promise<void>
@@ -177,6 +179,8 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   const currentTurnIdRef = useRef<string | null>(null)
   const currentSessionIdRef = useRef<string | null>(null)
   const messagesRef = useRef<Message[]>([])
+  const sessionStateRef = useRef(sessionState)
+  sessionStateRef.current = sessionState
   // Set once the queue hook is initialized below; newChat and respondToInterrupt
   // are declared before it.
   const clearQueuedMessagesRef = useRef<() => void>(() => {})
@@ -605,6 +609,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     enqueue,
     remove: removeQueuedMessage,
     clear: clearQueuedMessages,
+    prioritize: prioritizeQueuedMessage,
     flushNext,
     hold: holdQueue,
     release: releaseHold,
@@ -845,28 +850,61 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId])
 
-  const stopGeneration = useCallback(async () => {
-    let previousStatus: AgentStatus = 'thinking'
-    setUIState(prev => {
-      previousStatus = prev.agentStatus
-      return { ...prev, agentStatus: 'stopping' }
-    })
+  const stopGeneration = useCallback(async (): Promise<boolean> => {
+    const stoppingSessionId = currentSessionIdRef.current
+    const previousStatus = uiState.agentStatus
+    setUIState(prev => ({ ...prev, agentStatus: 'stopping' }))
 
     const stopped = await sendStopSignal()
     if (stopped) {
+      // A session switch owns the UI now. The stop still succeeded for the old
+      // run, but must not reset or hold the newly selected session.
+      if (currentSessionIdRef.current !== stoppingSessionId) return true
+
       // The durable stop request has been accepted; the local stream can now close.
       resetStreamingState()
       // Stopping is a deliberate interruption, so don't immediately send whatever
       // was queued — that would look like the stop was ignored.
       holdQueue('stopped')
-      return
+      return true
     }
 
-    setUIState(prev => ({
-      ...prev,
-      agentStatus: previousStatus === 'stopping' ? 'thinking' : previousStatus,
-    }))
-  }, [sendStopSignal, resetStreamingState, holdQueue])
+    if (currentSessionIdRef.current === stoppingSessionId) {
+      setUIState(prev => ({
+        ...prev,
+        agentStatus: previousStatus === 'stopping' ? 'thinking' : previousStatus,
+      }))
+    }
+    return false
+  }, [sendStopSignal, resetStreamingState, holdQueue, uiState.agentStatus])
+
+  const interruptWithQueuedMessage = useCallback(async (id: string): Promise<boolean> => {
+    const interruptSessionId = sessionId
+    const initialState = sessionStateRef.current
+    if (initialState.interrupt || initialState.pendingOAuth) return false
+    if (!prioritizeQueuedMessage(id, interruptSessionId)) return false
+
+    const stopped = await stopGeneration()
+    if (!stopped || currentSessionIdRef.current !== interruptSessionId) return false
+
+    const latestState = sessionStateRef.current
+    if (latestState.interrupt || latestState.pendingOAuth) return false
+
+    // stopGeneration deliberately holds normal queued turns. This action is an
+    // explicit request to continue with the selected one, so release that hold
+    // and use the same guarded send path as every other queued turn.
+    releaseHold()
+    return flushNext(interruptSessionId, {
+      hasInterrupt: latestState.interrupt !== null,
+      hasPendingOAuth: !!latestState.pendingOAuth,
+    })
+  }, [
+    flushNext,
+    prioritizeQueuedMessage,
+    releaseHold,
+    sessionId,
+    stopGeneration,
+  ])
 
   const cancelOAuth = useCallback(() => {
     setSessionState(prev => ({ ...prev, pendingOAuth: null }))
@@ -1111,6 +1149,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     removeQueuedMessage,
     clearQueuedMessages,
     releaseQueue,
+    interruptWithQueuedMessage,
     newChat,
     compactSession,
     truncateFromMessage,

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -58,6 +58,8 @@ interface UseChatReturn {
   releaseQueue: () => void
   /** Stop the current turn and immediately dispatch the selected queued turn. */
   interruptWithQueuedMessage: (id: string) => Promise<boolean>
+  /** Immediately dispatch the selected queued turn while the agent is idle. */
+  sendQueuedMessageNow: (id: string) => Promise<boolean>
   newChat: () => Promise<void>
   compactSession: () => Promise<void>
   truncateFromMessage: (message: Message) => Promise<void>
@@ -181,6 +183,8 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   const messagesRef = useRef<Message[]>([])
   const sessionStateRef = useRef(sessionState)
   sessionStateRef.current = sessionState
+  const uiStateRef = useRef(uiState)
+  uiStateRef.current = uiState
   // Set once the queue hook is initialized below; newChat and respondToInterrupt
   // are declared before it.
   const clearQueuedMessagesRef = useRef<() => void>(() => {})
@@ -704,6 +708,31 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     })
   }, [releaseHold, flushNext, sessionId, sessionState.interrupt, sessionState.pendingOAuth])
 
+  const sendQueuedMessageNow = useCallback(async (id: string): Promise<boolean> => {
+    const targetSessionId = sessionId
+    const latestState = sessionStateRef.current
+    if (
+      uiStateRef.current.agentStatus !== 'idle' ||
+      latestState.interrupt ||
+      latestState.pendingOAuth
+    ) {
+      return false
+    }
+    if (!prioritizeQueuedMessage(id, targetSessionId)) return false
+    if (currentSessionIdRef.current !== targetSessionId) return false
+
+    releaseHold()
+    return flushNext(targetSessionId, {
+      hasInterrupt: false,
+      hasPendingOAuth: false,
+    })
+  }, [
+    flushNext,
+    prioritizeQueuedMessage,
+    releaseHold,
+    sessionId,
+  ])
+
   // localStorage key for compact recovery across browser refresh
   const getCompactPendingKey = (sid: string) => `compact_pending_${sid}`
 
@@ -1150,6 +1179,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     clearQueuedMessages,
     releaseQueue,
     interruptWithQueuedMessage,
+    sendQueuedMessageNow,
     newChat,
     compactSession,
     truncateFromMessage,

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -271,6 +271,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     replayExecution: apiReplayExecution,
     cleanup,
     sendStopSignal,
+    hasStoppableRun,
     loadSession: apiLoadSession,
     isReconnecting,
     reconnectAttempt,
@@ -931,10 +932,20 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     const interruptSessionId = sessionId
     const initialState = sessionStateRef.current
     if (initialState.interrupt || initialState.pendingOAuth) return false
-    if (!prioritizeQueuedMessage(id, interruptSessionId)) return false
+    const previousHoldReason = queueHoldReason
+    holdQueue('stopped')
 
     const stopped = await stopGeneration()
-    if (!stopped || currentSessionIdRef.current !== interruptSessionId) return false
+    if (!stopped) {
+      if (previousHoldReason) {
+        holdQueue(previousHoldReason)
+      } else {
+        releaseHold()
+      }
+      return false
+    }
+    if (currentSessionIdRef.current !== interruptSessionId) return false
+    if (!prioritizeQueuedMessage(id, interruptSessionId)) return false
 
     const latestState = sessionStateRef.current
     if (latestState.interrupt || latestState.pendingOAuth) return false
@@ -950,9 +961,11 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   }, [
     flushNext,
     prioritizeQueuedMessage,
+    queueHoldReason,
     releaseHold,
     sessionId,
     stopGeneration,
+    holdQueue,
   ])
 
   const cancelOAuth = useCallback(() => {
@@ -967,6 +980,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
   const turnControl = deriveTurnControl({
     agentStatus: uiState.agentStatus,
     isForegroundRunActive,
+    hasStoppableRun,
     isCompacting: isCurrentSessionCompacting,
     interruptCount: sessionState.interrupt?.interrupts.length ?? 0,
     hasPendingOAuth: Boolean(sessionState.pendingOAuth),

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -14,6 +14,7 @@ import { getApiUrl } from '@/config/environment'
 import { generateSessionId } from '@/config/session'
 import { apiGet, apiPost } from '@/lib/api-client'
 import { groupChatMessages, type GroupedChatMessage } from '@/lib/chat-message-groups'
+import { deriveTurnControl, type TurnControlState } from '@/lib/turn-control'
 
 import { WorkspaceDocument } from './useStreamEvents'
 import { ExtractedDataInfo } from './useCanvasHandlers'
@@ -40,6 +41,8 @@ interface UseChatReturn {
   agentStatus: AgentStatus
   /** A foreground chat request is still running and can receive a stop signal. */
   isForegroundRunActive: boolean
+  /** Canonical user-action state shared by the composer and queued turns. */
+  turnControl: TurnControlState
   currentToolExecutions: ToolExecution[]
   currentReasoning: ReasoningState | null
   showProgressPanel: boolean
@@ -956,6 +959,15 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
   // ==================== DERIVED STATE ====================
   const groupedMessages = useMemo(() => groupChatMessages(messages), [messages])
+  const isCurrentSessionCompacting =
+    compactingSessionId !== null && compactingSessionId === sessionId
+  const turnControl = deriveTurnControl({
+    agentStatus: uiState.agentStatus,
+    isForegroundRunActive,
+    isCompacting: isCurrentSessionCompacting,
+    interruptCount: sessionState.interrupt?.interrupts.length ?? 0,
+    hasPendingOAuth: Boolean(sessionState.pendingOAuth),
+  })
 
   // Update per-session model config (React state + global default via API)
   const updateModelConfig = useCallback((modelId: string, temperature?: number) => {
@@ -1180,6 +1192,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     isTyping: uiState.isTyping,
     agentStatus: uiState.agentStatus,
     isForegroundRunActive,
+    turnControl,
     currentToolExecutions: sessionState.toolExecutions,
     currentReasoning: sessionState.reasoning,
     showProgressPanel: uiState.showProgressPanel,
@@ -1200,7 +1213,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     truncateFromMessage,
     sessionId,
     isLoadingMessages,
-    isCompacting: compactingSessionId !== null && compactingSessionId === sessionId,
+    isCompacting: isCurrentSessionCompacting,
     loadSession: loadSessionWithPreferences,
     browserSession: sessionState.browserSession,
     browserProgress: sessionState.browserProgress,

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -38,6 +38,8 @@ interface UseChatReturn {
   isConnected: boolean
   isTyping: boolean
   agentStatus: AgentStatus
+  /** A foreground chat request is still running and can receive a stop signal. */
+  isForegroundRunActive: boolean
   currentToolExecutions: ToolExecution[]
   currentReasoning: ReasoningState | null
   showProgressPanel: boolean
@@ -175,6 +177,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
       endToEndLatency: null
     }
   })
+  const [isForegroundRunActive, setIsForegroundRunActive] = useState(false)
 
   // ==================== REFS ====================
   const currentToolExecutionsRef = useRef<ToolExecution[]>([])
@@ -348,6 +351,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
     // Stop any existing polling
     stopPolling()
+    setIsForegroundRunActive(false)
 
     // Set loading state for UI feedback
     setIsLoadingMessages(true)
@@ -450,6 +454,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
     const success = await apiNewChat()
     if (success) {
+      setIsForegroundRunActive(false)
       setSessionState({
         reasoning: null,
         streaming: null,
@@ -482,6 +487,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
     const agentStatus: 'thinking' | 'researching' = isResearchInterrupt ? 'researching' : 'thinking'
     setUIState(prev => ({ ...prev, isTyping: true, agentStatus }))
+    setIsForegroundRunActive(true)
 
     try {
       await apiSendMessage(
@@ -500,6 +506,8 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
       console.error('[Interrupt] Failed to respond to interrupt:', error)
       setTurnSettled({ outcome: 'error' })
       setUIState(prev => ({ ...prev, isTyping: false, agentStatus: 'idle' }))
+    } finally {
+      setIsForegroundRunActive(false)
     }
   }, [sessionState.interrupt, apiSendMessage])
 
@@ -568,27 +576,32 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     // where flushing the next queued message can be safe. Whether it actually
     // is safe also depends on interrupt/OAuth state, which is checked in the
     // effect below once React has committed this turn's events.
-    await apiSendMessage(
-      messageToSend,
-      files,
-      () => { setTurnSettled({ outcome: 'finished' }) },
-      () => {
-        setTurnSettled({ outcome: 'error' })
-        setSessionState(prev => ({
-          reasoning: null,
-          streaming: null,
-          toolExecutions: [],
-          browserSession: prev.browserSession,
-          browserProgress: undefined,
-          researchProgress: undefined,
-          interrupt: null,
-          pendingOAuth: null
-        }))
-        setUIState(prev => ({ ...prev, agentStatus: 'idle', isTyping: false }))
-      },
-      systemPrompt,
-      selectedArtifactId
-    )
+    setIsForegroundRunActive(true)
+    try {
+      await apiSendMessage(
+        messageToSend,
+        files,
+        () => { setTurnSettled({ outcome: 'finished' }) },
+        () => {
+          setTurnSettled({ outcome: 'error' })
+          setSessionState(prev => ({
+            reasoning: null,
+            streaming: null,
+            toolExecutions: [],
+            browserSession: prev.browserSession,
+            browserProgress: undefined,
+            researchProgress: undefined,
+            interrupt: null,
+            pendingOAuth: null
+          }))
+          setUIState(prev => ({ ...prev, agentStatus: 'idle', isTyping: false }))
+        },
+        systemPrompt,
+        selectedArtifactId
+      )
+    } finally {
+      setIsForegroundRunActive(false)
+    }
   }, [apiSendMessage, setUIState])
 
   // ==================== MESSAGE QUEUE ====================
@@ -892,6 +905,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
       // The durable stop request has been accepted; the local stream can now close.
       resetStreamingState()
+      setIsForegroundRunActive(false)
       // Stopping is a deliberate interruption, so don't immediately send whatever
       // was queued — that would look like the stop was ignored.
       holdQueue('stopped')
@@ -1165,6 +1179,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     isConnected: uiState.isConnected,
     isTyping: uiState.isTyping,
     agentStatus: uiState.agentStatus,
+    isForegroundRunActive,
     currentToolExecutions: sessionState.toolExecutions,
     currentReasoning: sessionState.reasoning,
     showProgressPanel: uiState.showProgressPanel,

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect } from 'react'
+import { useCallback, useRef, useEffect, useState } from 'react'
 import { Message, ToolExecution } from '@/types/chat'
 import { AGUIStreamEvent, ChatUIState, AGUI_EVENT_TYPES } from '@/types/events'
 import { getApiUrl } from '@/config/environment'
@@ -191,6 +191,7 @@ interface UseChatAPIReturn {
   ) => Promise<boolean>
   cleanup: () => void
   sendStopSignal: () => Promise<boolean>
+  hasStoppableRun: boolean
   loadSession: (sessionId: string) => Promise<{ preferences: SessionPreferences | null; messages: Message[] }>
 }
 
@@ -211,6 +212,7 @@ export const useChatAPI = ({
   const abortRef = useRef<{ unsubscribe: () => void } | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const activeRunIdRef = useRef<string | null>(null)
+  const [hasStoppableRun, setHasStoppableRun] = useState(false)
   // Read through a ref: adding conciseMode to sendMessage's deps would rebuild
   // it whenever the toggle flips, and useChat's queue flush closes over it.
   const conciseModeRef = useRef(conciseMode)
@@ -524,6 +526,7 @@ export const useChatAPI = ({
         const threadId = sessionIdRef.current ?? crypto.randomUUID()
         requestRunId = crypto.randomUUID()
         activeRunIdRef.current = requestRunId
+        setHasStoppableRun(true)
         const aguiBody = JSON.stringify({
           threadId,
           runId: requestRunId,
@@ -729,6 +732,7 @@ export const useChatAPI = ({
         // no run to target and only logged "No active run available to stop".
         if (activeRunIdRef.current === requestRunId && !endedAtInterrupt) {
           activeRunIdRef.current = null
+          setHasStoppableRun(false)
         }
         onSuccess?.()
       }
@@ -809,6 +813,7 @@ export const useChatAPI = ({
       onError?.(errorMessage)
       if (activeRunIdRef.current === requestRunId) {
         activeRunIdRef.current = null
+        setHasStoppableRun(false)
       }
     }
   }, [handleStreamEvent, setUIState, setMessages, onSessionCreated, currentModelId, currentTemperature, reconnect])
@@ -1405,6 +1410,7 @@ export const useChatAPI = ({
       abortRef.current = null
       if (activeRunIdRef.current === currentRunId) {
         activeRunIdRef.current = null
+        setHasStoppableRun(false)
       }
       logger.debug('Stop signal sent to backend')
       return true
@@ -1424,6 +1430,7 @@ export const useChatAPI = ({
     replayExecution,
     cleanup,
     sendStopSignal,
+    hasStoppableRun,
     loadSession,
     isReconnecting: reconnect.isReconnecting,
     reconnectAttempt: reconnect.reconnectAttempt,

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -8,6 +8,7 @@ import { buildToolMaps, createToolExecution } from '@/utils/messageParser'
 import { isSessionTimedOut, getLastActivity, updateLastActivity, clearSessionData, triggerWarmup, generateSessionId } from '@/config/session'
 import { isA2ATool } from './usePolling'
 import { useSSEReconnect } from './useSSEReconnect'
+import { arrayBufferToBase64 } from '@/lib/base64'
 
 /**
  * Process swarm message content blocks in order to preserve text/tool interleaving.
@@ -513,7 +514,7 @@ export const useChatAPI = ({
         if (files && files.length > 0) {
           for (const file of files) {
             const arrayBuffer = await file.arrayBuffer()
-            const base64 = btoa(new Uint8Array(arrayBuffer).reduce((d, b) => d + String.fromCharCode(b), ''))
+            const base64 = arrayBufferToBase64(arrayBuffer)
             contentParts.push({
               type: 'binary',
               mimeType: file.type || 'application/octet-stream',

--- a/chatbot-app/frontend/src/hooks/useMessageQueue.ts
+++ b/chatbot-app/frontend/src/hooks/useMessageQueue.ts
@@ -55,6 +55,8 @@ export interface UseMessageQueueReturn {
   enqueue: (message: Omit<QueuedMessage, 'id'>) => void
   remove: (id: string) => void
   clear: () => void
+  /** Move a message to the front so it is the next turn dispatched. */
+  prioritize: (id: string, sessionId: string) => boolean
   /**
    * Send the next queued message for `sessionId` if it is safe to do so.
    * Must be called after React has committed the finishing turn's events, so
@@ -128,6 +130,26 @@ export function useMessageQueue({ send }: UseMessageQueueProps): UseMessageQueue
     updateHold(null)
   }, [updateQueue, updateHold])
 
+  const prioritize = useCallback((id: string, sessionId: string): boolean => {
+    const current = queueRef.current
+    const index = current.findIndex(
+      message => message.id === id && message.sessionId === sessionId,
+    )
+    if (index < 0) return false
+    if (index === 0) return true
+
+    const next = [
+      current[index],
+      ...current.slice(0, index),
+      ...current.slice(index + 1),
+    ]
+    // Keep the ref current synchronously: an interrupt can proceed to flush as
+    // soon as the durable stop request resolves, before React renders again.
+    queueRef.current = next
+    setQueue(next)
+    return true
+  }, [])
+
   const hold = useCallback((reason: QueueHoldReason) => {
     if (queueRef.current.length === 0) return
     updateHold(reason)
@@ -187,6 +209,7 @@ export function useMessageQueue({ send }: UseMessageQueueProps): UseMessageQueue
     enqueue,
     remove,
     clear,
+    prioritize,
     flushNext,
     hold,
     release,

--- a/chatbot-app/frontend/src/hooks/useMessageQueue.ts
+++ b/chatbot-app/frontend/src/hooks/useMessageQueue.ts
@@ -93,11 +93,12 @@ export function useMessageQueue({ send }: UseMessageQueueProps): UseMessageQueue
   const holdReasonRef = useRef<QueueHoldReason | null>(null)
 
   const updateQueue = useCallback((next: (prev: QueuedMessage[]) => QueuedMessage[]) => {
-    setQueue(prev => {
-      const value = next(prev)
-      queueRef.current = value
-      return value
-    })
+    // queueRef is the authority for imperative flush operations. Commit it
+    // synchronously so a send rejection cannot observe the pre-dispatch queue
+    // while React is still scheduling the render.
+    const value = next(queueRef.current)
+    queueRef.current = value
+    setQueue(value)
   }, [])
 
   const updateHold = useCallback((reason: QueueHoldReason | null) => {
@@ -188,14 +189,17 @@ export function useMessageQueue({ send }: UseMessageQueueProps): UseMessageQueue
     const next = queueRef.current.find(m => m.sessionId === sessionId)!
 
     isFlushingRef.current = true
+    // The queue represents turns that have not entered the conversation yet.
+    // Remove this item before dispatch so it disappears as soon as send()
+    // accepts it into the normal user-turn path, not after the response ends.
+    updateQueue(prev => prev.filter(m => m.id !== next.id))
     try {
       await send(next.text, next.files, next.systemPrompt, next.selectedArtifactId)
-      // A transport failure is not proof that the backend accepted the turn.
-      // Keep the item until success so a transient error cannot silently lose
-      // user input. The error hold requires an explicit retry/discard decision.
-      updateQueue(prev => prev.filter(m => m.id !== next.id))
       return true
     } catch {
+      // send() adds the user turn before awaiting the transport. Re-inserting it
+      // here could dispatch the same accepted turn twice. Hold only messages
+      // that are still waiting behind the failed turn.
       hold('error')
       return false
     } finally {

--- a/chatbot-app/frontend/src/hooks/useResearchJobs.ts
+++ b/chatbot-app/frontend/src/hooks/useResearchJobs.ts
@@ -4,6 +4,27 @@ import type { ResearchJob } from '@/lib/research-jobs'
 
 const POLL_INTERVAL_MS = 2000
 const DISCOVERY_WINDOW_MS = 15000
+const ARTIFACT_HYDRATION_CONCURRENCY = 4
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  operation: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++
+        results[index] = await operation(items[index])
+      }
+    },
+  )
+  await Promise.all(workers)
+  return results
+}
 
 export function useResearchJobs(sessionId: string, refreshToken = 0) {
   const [jobs, setJobs] = useState<ResearchJob[]>([])
@@ -33,38 +54,70 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     const requestedSessionId = sessionId
     refreshingRef.current = true
     try {
-      const response = await apiFetch(`research/jobs?session_id=${encodeURIComponent(sessionId)}`, {
+      const activeJobIds = jobsRef.current
+        .filter(job => ['queued', 'running', 'delivering'].includes(job.status))
+        .map(job => job.jobId)
+      const waitingForDiscovery =
+        Date.now() < discoveryUntilRef.current &&
+        jobsRef.current.length < invocationCountRef.current
+      const targetedPoll =
+        statusesRef.current !== null &&
+        activeJobIds.length > 0 &&
+        !waitingForDiscovery
+      const query = new URLSearchParams({ session_id: sessionId })
+      if (targetedPoll) query.set('job_ids', activeJobIds.join(','))
+      const response = await apiFetch(`research/jobs?${query.toString()}`, {
         cache: 'no-store',
       })
       if (!response.ok) return
       const data = await response.json()
       if (sessionRef.current !== requestedSessionId) return
-      let nextJobs: ResearchJob[] = Array.isArray(data.jobs) ? data.jobs : []
+      let fetchedJobs: ResearchJob[] = Array.isArray(data.jobs) ? data.jobs : []
       const existingById = new Map(jobsRef.current.map(job => [job.jobId, job]))
-      nextJobs = nextJobs.map(job => {
+      fetchedJobs = fetchedJobs.map(job => {
         const existing = existingById.get(job.jobId)
         return existing?.artifact?.content
           ? { ...job, artifact: existing.artifact }
           : job
       })
 
-      const needsContent = nextJobs.some(job =>
+      const needsContent = fetchedJobs.some(job =>
         ['completed', 'delivering', 'delivered'].includes(job.status) &&
         !job.artifact?.content,
       )
       if (needsContent) {
-        const contentResponse = await apiFetch(
-          `research/jobs?session_id=${encodeURIComponent(sessionId)}&include_content=true`,
-          { cache: 'no-store' },
+        const hydrated = await mapWithConcurrency(
+          fetchedJobs,
+          ARTIFACT_HYDRATION_CONCURRENCY,
+          async job => {
+            if (
+              !['completed', 'delivering', 'delivered'].includes(job.status) ||
+              job.artifact?.content
+            ) {
+              return job
+            }
+            const contentResponse = await apiFetch(
+              `research/jobs?session_id=${encodeURIComponent(sessionId)}` +
+              `&job_id=${encodeURIComponent(job.jobId)}&include_content=true`,
+              { cache: 'no-store' },
+            )
+            if (!contentResponse.ok) return job
+            const contentData = await contentResponse.json()
+            return contentData.job || job
+          },
         )
-        if (contentResponse.ok) {
-          const contentData = await contentResponse.json()
-          if (sessionRef.current !== requestedSessionId) return
-          const hydrated: ResearchJob[] = Array.isArray(contentData.jobs) ? contentData.jobs : []
-          const hydratedById = new Map(hydrated.map(job => [job.jobId, job]))
-          nextJobs = nextJobs.map(job => hydratedById.get(job.jobId) || job)
-        }
+        if (sessionRef.current !== requestedSessionId) return
+        fetchedJobs = hydrated
       }
+      const targetedIds = new Set(activeJobIds)
+      const nextJobs = targetedPoll
+        ? [
+            ...jobsRef.current.filter(
+              job => !targetedIds.has(job.jobId),
+            ),
+            ...fetchedJobs,
+          ].sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+        : fetchedJobs
 
       const previous = statusesRef.current
       if (previous) {

--- a/chatbot-app/frontend/src/hooks/useResearchJobs.ts
+++ b/chatbot-app/frontend/src/hooks/useResearchJobs.ts
@@ -9,6 +9,8 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
   const [jobs, setJobs] = useState<ResearchJob[]>([])
   const [deliveredJobIds, setDeliveredJobIds] = useState<string[]>([])
   const [isActive, setIsActive] = useState(false)
+  const [hasPendingDelivery, setHasPendingDelivery] = useState(false)
+  const [deliveryVersion, setDeliveryVersion] = useState(0)
   const [snapshotSessionId, setSnapshotSessionId] = useState(sessionId)
   const statusesRef = useRef<Map<string, string> | null>(null)
   const jobsRef = useRef<ResearchJob[]>([])
@@ -69,9 +71,15 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
         const transitions = nextJobs
           .filter(job => job.status === 'delivered' && previous.get(job.jobId) !== 'delivered')
           .map(job => job.jobId)
-        if (transitions.length > 0) setDeliveredJobIds(transitions)
+        setDeliveredJobIds(transitions)
+        const deliveryTransitions = nextJobs.some(job =>
+          ['delivering', 'delivered'].includes(job.status) &&
+          previous.get(job.jobId) !== job.status,
+        )
+        if (deliveryTransitions) setDeliveryVersion(version => version + 1)
       }
       statusesRef.current = new Map(nextJobs.map(job => [job.jobId, job.status]))
+      setHasPendingDelivery(nextJobs.some(job => job.status === 'delivering'))
       const hasActiveJobs = nextJobs.some(job =>
         ['queued', 'running', 'delivering'].includes(job.status),
       )
@@ -121,6 +129,8 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     setJobs([])
     setDeliveredJobIds([])
     setIsActive(false)
+    setHasPendingDelivery(false)
+    setDeliveryVersion(0)
     void refresh()
     const timer = window.setInterval(() => {
       if (activeRef.current) void refresh()
@@ -142,6 +152,10 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     deliveredJobIds:
       snapshotSessionId === sessionId ? deliveredJobIds : [],
     isActive: snapshotSessionId === sessionId && isActive,
+    hasPendingDelivery:
+      snapshotSessionId === sessionId && hasPendingDelivery,
+    deliveryVersion:
+      snapshotSessionId === sessionId ? deliveryVersion : 0,
     refresh,
   }
 }

--- a/chatbot-app/frontend/src/hooks/useResearchJobs.ts
+++ b/chatbot-app/frontend/src/hooks/useResearchJobs.ts
@@ -8,6 +8,7 @@ const DISCOVERY_WINDOW_MS = 15000
 export function useResearchJobs(sessionId: string, refreshToken = 0) {
   const [jobs, setJobs] = useState<ResearchJob[]>([])
   const [deliveredJobIds, setDeliveredJobIds] = useState<string[]>([])
+  const [isActive, setIsActive] = useState(false)
   const [snapshotSessionId, setSnapshotSessionId] = useState(sessionId)
   const statusesRef = useRef<Map<string, string> | null>(null)
   const jobsRef = useRef<ResearchJob[]>([])
@@ -16,8 +17,10 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
   const activeRef = useRef(false)
   const discoveryUntilRef = useRef(0)
   const invocationCountRef = useRef(0)
+  const refreshTokenRef = useRef(refreshToken)
   const sessionRef = useRef(sessionId)
   sessionRef.current = sessionId
+  refreshTokenRef.current = refreshToken
 
   const refresh = useCallback(async () => {
     if (!sessionId) return
@@ -70,7 +73,7 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
       }
       statusesRef.current = new Map(nextJobs.map(job => [job.jobId, job.status]))
       const hasActiveJobs = nextJobs.some(job =>
-        ['queued', 'running', 'delivering'].includes(job.status),
+        ['queued', 'running', 'completed', 'delivering'].includes(job.status),
       )
       const expectedJobs = invocationCountRef.current
       if (nextJobs.length >= expectedJobs) {
@@ -79,7 +82,9 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
       const waitingForReceipt =
         nextJobs.length < expectedJobs &&
         Date.now() < discoveryUntilRef.current
-      activeRef.current = hasActiveJobs || waitingForReceipt
+      const nextActive = hasActiveJobs || waitingForReceipt
+      activeRef.current = nextActive
+      setIsActive(nextActive)
       const changed = nextJobs.length !== jobsRef.current.length || nextJobs.some((job, index) => {
         const current = jobsRef.current[index]
         return !current ||
@@ -107,12 +112,15 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     jobsRef.current = []
     activeRef.current = false
     discoveryUntilRef.current = 0
-    invocationCountRef.current = 0
+    // Tool invocations already present when a session opens are history, not
+    // evidence that a new job receipt is still propagating.
+    invocationCountRef.current = refreshTokenRef.current
     refreshingRef.current = false
     pendingRefreshRef.current = false
     setSnapshotSessionId(sessionId)
     setJobs([])
     setDeliveredJobIds([])
+    setIsActive(false)
     void refresh()
     const timer = window.setInterval(() => {
       if (activeRef.current) void refresh()
@@ -125,6 +133,7 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     invocationCountRef.current = refreshToken
     discoveryUntilRef.current = Date.now() + DISCOVERY_WINDOW_MS
     activeRef.current = true
+    setIsActive(true)
     void refresh()
   }, [refresh, refreshToken])
 
@@ -132,6 +141,7 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
     jobs: snapshotSessionId === sessionId ? jobs : [],
     deliveredJobIds:
       snapshotSessionId === sessionId ? deliveredJobIds : [],
+    isActive: snapshotSessionId === sessionId && isActive,
     refresh,
   }
 }

--- a/chatbot-app/frontend/src/hooks/useResearchJobs.ts
+++ b/chatbot-app/frontend/src/hooks/useResearchJobs.ts
@@ -73,7 +73,7 @@ export function useResearchJobs(sessionId: string, refreshToken = 0) {
       }
       statusesRef.current = new Map(nextJobs.map(job => [job.jobId, job.status]))
       const hasActiveJobs = nextJobs.some(job =>
-        ['queued', 'running', 'completed', 'delivering'].includes(job.status),
+        ['queued', 'running', 'delivering'].includes(job.status),
       )
       const expectedJobs = invocationCountRef.current
       if (nextJobs.length >= expectedJobs) {

--- a/chatbot-app/frontend/src/hooks/useSessionEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useSessionEvents.ts
@@ -3,9 +3,12 @@ import { apiFetch } from '@/lib/api-client'
 import type { SessionEventProjection } from '@/lib/session-events'
 
 const ACTIVE_POLL_INTERVAL_MS = 2000
-const IDLE_POLL_INTERVALS_MS = [5000, 10000, 30000] as const
 
-export function useSessionEvents(sessionId: string, hasPendingDelivery = false) {
+export function useSessionEvents(
+  sessionId: string,
+  hasPendingDelivery = false,
+  deliveryVersion = 0,
+) {
   const [events, setEvents] = useState<SessionEventProjection[]>([])
   const [snapshotSessionId, setSnapshotSessionId] = useState(sessionId)
   const seenRef = useRef<Set<string> | null>(null)
@@ -77,7 +80,6 @@ export function useSessionEvents(sessionId: string, hasPendingDelivery = false) 
 
     let cancelled = false
     let polling = false
-    let quietPolls = 0
     let timer: number | null = null
 
     const clearTimer = () => {
@@ -87,26 +89,19 @@ export function useSessionEvents(sessionId: string, hasPendingDelivery = false) 
       }
     }
 
-    const nextIdleDelay = () => {
-      const index = Math.min(
-        Math.max(quietPolls - 1, 0),
-        IDLE_POLL_INTERVALS_MS.length - 1,
-      )
-      return IDLE_POLL_INTERVALS_MS[index]
-    }
-
     const schedule = () => {
       clearTimer()
       if (
         cancelled ||
         !sessionId ||
+        !hasPendingDelivery ||
         document.visibilityState !== 'visible'
       ) {
         return
       }
       timer = window.setTimeout(
         () => { void poll() },
-        hasPendingDelivery ? ACTIVE_POLL_INTERVAL_MS : nextIdleDelay(),
+        ACTIVE_POLL_INTERVAL_MS,
       )
     }
 
@@ -115,12 +110,7 @@ export function useSessionEvents(sessionId: string, hasPendingDelivery = false) 
       polling = true
       clearTimer()
       try {
-        const changed = await refresh()
-        if (hasPendingDelivery || changed) {
-          quietPolls = 0
-        } else {
-          quietPolls += 1
-        }
+        await refresh()
       } finally {
         polling = false
         schedule()
@@ -132,11 +122,11 @@ export function useSessionEvents(sessionId: string, hasPendingDelivery = false) 
         clearTimer()
         return
       }
-      quietPolls = 0
       void poll()
     }
 
-    // Baseline the session immediately. Subsequent reads are adaptive.
+    // Baseline immediately. After that, poll only while a producer has
+    // explicitly reported that a durable delivery is pending.
     void poll()
     document.addEventListener('visibilitychange', wake)
     window.addEventListener('focus', wake)
@@ -147,7 +137,7 @@ export function useSessionEvents(sessionId: string, hasPendingDelivery = false) 
       document.removeEventListener('visibilitychange', wake)
       window.removeEventListener('focus', wake)
     }
-  }, [hasPendingDelivery, refresh, sessionId])
+  }, [deliveryVersion, hasPendingDelivery, refresh, sessionId])
 
   return {
     events: snapshotSessionId === sessionId ? events : [],

--- a/chatbot-app/frontend/src/hooks/useSessionEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useSessionEvents.ts
@@ -2,18 +2,20 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { apiFetch } from '@/lib/api-client'
 import type { SessionEventProjection } from '@/lib/session-events'
 
-const POLL_INTERVAL_MS = 2000
+const ACTIVE_POLL_INTERVAL_MS = 2000
+const IDLE_POLL_INTERVALS_MS = [5000, 10000, 30000] as const
 
-export function useSessionEvents(sessionId: string) {
+export function useSessionEvents(sessionId: string, hasPendingDelivery = false) {
   const [events, setEvents] = useState<SessionEventProjection[]>([])
   const [snapshotSessionId, setSnapshotSessionId] = useState(sessionId)
   const seenRef = useRef<Set<string> | null>(null)
+  const currentEventIdsRef = useRef<Set<string>>(new Set())
   const refreshingRef = useRef(false)
   const sessionRef = useRef(sessionId)
   sessionRef.current = sessionId
 
-  const refresh = useCallback(async () => {
-    if (!sessionId || refreshingRef.current) return
+  const refresh = useCallback(async (): Promise<boolean> => {
+    if (!sessionId || refreshingRef.current) return false
     const requestedSessionId = sessionId
     refreshingRef.current = true
     try {
@@ -21,12 +23,18 @@ export function useSessionEvents(sessionId: string) {
         `session/events?session_id=${encodeURIComponent(sessionId)}`,
         { cache: 'no-store' },
       )
-      if (!response.ok) return
+      if (!response.ok) return false
       const data = await response.json()
-      if (sessionRef.current !== requestedSessionId) return
+      if (sessionRef.current !== requestedSessionId) return false
       const next: SessionEventProjection[] = Array.isArray(data.events)
         ? data.events
         : []
+      const nextIds = new Set(next.map(item => item.eventId))
+      const previousIds = currentEventIdsRef.current
+      const snapshotChanged =
+        nextIds.size !== previousIds.size ||
+        [...nextIds].some(eventId => !previousIds.has(eventId))
+      currentEventIdsRef.current = nextIds
 
       if (seenRef.current === null) {
         seenRef.current = new Set(next.map(item => item.eventId))
@@ -35,7 +43,7 @@ export function useSessionEvents(sessionId: string) {
         // a completion committed between the two reads cannot be lost.
         setSnapshotSessionId(requestedSessionId)
         setEvents(next)
-        return
+        return snapshotChanged
       }
 
       const discovered = next.filter(item => !seenRef.current!.has(item.eventId))
@@ -52,6 +60,9 @@ export function useSessionEvents(sessionId: string) {
         }
         return [...retained, ...discovered]
       })
+      return snapshotChanged
+    } catch {
+      return false
     } finally {
       refreshingRef.current = false
     }
@@ -59,16 +70,84 @@ export function useSessionEvents(sessionId: string) {
 
   useEffect(() => {
     seenRef.current = null
+    currentEventIdsRef.current = new Set()
     refreshingRef.current = false
     setSnapshotSessionId(sessionId)
     setEvents([])
-    void refresh()
 
-    const timer = window.setInterval(() => {
-      if (document.visibilityState === 'visible') void refresh()
-    }, POLL_INTERVAL_MS)
-    return () => window.clearInterval(timer)
-  }, [refresh])
+    let cancelled = false
+    let polling = false
+    let quietPolls = 0
+    let timer: number | null = null
+
+    const clearTimer = () => {
+      if (timer !== null) {
+        window.clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    const nextIdleDelay = () => {
+      const index = Math.min(
+        Math.max(quietPolls - 1, 0),
+        IDLE_POLL_INTERVALS_MS.length - 1,
+      )
+      return IDLE_POLL_INTERVALS_MS[index]
+    }
+
+    const schedule = () => {
+      clearTimer()
+      if (
+        cancelled ||
+        !sessionId ||
+        document.visibilityState !== 'visible'
+      ) {
+        return
+      }
+      timer = window.setTimeout(
+        () => { void poll() },
+        hasPendingDelivery ? ACTIVE_POLL_INTERVAL_MS : nextIdleDelay(),
+      )
+    }
+
+    const poll = async () => {
+      if (cancelled || polling) return
+      polling = true
+      clearTimer()
+      try {
+        const changed = await refresh()
+        if (hasPendingDelivery || changed) {
+          quietPolls = 0
+        } else {
+          quietPolls += 1
+        }
+      } finally {
+        polling = false
+        schedule()
+      }
+    }
+
+    const wake = () => {
+      if (document.visibilityState !== 'visible') {
+        clearTimer()
+        return
+      }
+      quietPolls = 0
+      void poll()
+    }
+
+    // Baseline the session immediately. Subsequent reads are adaptive.
+    void poll()
+    document.addEventListener('visibilitychange', wake)
+    window.addEventListener('focus', wake)
+
+    return () => {
+      cancelled = true
+      clearTimer()
+      document.removeEventListener('visibilitychange', wake)
+      window.removeEventListener('focus', wake)
+    }
+  }, [hasPendingDelivery, refresh, sessionId])
 
   return {
     events: snapshotSessionId === sessionId ? events : [],

--- a/chatbot-app/frontend/src/hooks/useSessionEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useSessionEvents.ts
@@ -129,13 +129,11 @@ export function useSessionEvents(
     // explicitly reported that a durable delivery is pending.
     void poll()
     document.addEventListener('visibilitychange', wake)
-    window.addEventListener('focus', wake)
 
     return () => {
       cancelled = true
       clearTimer()
       document.removeEventListener('visibilitychange', wake)
-      window.removeEventListener('focus', wake)
     }
   }, [deliveryVersion, hasPendingDelivery, refresh, sessionId])
 

--- a/chatbot-app/frontend/src/hooks/useSessionEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useSessionEvents.ts
@@ -8,11 +8,13 @@ export function useSessionEvents(
   sessionId: string,
   hasPendingDelivery = false,
   deliveryVersion = 0,
+  refreshVersion = 0,
 ) {
   const [events, setEvents] = useState<SessionEventProjection[]>([])
   const [snapshotSessionId, setSnapshotSessionId] = useState(sessionId)
   const seenRef = useRef<Set<string> | null>(null)
-  const currentEventIdsRef = useRef<Set<string>>(new Set())
+  const cursorRef = useRef<string | null>(null)
+  const conversationEpochRef = useRef<number | null>(null)
   const refreshingRef = useRef(false)
   const sessionRef = useRef(sessionId)
   sessionRef.current = sessionId
@@ -22,48 +24,56 @@ export function useSessionEvents(
     const requestedSessionId = sessionId
     refreshingRef.current = true
     try {
-      const response = await apiFetch(
-        `session/events?session_id=${encodeURIComponent(sessionId)}`,
-        { cache: 'no-store' },
-      )
-      if (!response.ok) return false
-      const data = await response.json()
-      if (sessionRef.current !== requestedSessionId) return false
-      const next: SessionEventProjection[] = Array.isArray(data.events)
-        ? data.events
-        : []
-      const nextIds = new Set(next.map(item => item.eventId))
-      const previousIds = currentEventIdsRef.current
-      const snapshotChanged =
-        nextIds.size !== previousIds.size ||
-        [...nextIds].some(eventId => !previousIds.has(eventId))
-      currentEventIdsRef.current = nextIds
+      const collected: SessionEventProjection[] = []
+      let cursor = cursorRef.current
+      let epoch = conversationEpochRef.current
+      let hasMore = false
+      let epochChanged = false
+      do {
+        const params = new URLSearchParams({ session_id: sessionId })
+        if (cursor) params.set('cursor', cursor)
+        if (epoch !== null) params.set('epoch', String(epoch))
+        const response = await apiFetch(
+          `session/events?${params.toString()}`,
+          { cache: 'no-store' },
+        )
+        if (!response.ok) return false
+        const data = await response.json()
+        if (sessionRef.current !== requestedSessionId) return false
+        const pageEpoch = Number.isFinite(Number(data.conversationEpoch))
+          ? Number(data.conversationEpoch)
+          : epoch ?? 0
+        if (epoch !== null && pageEpoch !== epoch) {
+          epochChanged = true
+          collected.length = 0
+        }
+        epoch = pageEpoch
+        collected.push(
+          ...(Array.isArray(data.events) ? data.events : []),
+        )
+        cursor = typeof data.cursor === 'string' ? data.cursor : cursor
+        hasMore = data.hasMore === true
+      } while (hasMore)
 
-      if (seenRef.current === null) {
-        seenRef.current = new Set(next.map(item => item.eventId))
-        // The history request and this first projection read are independent.
-        // Let the consumer suppress events already represented by history so
-        // a completion committed between the two reads cannot be lost.
+      cursorRef.current = cursor
+      conversationEpochRef.current = epoch
+      if (seenRef.current === null || epochChanged) {
+        seenRef.current = new Set(collected.map(item => item.eventId))
         setSnapshotSessionId(requestedSessionId)
-        setEvents(next)
-        return snapshotChanged
+        setEvents(collected)
+        return collected.length > 0 || epochChanged
       }
 
-      const discovered = next.filter(item => !seenRef.current!.has(item.eventId))
+      const discovered = collected.filter(
+        item => !seenRef.current!.has(item.eventId),
+      )
       discovered.forEach(item => seenRef.current!.add(item.eventId))
-      const durableIds = new Set(next.map(item => item.eventId))
       setSnapshotSessionId(requestedSessionId)
       setEvents(current => {
-        const retained = current.filter(item => durableIds.has(item.eventId))
-        if (
-          discovered.length === 0 &&
-          retained.length === current.length
-        ) {
-          return current
-        }
-        return [...retained, ...discovered]
+        if (discovered.length === 0) return current
+        return [...current, ...discovered]
       })
-      return snapshotChanged
+      return discovered.length > 0
     } catch {
       return false
     } finally {
@@ -73,7 +83,8 @@ export function useSessionEvents(
 
   useEffect(() => {
     seenRef.current = null
-    currentEventIdsRef.current = new Set()
+    cursorRef.current = null
+    conversationEpochRef.current = null
     refreshingRef.current = false
     setSnapshotSessionId(sessionId)
     setEvents([])
@@ -135,7 +146,13 @@ export function useSessionEvents(
       clearTimer()
       document.removeEventListener('visibilitychange', wake)
     }
-  }, [deliveryVersion, hasPendingDelivery, refresh, sessionId])
+  }, [
+    deliveryVersion,
+    hasPendingDelivery,
+    refresh,
+    refreshVersion,
+    sessionId,
+  ])
 
   return {
     events: snapshotSessionId === sessionId ? events : [],

--- a/chatbot-app/frontend/src/hooks/useStreamEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useStreamEvents.ts
@@ -91,6 +91,30 @@ export const useStreamEvents = ({
   // not at initialization, to avoid stale closure issues with streamingIdRef
   const textBuffer = useTextBuffer({ flushInterval: 50 })
 
+  const updateToolExecution = useCallback((
+    toolCallId: string,
+    update: (tool: ToolExecution) => ToolExecution,
+  ) => {
+    const updatedExecutions = currentToolExecutionsRef.current.map(tool =>
+      tool.id === toolCallId ? update(tool) : tool
+    )
+    currentToolExecutionsRef.current = updatedExecutions
+
+    setSessionState(prev => ({
+      ...prev,
+      toolExecutions: updatedExecutions,
+    }))
+    setMessages(prevMessages => prevMessages.map(message => {
+      if (!message.isToolMessage || !message.toolExecutions) return message
+      return {
+        ...message,
+        toolExecutions: message.toolExecutions.map(tool =>
+          tool.id === toolCallId ? update(tool) : tool
+        ),
+      }
+    }))
+  }, [currentToolExecutionsRef, setMessages, setSessionState])
+
   const consumeAssistantTurnBoundary = useCallback(() => {
     if (!pendingAssistantTurnBoundaryRef.current) return {}
     pendingAssistantTurnBoundaryRef.current = false
@@ -371,6 +395,8 @@ export const useStreamEvents = ({
         id: event.toolCallId,
         toolName: event.toolCallName,
         toolInput: normalizedInput,
+        toolInputRaw: '',
+        toolInputState: 'streaming',
         reasoning: [],
         isComplete: false,
         isExpanded: true
@@ -404,8 +430,23 @@ export const useStreamEvents = ({
 
   const handleToolCallArgsEvent = useCallback((event: ToolCallArgsEvent) => {
     const current = toolInputAccumulatorRef.current[event.toolCallId] || ''
-    toolInputAccumulatorRef.current[event.toolCallId] = current + event.delta
-  }, [toolInputAccumulatorRef])
+    const accumulated = current + event.delta
+    toolInputAccumulatorRef.current[event.toolCallId] = accumulated
+
+    let parsedInput: any
+    try {
+      parsedInput = JSON.parse(accumulated)
+    } catch {
+      parsedInput = undefined
+    }
+
+    updateToolExecution(event.toolCallId, tool => ({
+      ...tool,
+      ...(parsedInput === undefined ? {} : { toolInput: parsedInput }),
+      toolInputRaw: accumulated,
+      toolInputState: 'streaming',
+    }))
+  }, [toolInputAccumulatorRef, updateToolExecution])
 
   const handleToolCallEndEvent = useCallback((event: ToolCallEndEvent) => {
     const accumulated = toolInputAccumulatorRef.current[event.toolCallId] || ''
@@ -420,26 +461,55 @@ export const useStreamEvents = ({
 
     const normalizedInput = parsedInput === null || parsedInput === undefined ? {} : parsedInput
 
-    const updatedExecutions = currentToolExecutionsRef.current.map(tool =>
-      tool.id === event.toolCallId ? { ...tool, toolInput: normalizedInput } : tool
-    )
-    currentToolExecutionsRef.current = updatedExecutions
-
-    setSessionState(prev => ({
-      ...prev,
-      toolExecutions: updatedExecutions
+    updateToolExecution(event.toolCallId, tool => ({
+      ...tool,
+      toolInput: normalizedInput,
+      toolInputRaw: accumulated,
+      toolInputState: 'complete',
     }))
+  }, [toolInputAccumulatorRef, updateToolExecution])
 
-    setMessages(prevMessages => prevMessages.map(msg => {
-      if (msg.isToolMessage && msg.toolExecutions) {
-        const updatedToolExecutions = msg.toolExecutions.map(tool =>
-          tool.id === event.toolCallId ? { ...tool, toolInput: normalizedInput } : tool
-        )
-        return { ...msg, toolExecutions: updatedToolExecutions }
+  const handleToolCallNameUpdateEvent = useCallback((event: CustomEvent) => {
+    const value = (event as any).value
+    const toolCallId = value?.toolCallId
+    const toolCallName = value?.toolCallName
+    if (!toolCallId || !toolCallName) return
+
+    if (swarmModeRef.current.isActive && swarmModeRef.current.agentSteps.length > 0) {
+      const stepIndex = swarmModeRef.current.agentSteps.length - 1
+      const currentStep = swarmModeRef.current.agentSteps[stepIndex]
+      const toolCalls = [...(currentStep.toolCalls || [])]
+      let runningIndex = -1
+      for (let index = toolCalls.length - 1; index >= 0; index -= 1) {
+        if (toolCalls[index].status === 'running') {
+          runningIndex = index
+          break
+        }
       }
-      return msg
+      if (runningIndex >= 0) {
+        toolCalls[runningIndex] = {
+          ...toolCalls[runningIndex],
+          toolName: toolCallName,
+        }
+        swarmModeRef.current.agentSteps[stepIndex] = {
+          ...currentStep,
+          toolCalls,
+        }
+      }
+    }
+
+    updateToolExecution(toolCallId, tool => ({
+      ...tool,
+      toolName: toolCallName,
     }))
-  }, [toolInputAccumulatorRef, currentToolExecutionsRef, setSessionState, setMessages])
+    if (isA2ATool(toolCallName) && sessionId && startPollingRef.current) {
+      startPollingRef.current(sessionId)
+    }
+    setUIState(prev => ({
+      ...prev,
+      agentStatus: getAgentStatusForTool(toolCallName),
+    }))
+  }, [sessionId, setUIState, startPollingRef, updateToolExecution])
 
   const handleToolCallResultEvent = useCallback((event: ToolCallResultEvent) => {
     // AG-UI: content is a JSON string: '{"result":"...","metadata":{...},"images":[...],"status":"..."}'
@@ -544,7 +614,15 @@ export const useStreamEvents = ({
 
     const updatedExecutions = currentToolExecutionsRef.current.map(tool =>
       tool.id === event.toolCallId
-        ? { ...tool, toolResult: toolOutput, metadata: toolMetadata, images: filteredImages, isComplete: true, isCancelled }
+        ? {
+            ...tool,
+            toolInputState: 'complete' as const,
+            toolResult: toolOutput,
+            metadata: toolMetadata,
+            images: filteredImages,
+            isComplete: true,
+            isCancelled,
+          }
         : tool
     )
 
@@ -584,7 +662,14 @@ export const useStreamEvents = ({
         if (msg.isToolMessage && msg.toolExecutions) {
           const updatedToolExecutions = msg.toolExecutions.map(tool =>
             tool.id === event.toolCallId
-              ? { ...tool, toolResult: toolOutput, metadata: toolMetadata, images: filteredImages, isComplete: true }
+              ? {
+                  ...tool,
+                  toolInputState: 'complete' as const,
+                  toolResult: toolOutput,
+                  metadata: toolMetadata,
+                  images: filteredImages,
+                  isComplete: true,
+                }
               : tool
           )
           return {
@@ -1511,6 +1596,9 @@ export const useStreamEvents = ({
             case 'reasoning':
               handleReasoningEvent(customEvent)
               break
+            case 'tool_call_name_update':
+              handleToolCallNameUpdateEvent(customEvent)
+              break
             case 'interrupt':
               handleInterruptEvent(customEvent)
               break
@@ -1607,6 +1695,7 @@ export const useStreamEvents = ({
     handleToolCallStartEvent,
     handleToolCallArgsEvent,
     handleToolCallEndEvent,
+    handleToolCallNameUpdateEvent,
     handleToolCallResultEvent,
     handleCompleteEvent,
     handleInitEvent,

--- a/chatbot-app/frontend/src/lib/base64.ts
+++ b/chatbot-app/frontend/src/lib/base64.ts
@@ -1,0 +1,15 @@
+const BASE64_CHUNK_SIZE = 0x8000
+
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  const chunks: string[] = []
+
+  for (let offset = 0; offset < bytes.length; offset += BASE64_CHUNK_SIZE) {
+    chunks.push(String.fromCharCode(...bytes.subarray(
+      offset,
+      Math.min(offset + BASE64_CHUNK_SIZE, bytes.length),
+    )))
+  }
+
+  return btoa(chunks.join(''))
+}

--- a/chatbot-app/frontend/src/lib/research-jobs.ts
+++ b/chatbot-app/frontend/src/lib/research-jobs.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import {
   DynamoDBClient,
+  GetItemCommand,
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
@@ -36,6 +37,7 @@ export interface ResearchJob {
   deliveredAt?: string
   error?: string
   deliveryError?: string
+  conversationEpoch?: number
   progress?: {
     stepNumber: number
     content: string
@@ -48,6 +50,33 @@ export interface ResearchJob {
 
 function validSessionId(sessionId: string): boolean {
   return /^[a-zA-Z0-9_-]+$/.test(sessionId)
+}
+
+function legacyJobReadsEnabled(): boolean {
+  return (
+    !ORCHESTRATION_TABLE_NAME ||
+    process.env.RESEARCH_JOB_LEGACY_READ_ENABLED === 'true'
+  )
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  operation: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++
+        results[index] = await operation(items[index])
+      }
+    },
+  )
+  await Promise.all(workers)
+  return results
 }
 
 async function bodyToString(body: any): Promise<string> {
@@ -143,26 +172,88 @@ async function readCloudJobs(sessionId: string, userId: string): Promise<Researc
     } while (exclusiveStartKey)
   }
 
-  let legacyStartKey: Record<string, any> | undefined
-  do {
-    const response = await client.send(new QueryCommand({
-      TableName: USERS_TABLE_NAME,
-      KeyConditionExpression: 'userId = :userId AND begins_with(sk, :prefix)',
-      ExpressionAttributeValues: {
-        ':userId': { S: userId },
-        ':prefix': { S: `RESEARCH_JOB#${sessionId}#` },
-      },
-      ConsistentRead: true,
-      ExclusiveStartKey: legacyStartKey,
-    }))
-    for (const item of response.Items || []) {
-      const job = unmarshall(item) as ResearchJob
-      if (!jobsById.has(job.jobId)) jobsById.set(job.jobId, job)
-    }
-    legacyStartKey = response.LastEvaluatedKey
-  } while (legacyStartKey)
+  if (legacyJobReadsEnabled()) {
+    let legacyStartKey: Record<string, any> | undefined
+    do {
+      const response = await client.send(new QueryCommand({
+        TableName: USERS_TABLE_NAME,
+        KeyConditionExpression: 'userId = :userId AND begins_with(sk, :prefix)',
+        ExpressionAttributeValues: {
+          ':userId': { S: userId },
+          ':prefix': { S: `RESEARCH_JOB#${sessionId}#` },
+        },
+        ConsistentRead: true,
+        ExclusiveStartKey: legacyStartKey,
+      }))
+      for (const item of response.Items || []) {
+        const job = unmarshall(item) as ResearchJob
+        if (!jobsById.has(job.jobId)) jobsById.set(job.jobId, job)
+      }
+      legacyStartKey = response.LastEvaluatedKey
+    } while (legacyStartKey)
+  }
 
   return Array.from(jobsById.values())
+}
+
+export async function getResearchJob(
+  userId: string,
+  sessionId: string,
+  jobId: string,
+  options: { includeContent?: boolean } = {},
+): Promise<ResearchJob | null> {
+  let job: ResearchJob | null = null
+  if (IS_LOCAL || userId === 'anonymous') {
+    job = readLocalJobs(sessionId, userId)
+      .find(item => item.jobId === jobId) || null
+  } else {
+    const client = new DynamoDBClient({ region: AWS_REGION })
+    if (ORCHESTRATION_TABLE_NAME) {
+      const response = await client.send(new GetItemCommand({
+        TableName: ORCHESTRATION_TABLE_NAME,
+        Key: {
+          sessionKey: { S: `USER#${userId}#SESSION#${sessionId}` },
+          recordKey: { S: `JOB#${jobId}` },
+        },
+        ConsistentRead: true,
+      }))
+      if (response.Item) job = unmarshall(response.Item) as ResearchJob
+    }
+    if (!job && legacyJobReadsEnabled()) {
+      const response = await client.send(new GetItemCommand({
+        TableName: USERS_TABLE_NAME,
+        Key: {
+          userId: { S: userId },
+          sk: { S: `RESEARCH_JOB#${sessionId}#${jobId}` },
+        },
+        ConsistentRead: true,
+      }))
+      if (response.Item) job = unmarshall(response.Item) as ResearchJob
+    }
+  }
+
+  if (!job || !options.includeContent) return job
+  try {
+    return await hydrateArtifact(job)
+  } catch (error) {
+    console.error(`[ResearchJobs] Failed to hydrate ${job.jobId}:`, error)
+    return job
+  }
+}
+
+export async function getResearchJobs(
+  userId: string,
+  sessionId: string,
+  jobIds: string[],
+  options: { includeContent?: boolean } = {},
+): Promise<ResearchJob[]> {
+  const uniqueIds = Array.from(new Set(jobIds)).slice(0, 100)
+  const jobs = await mapWithConcurrency(uniqueIds, 10, jobId =>
+    getResearchJob(userId, sessionId, jobId, options),
+  )
+  return jobs
+    .filter((job): job is ResearchJob => job !== null)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
 }
 
 export async function listResearchJobs(
@@ -178,14 +269,14 @@ export async function listResearchJobs(
     return jobs.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
   }
 
-  const hydrated = await Promise.all(jobs.map(async job => {
+  const hydrated = await mapWithConcurrency(jobs, 4, async job => {
     try {
       return await hydrateArtifact(job)
     } catch (error) {
       console.error(`[ResearchJobs] Failed to hydrate ${job.jobId}:`, error)
       return job
     }
-  }))
+  })
   return hydrated.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
 }
 

--- a/chatbot-app/frontend/src/lib/session-events.ts
+++ b/chatbot-app/frontend/src/lib/session-events.ts
@@ -1,9 +1,9 @@
 import fs from 'fs'
 import path from 'path'
-import { createHash, randomUUID } from 'crypto'
+import { createHash } from 'crypto'
 import {
-  DeleteItemCommand,
   DynamoDBClient,
+  GetItemCommand,
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
@@ -12,6 +12,9 @@ const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 const AWS_REGION =
   process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
 const TABLE_NAME = process.env.SESSION_ORCHESTRATION_TABLE || ''
+const STREAM_PREFIX = 'OUTBOX_V2#'
+const LEGACY_PREFIX = 'OUTBOX#'
+const PAGE_SIZE = 100
 
 export interface SessionEventProjection {
   schemaVersion: number
@@ -21,116 +24,257 @@ export interface SessionEventProjection {
   userId: string
   createdAt: string
   originEventId: string
+  conversationEpoch?: number
   correlation: Record<string, string>
   payload: Record<string, any>
+}
+
+export interface SessionEventPage {
+  events: SessionEventProjection[]
+  cursor: string
+  conversationEpoch: number
+  hasMore: boolean
 }
 
 function sessionKey(userId: string, sessionId: string): string {
   return `USER#${userId}#SESSION#${sessionId}`
 }
 
-function readLocalEvents(
-  userId: string,
-  sessionId: string,
-): SessionEventProjection[] {
+function localMailboxPath(userId: string, sessionId: string): string {
   const digest = createHash('sha256')
     .update(sessionKey(userId, sessionId))
     .digest('hex')
-  const mailboxDir = path.resolve(process.cwd(), '..', 'agentcore', 'sessions', 'mailbox')
-  const mailboxPath = path.resolve(mailboxDir, `${digest}.json`)
-  if (!mailboxPath.startsWith(mailboxDir + path.sep) || !fs.existsSync(mailboxPath)) {
-    return []
+  return path.resolve(
+    process.cwd(),
+    '..',
+    'agentcore',
+    'sessions',
+    'mailbox',
+    `${digest}.json`,
+  )
+}
+
+function projectionCursor(event: SessionEventProjection): string {
+  return `${STREAM_PREFIX}${event.createdAt}#${event.eventId}`
+}
+
+function readLocalPage(
+  userId: string,
+  sessionId: string,
+  cursor?: string,
+  knownEpoch?: number,
+): SessionEventPage {
+  const targetPath = localMailboxPath(userId, sessionId)
+  if (!fs.existsSync(targetPath)) {
+    return {
+      events: [],
+      cursor: cursor || STREAM_PREFIX,
+      conversationEpoch: 0,
+      hasMore: false,
+    }
   }
 
   try {
-    const data = JSON.parse(fs.readFileSync(mailboxPath, 'utf-8'))
-    return Object.values(data.sessionEvents || {}) as SessionEventProjection[]
+    const data = JSON.parse(fs.readFileSync(targetPath, 'utf-8'))
+    const conversationEpoch = Number(data.state?.conversationEpoch || 0)
+    const epochChanged =
+      knownEpoch !== undefined && knownEpoch !== conversationEpoch
+    const effectiveCursor = epochChanged ? undefined : cursor
+    const events = Object.values(
+      data.sessionEvents || {},
+    ) as SessionEventProjection[]
+    const sorted = events.sort(
+      (left, right) =>
+        left.createdAt.localeCompare(right.createdAt) ||
+        left.eventId.localeCompare(right.eventId),
+    )
+    const page = sorted
+      .filter(event =>
+        !effectiveCursor || projectionCursor(event) > effectiveCursor,
+      )
+      .slice(0, PAGE_SIZE)
+    return {
+      events: page,
+      cursor:
+        page.length > 0
+          ? projectionCursor(page[page.length - 1])
+          : effectiveCursor || STREAM_PREFIX,
+      conversationEpoch,
+      hasMore:
+        sorted.some(event =>
+          projectionCursor(event) >
+          (page.length > 0
+            ? projectionCursor(page[page.length - 1])
+            : effectiveCursor || STREAM_PREFIX),
+        ),
+    }
   } catch {
-    return []
+    return {
+      events: [],
+      cursor: cursor || STREAM_PREFIX,
+      conversationEpoch: 0,
+      hasMore: false,
+    }
   }
 }
 
-async function readCloudEvents(
+async function readConversationEpoch(
+  client: DynamoDBClient,
   userId: string,
   sessionId: string,
-): Promise<SessionEventProjection[]> {
-  if (!TABLE_NAME) return []
+): Promise<number> {
+  const response = await client.send(new GetItemCommand({
+    TableName: TABLE_NAME,
+    Key: {
+      sessionKey: { S: sessionKey(userId, sessionId) },
+      recordKey: { S: 'STATE' },
+    },
+    ConsistentRead: true,
+    ProjectionExpression: 'conversationEpoch',
+  }))
+  if (!response.Item) return 0
+  return Number(unmarshall(response.Item).conversationEpoch || 0)
+}
+
+export async function getSessionConversationEpoch(
+  userId: string,
+  sessionId: string,
+): Promise<number> {
+  if (IS_LOCAL || userId === 'anonymous') {
+    const targetPath = localMailboxPath(userId, sessionId)
+    if (!fs.existsSync(targetPath)) return 0
+    const data = JSON.parse(fs.readFileSync(targetPath, 'utf-8'))
+    return Number(data.state?.conversationEpoch || 0)
+  }
+  if (!TABLE_NAME) return 0
+  return readConversationEpoch(
+    new DynamoDBClient({ region: AWS_REGION }),
+    userId,
+    sessionId,
+  )
+}
+
+async function queryPrefix(
+  client: DynamoDBClient,
+  userId: string,
+  sessionId: string,
+  prefix: string,
+  cursor?: string,
+  limit?: number,
+) {
+  const response = await client.send(new QueryCommand({
+    TableName: TABLE_NAME,
+    KeyConditionExpression:
+      'sessionKey = :sessionKey AND begins_with(recordKey, :prefix)',
+    ExpressionAttributeValues: {
+      ':sessionKey': { S: sessionKey(userId, sessionId) },
+      ':prefix': { S: prefix },
+    },
+    ConsistentRead: true,
+    ExclusiveStartKey:
+      cursor && cursor !== STREAM_PREFIX
+        ? {
+            sessionKey: { S: sessionKey(userId, sessionId) },
+            recordKey: { S: cursor },
+          }
+        : undefined,
+    Limit: limit,
+  }))
+  return {
+    events: (response.Items || []).map(
+      item => unmarshall(item) as SessionEventProjection,
+    ),
+    lastKey: response.LastEvaluatedKey?.recordKey?.S,
+  }
+}
+
+async function readCloudPage(
+  userId: string,
+  sessionId: string,
+  cursor?: string,
+  knownEpoch?: number,
+): Promise<SessionEventPage> {
+  if (!TABLE_NAME) {
+    return {
+      events: [],
+      cursor: cursor || STREAM_PREFIX,
+      conversationEpoch: 0,
+      hasMore: false,
+    }
+  }
 
   const client = new DynamoDBClient({ region: AWS_REGION })
-  const events: SessionEventProjection[] = []
-  let exclusiveStartKey: Record<string, any> | undefined
-  do {
-    const response = await client.send(new QueryCommand({
-      TableName: TABLE_NAME,
-      KeyConditionExpression:
-        'sessionKey = :sessionKey AND begins_with(recordKey, :prefix)',
-      ExpressionAttributeValues: {
-        ':sessionKey': { S: sessionKey(userId, sessionId) },
-        ':prefix': { S: 'OUTBOX#' },
-      },
-      ConsistentRead: true,
-      ExclusiveStartKey: exclusiveStartKey,
-    }))
-    events.push(
-      ...(response.Items || []).map(
-        item => unmarshall(item) as SessionEventProjection,
-      ),
-    )
-    exclusiveStartKey = response.LastEvaluatedKey
-  } while (exclusiveStartKey)
+  const conversationEpoch = await readConversationEpoch(
+    client,
+    userId,
+    sessionId,
+  )
+  const epochChanged =
+    knownEpoch !== undefined && knownEpoch !== conversationEpoch
+  const effectiveCursor = epochChanged ? undefined : cursor
+  const streamPage = await queryPrefix(
+    client,
+    userId,
+    sessionId,
+    STREAM_PREFIX,
+    effectiveCursor,
+    PAGE_SIZE,
+  )
 
-  return events
+  let events = streamPage.events
+  if (!effectiveCursor) {
+    const legacy: SessionEventProjection[] = []
+    let legacyCursor: string | undefined
+    do {
+      const page = await queryPrefix(
+        client,
+        userId,
+        sessionId,
+        LEGACY_PREFIX,
+        legacyCursor,
+      )
+      legacy.push(...page.events)
+      legacyCursor = page.lastKey
+    } while (legacyCursor)
+    events = [...legacy, ...events]
+  }
+
+  events.sort(
+    (left, right) =>
+      left.createdAt.localeCompare(right.createdAt) ||
+      left.eventId.localeCompare(right.eventId),
+  )
+  const lastStreamEvent = streamPage.events[streamPage.events.length - 1]
+  return {
+    events,
+    cursor:
+      lastStreamEvent
+        ? projectionCursor(lastStreamEvent)
+        : effectiveCursor || STREAM_PREFIX,
+    conversationEpoch,
+    hasMore: Boolean(streamPage.lastKey),
+  }
 }
 
 export async function listSessionEvents(
   userId: string,
   sessionId: string,
-): Promise<SessionEventProjection[]> {
-  const events = (IS_LOCAL || userId === 'anonymous')
-    ? readLocalEvents(userId, sessionId)
-    : await readCloudEvents(userId, sessionId)
-  return events.sort(
-    (left, right) =>
-      left.createdAt.localeCompare(right.createdAt) ||
-      left.eventId.localeCompare(right.eventId),
-  )
-}
-
-export async function deleteSessionEventProjection(
-  userId: string,
-  sessionId: string,
-  eventId: string,
-): Promise<void> {
-  if (IS_LOCAL || userId === 'anonymous') {
-    const digest = createHash('sha256')
-      .update(sessionKey(userId, sessionId))
-      .digest('hex')
-    const mailboxDir = path.resolve(
-      process.cwd(),
-      '..',
-      'agentcore',
-      'sessions',
-      'mailbox',
-    )
-    const mailboxPath = path.resolve(mailboxDir, `${digest}.json`)
-    if (!mailboxPath.startsWith(mailboxDir + path.sep) || !fs.existsSync(mailboxPath)) {
-      return
-    }
-    const data = JSON.parse(fs.readFileSync(mailboxPath, 'utf-8'))
-    if (!data.sessionEvents?.[eventId]) return
-    delete data.sessionEvents[eventId]
-    const temporaryPath = `${mailboxPath}.${randomUUID()}.tmp`
-    fs.writeFileSync(temporaryPath, JSON.stringify(data, null, 2))
-    fs.renameSync(temporaryPath, mailboxPath)
-    return
-  }
-
-  if (!TABLE_NAME) return
-  await new DynamoDBClient({ region: AWS_REGION }).send(new DeleteItemCommand({
-    TableName: TABLE_NAME,
-    Key: {
-      sessionKey: { S: sessionKey(userId, sessionId) },
-      recordKey: { S: `OUTBOX#${eventId}` },
-    },
-  }))
+  options: {
+    cursor?: string
+    knownEpoch?: number
+  } = {},
+): Promise<SessionEventPage> {
+  return (IS_LOCAL || userId === 'anonymous')
+    ? readLocalPage(
+        userId,
+        sessionId,
+        options.cursor,
+        options.knownEpoch,
+      )
+    : readCloudPage(
+        userId,
+        sessionId,
+        options.cursor,
+        options.knownEpoch,
+      )
 }

--- a/chatbot-app/frontend/src/lib/session-lifecycle.ts
+++ b/chatbot-app/frontend/src/lib/session-lifecycle.ts
@@ -1,8 +1,14 @@
 import fs from 'fs'
 import path from 'path'
 import { createHash, randomUUID } from 'crypto'
-import { DynamoDBClient, UpdateItemCommand } from '@aws-sdk/client-dynamodb'
-import { marshall } from '@aws-sdk/util-dynamodb'
+import {
+  BatchWriteItemCommand,
+  DynamoDBClient,
+  QueryCommand,
+  UpdateItemCommand,
+  type WriteRequest,
+} from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 
 const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 const AWS_REGION =
@@ -35,9 +41,293 @@ function tombstoneLocalSession(userId: string, sessionId: string, deletedAt: str
   }
   delete data.state.leaseOwner
   delete data.state.leaseUntil
+  data.events = {}
+  data.sessionEvents = {}
   const temporaryPath = `${mailboxPath}.${randomUUID()}.tmp`
   fs.writeFileSync(temporaryPath, JSON.stringify(data, null, 2))
   fs.renameSync(temporaryPath, mailboxPath)
+}
+
+function mailboxPath(userId: string, sessionId: string): string {
+  const digest = createHash('sha256')
+    .update(sessionKey(userId, sessionId))
+    .digest('hex')
+  const mailboxDir = path.resolve(process.cwd(), '..', 'agentcore', 'sessions', 'mailbox')
+  fs.mkdirSync(mailboxDir, { recursive: true })
+  return path.resolve(mailboxDir, `${digest}.json`)
+}
+
+function writeLocalMailbox(targetPath: string, data: Record<string, any>) {
+  const temporaryPath = `${targetPath}.${randomUUID()}.tmp`
+  fs.writeFileSync(temporaryPath, JSON.stringify(data, null, 2))
+  fs.renameSync(temporaryPath, targetPath)
+}
+
+function advanceLocalConversationEpoch(
+  userId: string,
+  sessionId: string,
+  cutoff: string,
+): number {
+  const targetPath = mailboxPath(userId, sessionId)
+  const data = fs.existsSync(targetPath)
+    ? JSON.parse(fs.readFileSync(targetPath, 'utf-8'))
+    : {
+        state: { leaseEpoch: 0, version: 0, conversationEpoch: 0 },
+        events: {},
+        sessionEvents: {},
+      }
+  const updatedAt = new Date().toISOString()
+  const nextEpoch = Number(data.state?.conversationEpoch || 0) + 1
+  data.state = {
+    ...(data.state || {}),
+    conversationEpoch: nextEpoch,
+    leaseEpoch: Number(data.state?.leaseEpoch || 0) + 1,
+    truncatedAt: updatedAt,
+    updatedAt,
+  }
+  delete data.state.leaseOwner
+  delete data.state.leaseUntil
+
+  const terminalTtl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+  for (const event of Object.values(data.events || {}) as Record<string, any>[]) {
+    if (
+      Number(event.conversationEpoch || 0) < nextEpoch &&
+      ['pending', 'processing'].includes(event.status)
+    ) {
+      Object.assign(event, {
+        status: 'cancelled',
+        processedAt: updatedAt,
+        updatedAt,
+        lastError: 'Conversation truncated',
+        ttl: terminalTtl,
+      })
+      delete event.leaseOwner
+      delete event.leaseEpoch
+      delete event.eventLeaseUntil
+    }
+  }
+
+  const cutoffMs = Date.parse(cutoff)
+  for (const [eventId, event] of Object.entries(
+    data.sessionEvents || {},
+  ) as [string, Record<string, any>][]) {
+    if (Date.parse(event.createdAt) >= cutoffMs) {
+      delete data.sessionEvents[eventId]
+    }
+  }
+  writeLocalMailbox(targetPath, data)
+  return nextEpoch
+}
+
+async function queryOrchestrationRecords(
+  client: DynamoDBClient,
+  userId: string,
+  sessionId: string,
+  prefix: string,
+) {
+  const records: Array<{
+    key: Record<string, any>
+    value: Record<string, any>
+  }> = []
+  let exclusiveStartKey: Record<string, any> | undefined
+  do {
+    const response = await client.send(new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression:
+        'sessionKey = :sessionKey AND begins_with(recordKey, :prefix)',
+      ExpressionAttributeValues: marshall({
+        ':sessionKey': sessionKey(userId, sessionId),
+        ':prefix': prefix,
+      }),
+      ConsistentRead: true,
+      ExclusiveStartKey: exclusiveStartKey,
+    }))
+    for (const item of response.Items || []) {
+      records.push({
+        key: {
+          sessionKey: item.sessionKey,
+          recordKey: item.recordKey,
+        },
+        value: unmarshall(item),
+      })
+    }
+    exclusiveStartKey = response.LastEvaluatedKey
+  } while (exclusiveStartKey)
+  return records
+}
+
+async function inBatches<T>(
+  items: T[],
+  size: number,
+  operation: (item: T) => Promise<unknown>,
+) {
+  for (let index = 0; index < items.length; index += size) {
+    await Promise.all(items.slice(index, index + size).map(operation))
+  }
+}
+
+function isConditionalFailure(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name?: string }).name === 'ConditionalCheckFailedException'
+  )
+}
+
+async function ignoreConditionalFailure(
+  operation: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    await operation()
+  } catch (error) {
+    if (!isConditionalFailure(error)) throw error
+  }
+}
+
+async function deleteInBatches(
+  client: DynamoDBClient,
+  keys: Record<string, any>[],
+): Promise<void> {
+  for (let index = 0; index < keys.length; index += 25) {
+    let pending: WriteRequest[] = keys.slice(index, index + 25).map(key => ({
+      DeleteRequest: { Key: key },
+    }))
+    for (let attempt = 0; pending.length > 0 && attempt < 6; attempt++) {
+      const response = await client.send(new BatchWriteItemCommand({
+        RequestItems: { [TABLE_NAME]: pending },
+      }))
+      pending = response.UnprocessedItems?.[TABLE_NAME] || []
+      if (pending.length > 0) {
+        await new Promise(resolve =>
+          setTimeout(resolve, Math.min(1000, 50 * 2 ** attempt)),
+        )
+      }
+    }
+    if (pending.length > 0) {
+      throw new Error(
+        `Failed to delete ${pending.length} orchestration records`,
+      )
+    }
+  }
+}
+
+export async function advanceSessionConversationEpoch(
+  userId: string,
+  sessionId: string,
+  cutoff: string,
+): Promise<number> {
+  if (IS_LOCAL || userId === 'anonymous') {
+    return advanceLocalConversationEpoch(userId, sessionId, cutoff)
+  }
+  if (!TABLE_NAME) {
+    throw new Error('SESSION_ORCHESTRATION_TABLE is required for truncation')
+  }
+
+  const client = new DynamoDBClient({ region: AWS_REGION })
+  const updatedAt = new Date().toISOString()
+  const state = await client.send(new UpdateItemCommand({
+    TableName: TABLE_NAME,
+    Key: marshall({
+      sessionKey: sessionKey(userId, sessionId),
+      recordKey: 'STATE',
+    }),
+    UpdateExpression:
+      'SET conversationEpoch = if_not_exists(conversationEpoch, :zero) + :one, ' +
+      'leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, ' +
+      'truncatedAt = :updated, updatedAt = :updated ' +
+      'REMOVE leaseOwner, leaseUntil',
+    ConditionExpression: 'attribute_not_exists(deletedAt)',
+    ExpressionAttributeValues: marshall({
+      ':zero': 0,
+      ':one': 1,
+      ':updated': updatedAt,
+    }),
+    ReturnValues: 'ALL_NEW',
+  }))
+  const nextEpoch = Number(
+    state.Attributes ? unmarshall(state.Attributes).conversationEpoch : 0,
+  )
+  if (!nextEpoch) {
+    throw new Error('Failed to advance conversation epoch')
+  }
+
+  const [inbox, outboxV2, legacyOutbox, jobs] = await Promise.all([
+    queryOrchestrationRecords(client, userId, sessionId, 'INBOX#'),
+    queryOrchestrationRecords(client, userId, sessionId, 'OUTBOX_V2#'),
+    queryOrchestrationRecords(client, userId, sessionId, 'OUTBOX#'),
+    queryOrchestrationRecords(client, userId, sessionId, 'JOB#'),
+  ])
+  const outbox = [...outboxV2, ...legacyOutbox]
+  const terminalTtl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+
+  const staleInbox = inbox.filter(({ value }) =>
+    Number(value.conversationEpoch || 0) < nextEpoch &&
+    ['pending', 'processing'].includes(value.status),
+  )
+  await inBatches(staleInbox, 10, ({ key }) =>
+    ignoreConditionalFailure(() => client.send(new UpdateItemCommand({
+      TableName: TABLE_NAME,
+      Key: key,
+      UpdateExpression:
+        'SET #status = :cancelled, processedAt = :updated, updatedAt = :updated, ' +
+        'lastError = :reason, #ttl = :ttl ' +
+        'REMOVE leaseOwner, leaseEpoch, eventLeaseUntil',
+      ConditionExpression:
+        '(attribute_not_exists(conversationEpoch) OR conversationEpoch < :epoch) ' +
+        'AND (#status = :pending OR #status = :processing)',
+      ExpressionAttributeNames: {
+        '#status': 'status',
+        '#ttl': 'ttl',
+      },
+      ExpressionAttributeValues: marshall({
+        ':cancelled': 'cancelled',
+        ':updated': updatedAt,
+        ':reason': 'Conversation truncated',
+        ':ttl': terminalTtl,
+        ':epoch': nextEpoch,
+        ':pending': 'pending',
+        ':processing': 'processing',
+      }),
+    }))),
+  )
+
+  const cutoffMs = Date.parse(cutoff)
+  const staleOutbox = outbox.filter(
+    ({ value }) => Date.parse(value.createdAt) >= cutoffMs,
+  )
+  await deleteInBatches(
+    client,
+    staleOutbox.map(({ key }) => key),
+  )
+
+  const staleJobs = jobs.filter(({ value }) =>
+    Date.parse(value.createdAt) >= cutoffMs &&
+    !['cancelled', 'delivered', 'error'].includes(value.status),
+  )
+  await inBatches(staleJobs, 10, ({ key }) =>
+    ignoreConditionalFailure(() => client.send(new UpdateItemCommand({
+      TableName: TABLE_NAME,
+      Key: key,
+      UpdateExpression:
+        'SET #status = :cancelled, updatedAt = :updated, deliveryError = :reason',
+      ConditionExpression:
+        '#status = :queued OR #status = :running OR #status = :completed ' +
+        'OR #status = :delivering',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: marshall({
+        ':cancelled': 'cancelled',
+        ':updated': updatedAt,
+        ':reason': 'Conversation truncated',
+        ':queued': 'queued',
+        ':running': 'running',
+        ':completed': 'completed',
+        ':delivering': 'delivering',
+      }),
+    }))),
+  )
+
+  return nextEpoch
 }
 
 export async function tombstoneSessionOrchestration(
@@ -51,7 +341,8 @@ export async function tombstoneSessionOrchestration(
   }
   if (!TABLE_NAME) return
 
-  await new DynamoDBClient({ region: AWS_REGION }).send(new UpdateItemCommand({
+  const client = new DynamoDBClient({ region: AWS_REGION })
+  await client.send(new UpdateItemCommand({
     TableName: TABLE_NAME,
     Key: marshall({
       sessionKey: sessionKey(userId, sessionId),
@@ -68,4 +359,17 @@ export async function tombstoneSessionOrchestration(
       ':status': 'deleted',
     }),
   }))
+
+  const records = (
+    await Promise.all([
+      queryOrchestrationRecords(client, userId, sessionId, 'INBOX#'),
+      queryOrchestrationRecords(client, userId, sessionId, 'JOB#'),
+      queryOrchestrationRecords(client, userId, sessionId, 'OUTBOX#'),
+      queryOrchestrationRecords(client, userId, sessionId, 'OUTBOX_V2#'),
+    ])
+  ).flat()
+  await deleteInBatches(
+    client,
+    records.map(({ key }) => key),
+  )
 }

--- a/chatbot-app/frontend/src/lib/turn-control.ts
+++ b/chatbot-app/frontend/src/lib/turn-control.ts
@@ -9,6 +9,7 @@ export interface TurnControlState {
 interface DeriveTurnControlOptions {
   agentStatus: AgentStatus
   isForegroundRunActive: boolean
+  hasStoppableRun: boolean
   isCompacting: boolean
   interruptCount: number
   hasPendingOAuth: boolean
@@ -21,6 +22,7 @@ interface DeriveTurnControlOptions {
 export function deriveTurnControl({
   agentStatus,
   isForegroundRunActive,
+  hasStoppableRun,
   isCompacting,
   interruptCount,
   hasPendingOAuth,
@@ -36,7 +38,7 @@ export function deriveTurnControl({
     isBusy,
     isBlocked,
     canInterrupt:
-      isBusy &&
+      hasStoppableRun &&
       !isBlocked &&
       !isCompacting &&
       agentStatus !== 'stopping' &&

--- a/chatbot-app/frontend/src/lib/turn-control.ts
+++ b/chatbot-app/frontend/src/lib/turn-control.ts
@@ -1,0 +1,46 @@
+import type { AgentStatus } from '@/types/events'
+
+export interface TurnControlState {
+  isBusy: boolean
+  isBlocked: boolean
+  canInterrupt: boolean
+}
+
+interface DeriveTurnControlOptions {
+  agentStatus: AgentStatus
+  isForegroundRunActive: boolean
+  isCompacting: boolean
+  interruptCount: number
+  hasPendingOAuth: boolean
+}
+
+/**
+ * Single control-state projection shared by the composer and queued turns.
+ * AgentStatus remains presentational; this projection owns user actions.
+ */
+export function deriveTurnControl({
+  agentStatus,
+  isForegroundRunActive,
+  isCompacting,
+  interruptCount,
+  hasPendingOAuth,
+}: DeriveTurnControlOptions): TurnControlState {
+  const isBlocked = interruptCount > 0 || hasPendingOAuth
+  const isBusy =
+    isForegroundRunActive ||
+    agentStatus !== 'idle' ||
+    isBlocked
+  const isVoiceActivity = agentStatus.startsWith('voice_')
+
+  return {
+    isBusy,
+    isBlocked,
+    canInterrupt:
+      isBusy &&
+      !isBlocked &&
+      !isCompacting &&
+      agentStatus !== 'stopping' &&
+      agentStatus !== 'compacting' &&
+      !isVoiceActivity,
+  }
+}

--- a/chatbot-app/frontend/src/types/chat.ts
+++ b/chatbot-app/frontend/src/types/chat.ts
@@ -2,6 +2,8 @@ export interface ToolExecution {
   id: string
   toolName: string
   toolInput?: any
+  toolInputRaw?: string
+  toolInputState?: 'streaming' | 'complete'
   reasoning: string[]
   reasoningText?: string
   toolResult?: string

--- a/docs/architecture/session-mailbox.md
+++ b/docs/architecture/session-mailbox.md
@@ -15,8 +15,10 @@ Implemented:
 - Research job migration from the users table to orchestration records.
 - Stable logical message identity with legacy event-ID fallback.
 - Session delete tombstones that reject late background delivery.
-- Truncate invalidation for mailbox assistant projections when origin identity
-  is available.
+- Conversation-epoch fencing for truncate across jobs, inbox work, projections,
+  AgentCore Memory restore, and frontend history.
+- Cursor-based incremental OUTBOX consumption.
+- FIFO SQS isolation between DynamoDB Streams and long-running Runtime drains.
 
 Compatibility paths remain for legacy research jobs, message metadata maps,
 and non-research artifacts. General tool artifacts still require the catalog
@@ -127,6 +129,7 @@ terminal projections.
   "userId": "authenticated owner id",
   "createdAt": "ISO-8601",
   "availableAt": "ISO-8601",
+  "conversationEpoch": 0,
   "source": {
     "type": "research_job",
     "id": "job id"
@@ -163,7 +166,7 @@ Record families:
 ```text
 STATE
 INBOX#{eventId}
-OUTBOX#{eventId}
+OUTBOX_V2#{createdAt}#{eventId}
 RUN#{runId}
 JOB#{jobId}
 ARTIFACT#{artifactId}
@@ -187,6 +190,7 @@ leaseEpoch
 leaseUntil
 version
 lastProcessedAt
+conversationEpoch
 ```
 
 Lease acquisition and renewal are conditional on `version` and `leaseEpoch`.
@@ -209,11 +213,14 @@ to be small. A status GSI is added only if measurements show it is necessary.
    tokens and stable logical message metadata.
 8. Coordinator transactionally marks the inbox event processed, updates small
    projections, and creates durable outbox milestones.
-9. Live subscribers receive the outbox milestone and any available transient
+9. Only after acknowledgement succeeds, a post-ack hook updates the producer
+   job projection to `delivered`.
+10. Live subscribers receive the outbox milestone and any available transient
    stream.
 
 The acknowledgement occurs only after canonical AgentCore persistence
-succeeds.
+succeeds. Producer job status is not the delivery commit point; the processed
+INBOX record plus its OUTBOX projections are.
 
 ## Cross-store Recovery
 
@@ -246,6 +253,7 @@ AgentCore Memory event metadata also records:
 logicalMessageId
 originEventId
 visibility
+conversationEpoch
 ```
 
 If the process crashes after the Memory write, retrying the mailbox event does
@@ -277,6 +285,13 @@ ambiguous retry window can repeat a model inference but cannot repeat an
 external tool side effect. Deterministic Memory client tokens prevent duplicate
 transcript events. Exactly-once model execution is not claimed.
 
+Truncate increments `STATE.conversationEpoch`. A continuation checks its
+captured epoch before generation and before committing agent state. Scoped
+Memory messages carry that epoch; backend restore and frontend history exclude
+messages from older epochs. This logical fence covers a Memory write that
+races with physical deletion. Physical cleanup remains a garbage-collection
+concern, not a correctness dependency.
+
 ## Busy and Idle Semantics
 
 ### Idle session
@@ -285,10 +300,14 @@ A pending mailbox event triggers a dispatcher invocation for the same Runtime
 session. The coordinator creates a separate assistant turn and publishes its
 terminal projection.
 
-DynamoDB Streams alone do not wake AgentCore Runtime. The dispatcher must
-obtain a service Cognito token, invoke `drain_mailbox`, and prove that the
-mailbox session belongs to the requested user. Runtime code must not trust an
-arbitrary `state.user_id` supplied by a general client.
+DynamoDB Streams alone do not wake AgentCore Runtime. A short-lived ingress
+Lambda coalesces inserts per session and writes a FIFO SQS wake message. A
+worker Lambda obtains a service Cognito token and invokes `drain_mailbox`.
+FIFO message groups serialize wakes for one session while allowing unrelated
+sessions to drain concurrently. Failed wakes retry through SQS and eventually
+move to a DLQ, so a slow or poisoned session cannot block a DynamoDB stream
+shard. Runtime code must still prove ownership and must not trust an arbitrary
+`state.user_id` supplied by a general client.
 
 ### Busy session
 
@@ -320,6 +339,15 @@ assistant completion as a separate turn.
 Process-local SSE buffering remains an optimization. If it is unavailable
 after a restart, the frontend reloads AgentCore history and DynamoDB
 projections instead of treating replay failure as data loss.
+
+New projections use `OUTBOX_V2#{createdAt}#{eventId}`. The frontend retains a
+server-issued cursor and reads only later keys. Legacy `OUTBOX#` records are
+loaded only on the initial baseline during migration.
+
+Research polling follows the same bounded-read rule: the first baseline and
+new-job discovery query the session job prefix, then active polling reads only
+the known queued/running/delivering job IDs. Artifact hydration uses direct job
+reads and bounded S3 concurrency.
 
 ## Artifact Migration
 
@@ -363,9 +391,11 @@ The target workflows are:
 - Pending asynchronous results targeting a deleted session become cancelled,
   not delivered to a recreated session with the same display title.
 
-The current rollout implements the delete tombstone and mailbox projection
-invalidation. It does not yet perform the full cross-store garbage collection
-described above.
+The current rollout implements delete tombstones and truncate epoch fencing.
+Truncate first advances the epoch, cancels old inbox work and affected jobs,
+then removes Memory events and OUTBOX projections. Retrying this saga is
+fail-closed: another epoch increment is safe. Full physical garbage collection
+of stale Memory, S3, and metadata records remains asynchronous cleanup work.
 
 ## Migration Plan
 
@@ -419,6 +449,7 @@ Exit criteria:
 ### Phase 4: wake dispatcher
 
 - Add DynamoDB Stream to dispatcher integration.
+- Buffer stream wakes in a per-session FIFO SQS queue with a DLQ.
 - Acquire a service Cognito token and invoke `drain_mailbox`.
 - Add ownership validation and wake coalescing.
 
@@ -453,13 +484,16 @@ Feature flags:
 ```text
 SESSION_MAILBOX_WRITE_ENABLED
 SESSION_MAILBOX_DELIVERY_ENABLED
+RESEARCH_JOB_LEGACY_READ_ENABLED
 SESSION_EVENT_PROJECTION_ENABLED
 ARTIFACT_CATALOG_WRITE_ENABLED
 ARTIFACT_CATALOG_READ_ENABLED
 ```
 
-The first two flags are implemented. The remaining names reserve later
-artifact-catalog rollout boundaries and are not active configuration yet.
+The first three flags are implemented. Legacy research reads default off once
+the orchestration table is configured and may be enabled only for a bounded
+migration window. The remaining names reserve later artifact-catalog rollout
+boundaries and are not active configuration yet.
 
 Rollout order is write-only, shadow verification, read enablement, delivery
 enablement, then legacy removal.
@@ -474,6 +508,8 @@ Rollback must not delete mailbox events or catalog entries.
 - Lease expiry and stale-owner acknowledgement.
 - Crash after S3 upload but before catalog commit.
 - Crash after AgentCore message write but before mailbox acknowledgement.
+- Producer job remains non-delivered until mailbox acknowledgement commits.
+- Post-ack job update failure reconciles from a processed inbox event.
 - Busy user turn plus one or more asynchronous completions.
 - Interrupt waiting while an asynchronous result arrives.
 - Stop signal while mailbox work is queued.
@@ -481,5 +517,8 @@ Rollback must not delete mailbox events or catalog entries.
 - Runtime restart before frontend replay.
 - Artifact update version conflict.
 - Session delete while a worker is running.
+- Truncate while a mailbox continuation is writing Memory.
+- Cursor pagination, epoch reset, and legacy OUTBOX baseline.
+- SQS wake retry and per-session coalescing.
 - Old event-ID feedback migration.
 - Internal message exclusion from UI and long-term-memory extraction.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -360,6 +360,8 @@ module "session_mailbox_dispatcher" {
   source_dir   = "${local.root_dir}/infra/lambda/session-mailbox-dispatcher"
 
   orchestration_stream_arn = module.data.session_orchestration_stream_arn
+  orchestration_table_arn  = module.data.session_orchestration_table_arn
+  orchestration_table_name = module.data.session_orchestration_table_name
   agentcore_runtime_url    = module.runtime_orchestrator.runtime_invocation_url
   cognito_domain_url       = module.auth.domain_url
   m2m_client_id            = module.auth.m2m_client_id

--- a/infra/lambda/session-mailbox-dispatcher/lambda_function.py
+++ b/infra/lambda/session-mailbox-dispatcher/lambda_function.py
@@ -3,21 +3,23 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
 import time
 import urllib.parse
 import urllib.request
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import boto3
-
 
 logger = logging.getLogger(__name__)
 
 _token: str | None = None
 _token_expires_at = 0.0
+_TERMINAL_TTL_DAYS = 30
 
 
 def _secret() -> dict[str, str]:
@@ -59,7 +61,11 @@ def _access_token() -> str:
     return _token
 
 
-def _wake(user_id: str, session_id: str) -> None:
+def _wake(
+    user_id: str,
+    session_id: str,
+    event_ids: list[str] | None = None,
+) -> None:
     payload = json.dumps({
         "thread_id": session_id,
         "run_id": f"mailbox-dispatch-{int(time.time() * 1000)}",
@@ -69,6 +75,7 @@ def _wake(user_id: str, session_id: str) -> None:
         "state": {
             "action": "drain_mailbox",
             "user_id": user_id,
+            "event_ids": event_ids or [],
         },
     }).encode()
     request = urllib.request.Request(
@@ -81,7 +88,10 @@ def _wake(user_id: str, session_id: str) -> None:
         },
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=30) as response:
+    timeout_seconds = int(
+        os.environ.get("RUNTIME_REQUEST_TIMEOUT_SECONDS", "540")
+    )
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
         result = json.loads(response.read())
     if result.get("status") != "drained":
         raise RuntimeError(
@@ -89,7 +99,7 @@ def _wake(user_id: str, session_id: str) -> None:
         )
 
 
-def _mailbox_target(record: dict[str, Any]) -> tuple[str, str] | None:
+def _mailbox_target(record: dict[str, Any]) -> tuple[str, str, str] | None:
     if record.get("eventName") != "INSERT":
         return None
     image = record.get("dynamodb", {}).get("NewImage", {})
@@ -99,34 +109,211 @@ def _mailbox_target(record: dict[str, Any]) -> tuple[str, str] | None:
         return None
     user_id = image.get("userId", {}).get("S")
     session_id = image.get("sessionId", {}).get("S")
-    if not user_id or not session_id:
+    mailbox_event_id = image.get("eventId", {}).get("S")
+    if not user_id or not session_id or not mailbox_event_id:
         return None
-    return user_id, session_id
+    return user_id, session_id, mailbox_event_id
 
 
-def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
-    records_by_target: dict[tuple[str, str], list[str]] = {}
+def _enqueue_wake(
+    user_id: str,
+    session_id: str,
+    event_ids: list[str],
+) -> None:
+    body = json.dumps({
+        "userId": user_id,
+        "sessionId": session_id,
+        "eventIds": event_ids,
+    })
+    target = f"{user_id}\n{session_id}".encode()
+    deduplication = "\n".join(sorted(event_ids)).encode()
+    boto3.client("sqs").send_message(
+        QueueUrl=os.environ["WAKE_QUEUE_URL"],
+        MessageBody=body,
+        MessageGroupId=hashlib.sha256(target).hexdigest(),
+        MessageDeduplicationId=hashlib.sha256(
+            target + b"\n" + deduplication
+        ).hexdigest(),
+    )
+
+
+def _discard_deleted_session_wake(
+    user_id: str,
+    session_id: str,
+    event_ids: list[str],
+) -> bool:
+    table_name = os.environ["ORCHESTRATION_TABLE_NAME"]
+    session_key = f"USER#{user_id}#SESSION#{session_id}"
+    client = boto3.client("dynamodb")
+    state = client.get_item(
+        TableName=table_name,
+        Key={
+            "sessionKey": {"S": session_key},
+            "recordKey": {"S": "STATE"},
+        },
+        ConsistentRead=True,
+        ProjectionExpression="deletedAt",
+    ).get("Item")
+    if not state or "deletedAt" not in state:
+        return False
+
+    now = datetime.now(timezone.utc)
+    updated_at = now.isoformat()
+    terminal_ttl = int(
+        (now + timedelta(days=_TERMINAL_TTL_DAYS)).timestamp()
+    )
+    for event_id in event_ids:
+        try:
+            client.update_item(
+                TableName=table_name,
+                Key={
+                    "sessionKey": {"S": session_key},
+                    "recordKey": {"S": f"INBOX#{event_id}"},
+                },
+                UpdateExpression=(
+                    "SET #status = :cancelled, processedAt = :updated, "
+                    "updatedAt = :updated, lastError = :reason, #ttl = :ttl "
+                    "REMOVE leaseOwner, leaseEpoch, eventLeaseUntil"
+                ),
+                ConditionExpression=(
+                    "#status = :pending OR #status = :processing"
+                ),
+                ExpressionAttributeNames={
+                    "#status": "status",
+                    "#ttl": "ttl",
+                },
+                ExpressionAttributeValues={
+                    ":cancelled": {"S": "cancelled"},
+                    ":updated": {"S": updated_at},
+                    ":reason": {"S": "Session deleted"},
+                    ":ttl": {"N": str(terminal_ttl)},
+                    ":pending": {"S": "pending"},
+                    ":processing": {"S": "processing"},
+                },
+            )
+        except Exception as error:
+            code = getattr(error, "response", {}).get("Error", {}).get("Code")
+            if code != "ConditionalCheckFailedException":
+                raise
+    return True
+
+
+def _handle_stream(event: dict[str, Any]) -> dict[str, Any]:
+    records_by_target: dict[
+        tuple[str, str],
+        dict[str, list[str]],
+    ] = {}
     for record in event.get("Records", []):
         target = _mailbox_target(record)
         if target:
-            records_by_target.setdefault(target, []).append(
-                record.get("eventID", ""),
+            user_id, session_id, mailbox_event_id = target
+            grouped = records_by_target.setdefault(
+                (user_id, session_id),
+                {"mailbox_event_ids": [], "stream_record_ids": []},
             )
+            grouped["mailbox_event_ids"].append(mailbox_event_id)
+            grouped["stream_record_ids"].append(record.get("eventID", ""))
 
     failures = []
-    for (user_id, session_id), event_ids in records_by_target.items():
+    for (user_id, session_id), grouped in records_by_target.items():
         try:
-            _wake(user_id, session_id)
+            _enqueue_wake(
+                user_id,
+                session_id,
+                grouped["mailbox_event_ids"],
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue mailbox wake for %s/%s",
+                user_id,
+                session_id,
+            )
+            failures.extend(
+                {"itemIdentifier": record_id}
+                for record_id in grouped["stream_record_ids"]
+                if record_id
+            )
+
+    return {"batchItemFailures": failures}
+
+
+def _handle_sqs(event: dict[str, Any]) -> dict[str, Any]:
+    records_by_target: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    invalid_records: list[dict[str, Any]] = []
+    for record in event.get("Records", []):
+        message_id = record.get("messageId", "")
+        try:
+            body = json.loads(record["body"])
+            target = (body["userId"], body["sessionId"])
+            record["_mailboxEventIds"] = [
+                str(event_id)
+                for event_id in body.get("eventIds", [])
+                if event_id
+            ]
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            logger.exception("Invalid mailbox wake message %s", message_id)
+            if message_id:
+                invalid_records.append(record)
+            continue
+        records_by_target.setdefault(target, []).append(record)
+
+    failures = []
+    for record in invalid_records:
+        _defer_retry(record)
+        failures.append({"itemIdentifier": record["messageId"]})
+    for (user_id, session_id), records in records_by_target.items():
+        try:
+            event_ids = sorted({
+                event_id
+                for record in records
+                for event_id in record.get("_mailboxEventIds", [])
+            })
+            if not _discard_deleted_session_wake(
+                user_id,
+                session_id,
+                event_ids,
+            ):
+                _wake(user_id, session_id, event_ids)
         except Exception:
             logger.exception(
                 "Failed to drain mailbox for %s/%s",
                 user_id,
                 session_id,
             )
-            failures.extend(
-                {"itemIdentifier": event_id}
-                for event_id in event_ids
-                if event_id
-            )
-
+            for record in records:
+                _defer_retry(record)
+                message_id = record.get("messageId")
+                if message_id:
+                    failures.append({"itemIdentifier": message_id})
     return {"batchItemFailures": failures}
+
+
+def _defer_retry(record: dict[str, Any]) -> None:
+    receipt_handle = record.get("receiptHandle")
+    if not receipt_handle:
+        return
+    try:
+        receive_count = int(
+            record.get("attributes", {}).get("ApproximateReceiveCount", "1")
+        )
+    except (TypeError, ValueError):
+        receive_count = 1
+    visibility_timeout = min(300, 5 * (2 ** max(0, receive_count - 1)))
+    try:
+        boto3.client("sqs").change_message_visibility(
+            QueueUrl=os.environ["WAKE_QUEUE_URL"],
+            ReceiptHandle=receipt_handle,
+            VisibilityTimeout=visibility_timeout,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to shorten retry visibility for message %s",
+            record.get("messageId", ""),
+        )
+
+
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    records = event.get("Records", [])
+    if records and records[0].get("eventSource") == "aws:sqs":
+        return _handle_sqs(event)
+    return _handle_stream(event)

--- a/infra/lambda/session-mailbox-dispatcher/test_lambda_function.py
+++ b/infra/lambda/session-mailbox-dispatcher/test_lambda_function.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import lambda_function
@@ -6,6 +7,7 @@ import lambda_function
 def record(
     event_id: str,
     *,
+    mailbox_event_id: str | None = None,
     user_id: str = "user-1",
     session_id: str = "session-1",
     event_name: str = "INSERT",
@@ -20,14 +22,35 @@ def record(
                 "status": {"S": "pending"},
                 "userId": {"S": user_id},
                 "sessionId": {"S": session_id},
+                "eventId": {"S": mailbox_event_id or f"mailbox-{event_id}"},
             }
         },
     }
 
 
+def sqs_record(
+    message_id: str,
+    *,
+    user_id: str = "user-1",
+    session_id: str = "session-1",
+    event_ids: list[str] | None = None,
+):
+    return {
+        "messageId": message_id,
+        "eventSource": "aws:sqs",
+        "receiptHandle": f"receipt-{message_id}",
+        "attributes": {"ApproximateReceiveCount": "1"},
+        "body": json.dumps({
+            "userId": user_id,
+            "sessionId": session_id,
+            "eventIds": event_ids or [f"event-{message_id}"],
+        }),
+    }
+
+
 def test_coalesces_multiple_inserts_for_one_session(monkeypatch):
-    wake = MagicMock()
-    monkeypatch.setattr(lambda_function, "_wake", wake)
+    enqueue = MagicMock()
+    monkeypatch.setattr(lambda_function, "_enqueue_wake", enqueue)
 
     result = lambda_function.lambda_handler(
         {"Records": [record("1"), record("2")]},
@@ -35,12 +58,16 @@ def test_coalesces_multiple_inserts_for_one_session(monkeypatch):
     )
 
     assert result == {"batchItemFailures": []}
-    wake.assert_called_once_with("user-1", "session-1")
+    enqueue.assert_called_once_with(
+        "user-1",
+        "session-1",
+        ["mailbox-1", "mailbox-2"],
+    )
 
 
 def test_ignores_non_inbox_stream_records(monkeypatch):
-    wake = MagicMock()
-    monkeypatch.setattr(lambda_function, "_wake", wake)
+    enqueue = MagicMock()
+    monkeypatch.setattr(lambda_function, "_enqueue_wake", enqueue)
 
     result = lambda_function.lambda_handler(
         {
@@ -53,13 +80,13 @@ def test_ignores_non_inbox_stream_records(monkeypatch):
     )
 
     assert result == {"batchItemFailures": []}
-    wake.assert_not_called()
+    enqueue.assert_not_called()
 
 
 def test_reports_each_coalesced_record_when_wake_fails(monkeypatch):
     monkeypatch.setattr(
         lambda_function,
-        "_wake",
+        "_enqueue_wake",
         MagicMock(side_effect=RuntimeError("still pending")),
     )
 
@@ -74,3 +101,134 @@ def test_reports_each_coalesced_record_when_wake_fails(monkeypatch):
             {"itemIdentifier": "2"},
         ]
     }
+
+
+def test_sqs_worker_coalesces_wakes_for_one_session(monkeypatch):
+    wake = MagicMock()
+    monkeypatch.setattr(
+        lambda_function,
+        "_discard_deleted_session_wake",
+        MagicMock(return_value=False),
+    )
+    monkeypatch.setattr(lambda_function, "_wake", wake)
+
+    result = lambda_function.lambda_handler(
+        {"Records": [sqs_record("1"), sqs_record("2")]},
+        None,
+    )
+
+    assert result == {"batchItemFailures": []}
+    wake.assert_called_once_with(
+        "user-1",
+        "session-1",
+        ["event-1", "event-2"],
+    )
+
+
+def test_sqs_worker_reports_failed_messages(monkeypatch):
+    defer = MagicMock()
+    monkeypatch.setattr(
+        lambda_function,
+        "_discard_deleted_session_wake",
+        MagicMock(return_value=False),
+    )
+    monkeypatch.setattr(lambda_function, "_defer_retry", defer)
+    monkeypatch.setattr(
+        lambda_function,
+        "_wake",
+        MagicMock(side_effect=RuntimeError("still pending")),
+    )
+
+    result = lambda_function.lambda_handler(
+        {"Records": [sqs_record("1"), sqs_record("2")]},
+        None,
+    )
+
+    assert result == {
+        "batchItemFailures": [
+            {"itemIdentifier": "1"},
+            {"itemIdentifier": "2"},
+        ]
+    }
+    assert [call.args[0]["messageId"] for call in defer.call_args_list] == [
+        "1",
+        "2",
+    ]
+
+
+def test_sqs_worker_discards_deleted_session_wake(monkeypatch):
+    discard = MagicMock(return_value=True)
+    wake = MagicMock()
+    monkeypatch.setattr(
+        lambda_function,
+        "_discard_deleted_session_wake",
+        discard,
+    )
+    monkeypatch.setattr(lambda_function, "_wake", wake)
+
+    result = lambda_function.lambda_handler(
+        {"Records": [sqs_record("1")]},
+        None,
+    )
+
+    assert result == {"batchItemFailures": []}
+    discard.assert_called_once_with(
+        "user-1",
+        "session-1",
+        ["event-1"],
+    )
+    wake.assert_not_called()
+
+
+def test_enqueue_uses_session_group_and_event_deduplication(monkeypatch):
+    send_message = MagicMock()
+    sqs = MagicMock(send_message=send_message)
+    monkeypatch.setattr(lambda_function.boto3, "client", lambda service: sqs)
+    monkeypatch.setenv("WAKE_QUEUE_URL", "https://sqs.example/queue")
+
+    lambda_function._enqueue_wake(
+        "user-1",
+        "session-1",
+        ["event-2", "event-1"],
+    )
+
+    kwargs = send_message.call_args.kwargs
+    assert kwargs["QueueUrl"] == "https://sqs.example/queue"
+    assert json.loads(kwargs["MessageBody"]) == {
+        "userId": "user-1",
+        "sessionId": "session-1",
+        "eventIds": ["event-2", "event-1"],
+    }
+    assert len(kwargs["MessageGroupId"]) == 64
+    assert len(kwargs["MessageDeduplicationId"]) == 64
+
+
+def test_failed_wake_uses_bounded_exponential_visibility(monkeypatch):
+    change_visibility = MagicMock()
+    sqs = MagicMock(change_message_visibility=change_visibility)
+    monkeypatch.setattr(lambda_function.boto3, "client", lambda service: sqs)
+    monkeypatch.setenv("WAKE_QUEUE_URL", "https://sqs.example/queue")
+    failed = sqs_record("message-1")
+    failed["attributes"]["ApproximateReceiveCount"] = "4"
+
+    lambda_function._defer_retry(failed)
+
+    change_visibility.assert_called_once_with(
+        QueueUrl="https://sqs.example/queue",
+        ReceiptHandle="receipt-message-1",
+        VisibilityTimeout=40,
+    )
+
+
+def test_wake_uses_configured_runtime_timeout(monkeypatch):
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"status":"drained"}'
+    urlopen = MagicMock(return_value=response)
+    monkeypatch.setattr(lambda_function, "_access_token", lambda: "token")
+    monkeypatch.setattr(lambda_function.urllib.request, "urlopen", urlopen)
+    monkeypatch.setenv("AGENTCORE_RUNTIME_URL", "https://runtime.example")
+    monkeypatch.setenv("RUNTIME_REQUEST_TIMEOUT_SECONDS", "420")
+
+    lambda_function._wake("user-1", "session-1")
+
+    assert urlopen.call_args.kwargs["timeout"] == 420

--- a/infra/modules/session-mailbox-dispatcher/main.tf
+++ b/infra/modules/session-mailbox-dispatcher/main.tf
@@ -1,5 +1,6 @@
 locals {
   function_name = "${var.project_name}-${var.environment}-session-mailbox-dispatcher"
+  worker_name   = "${local.function_name}-worker"
   zip_path      = "${path.module}/.build/session-mailbox-dispatcher.zip"
 }
 
@@ -36,8 +37,54 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy" "this" {
-  name = "dispatcher"
+  name = "stream-ingress"
   role = aws_iam_role.this.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:${var.account_id}:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:DescribeStream",
+          "dynamodb:GetRecords",
+          "dynamodb:GetShardIterator",
+          "dynamodb:ListStreams",
+        ]
+        Resource = var.orchestration_stream_arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.wake.arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role" "worker" {
+  name = "${local.worker_name}-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "worker" {
+  name = "queue-worker"
+  role = aws_iam_role.worker.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -58,12 +105,20 @@ resource "aws_iam_role_policy" "this" {
       {
         Effect = "Allow"
         Action = [
-          "dynamodb:DescribeStream",
-          "dynamodb:GetRecords",
-          "dynamodb:GetShardIterator",
-          "dynamodb:ListStreams",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:ChangeMessageVisibility",
         ]
-        Resource = var.orchestration_stream_arn
+        Resource = aws_sqs_queue.wake.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem",
+        ]
+        Resource = var.orchestration_table_arn
       },
     ]
   })
@@ -74,13 +129,45 @@ resource "aws_cloudwatch_log_group" "this" {
   retention_in_days = 14
 }
 
+resource "aws_cloudwatch_log_group" "worker" {
+  name              = "/aws/lambda/${local.worker_name}"
+  retention_in_days = 14
+}
+
+resource "aws_sqs_queue" "wake_dead_letter" {
+  name                      = "${local.function_name}-dlq.fifo"
+  fifo_queue                = true
+  message_retention_seconds = 1209600
+  sqs_managed_sse_enabled   = true
+}
+
+resource "aws_sqs_queue" "wake" {
+  name                       = "${local.function_name}.fifo"
+  fifo_queue                 = true
+  message_retention_seconds  = 345600
+  visibility_timeout_seconds = (var.runtime_request_timeout_seconds + 30) * 6
+  sqs_managed_sse_enabled    = true
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.wake_dead_letter.arn
+    maxReceiveCount     = 8
+  })
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "wake_dead_letter" {
+  queue_url = aws_sqs_queue.wake_dead_letter.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.wake.arn]
+  })
+}
+
 resource "aws_lambda_function" "this" {
   function_name = local.function_name
   role          = aws_iam_role.this.arn
   handler       = "lambda_function.lambda_handler"
   runtime       = "python3.13"
   architectures = ["arm64"]
-  timeout       = 45
+  timeout       = 30
   memory_size   = 256
 
   filename         = data.archive_file.this.output_path
@@ -88,15 +175,44 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = {
-      AGENTCORE_RUNTIME_URL = var.agentcore_runtime_url
-      COGNITO_TOKEN_URL     = "${var.cognito_domain_url}/oauth2/token"
-      M2M_SECRET_ARN        = aws_secretsmanager_secret.m2m.arn
+      WAKE_QUEUE_URL = aws_sqs_queue.wake.url
     }
   }
 
   depends_on = [
     aws_cloudwatch_log_group.this,
     aws_iam_role_policy.this,
+  ]
+}
+
+resource "aws_lambda_function" "worker" {
+  function_name = local.worker_name
+  role          = aws_iam_role.worker.arn
+  handler       = "lambda_function.lambda_handler"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+  timeout       = var.runtime_request_timeout_seconds + 30
+  memory_size   = 256
+
+  filename         = data.archive_file.this.output_path
+  source_code_hash = data.archive_file.this.output_base64sha256
+
+  environment {
+    variables = {
+      AGENTCORE_RUNTIME_URL    = var.agentcore_runtime_url
+      COGNITO_TOKEN_URL        = "${var.cognito_domain_url}/oauth2/token"
+      M2M_SECRET_ARN           = aws_secretsmanager_secret.m2m.arn
+      ORCHESTRATION_TABLE_NAME = var.orchestration_table_name
+      WAKE_QUEUE_URL           = aws_sqs_queue.wake.url
+      RUNTIME_REQUEST_TIMEOUT_SECONDS = tostring(
+        var.runtime_request_timeout_seconds
+      )
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.worker,
+    aws_iam_role_policy.worker,
     aws_secretsmanager_secret_version.m2m,
   ]
 }
@@ -111,4 +227,11 @@ resource "aws_lambda_event_source_mapping" "this" {
   maximum_retry_attempts             = -1
   bisect_batch_on_function_error     = true
   function_response_types            = ["ReportBatchItemFailures"]
+}
+
+resource "aws_lambda_event_source_mapping" "worker" {
+  event_source_arn        = aws_sqs_queue.wake.arn
+  function_name           = aws_lambda_function.worker.arn
+  batch_size              = 10
+  function_response_types = ["ReportBatchItemFailures"]
 }

--- a/infra/modules/session-mailbox-dispatcher/outputs.tf
+++ b/infra/modules/session-mailbox-dispatcher/outputs.tf
@@ -1,3 +1,15 @@
 output "function_name" {
   value = aws_lambda_function.this.function_name
 }
+
+output "worker_function_name" {
+  value = aws_lambda_function.worker.function_name
+}
+
+output "wake_queue_url" {
+  value = aws_sqs_queue.wake.url
+}
+
+output "wake_dead_letter_queue_url" {
+  value = aws_sqs_queue.wake_dead_letter.url
+}

--- a/infra/modules/session-mailbox-dispatcher/variables.tf
+++ b/infra/modules/session-mailbox-dispatcher/variables.tf
@@ -22,6 +22,14 @@ variable "orchestration_stream_arn" {
   type = string
 }
 
+variable "orchestration_table_arn" {
+  type = string
+}
+
+variable "orchestration_table_name" {
+  type = string
+}
+
 variable "agentcore_runtime_url" {
   type = string
 }
@@ -37,4 +45,18 @@ variable "m2m_client_id" {
 variable "m2m_client_secret" {
   type      = string
   sensitive = true
+}
+
+variable "runtime_request_timeout_seconds" {
+  description = "Maximum time to wait for one synchronous mailbox drain"
+  type        = number
+  default     = 540
+
+  validation {
+    condition = (
+      var.runtime_request_timeout_seconds >= 60 &&
+      var.runtime_request_timeout_seconds <= 870
+    )
+    error_message = "runtime_request_timeout_seconds must be between 60 and 870."
+  }
 }


### PR DESCRIPTION
## Summary
- make queued-message interrupts transactional and expose the action only for a stoppable foreground run
- harden durable mailbox delivery with post-ack state transitions, conversation epoch fencing, cursor projections, targeted research reads, and SQS-backed dispatch
- stream tool names and argument deltas through the AG-UI lifecycle while unwrapping skill executor names
- bound large text paste processing with attachment conversion, payload limits, chunked encoding, and cheaper previews

## Commit structure
- queue interrupt behavior is preserved in the existing feature commits
- `fix(mailbox): harden delivery and session fencing`
- `fix(chat): make queued interrupts transactional`
- `feat(chat): stream tool calls and arguments`
- `perf(chat): bound large paste processing`

## Verification
- frontend: type-check, 44 files / 665 tests, production build
- backend: Ruff, 557 unit tests, 136 integration tests (15 e2e deselected)
- mailbox dispatcher: 9 tests
- infrastructure: Terraform fmt/validate and deploy script syntax
- dev deployment: AgentCore runtime and frontend ECS rollout verified; SQS/DLQ converged to zero

## Dependency
- builds on the durable session mailbox merged in #227
