### PR TITLE
feat: add session workspace browser

### DIFF
--- a/chatbot-app/frontend/__tests__/components/CanvasResearchApproval.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/CanvasResearchApproval.test.tsx
@@ -24,6 +24,12 @@ vi.mock('@/components/canvas/ResearchArtifact', () => ({
   ),
 }))
 
+vi.mock('@/components/canvas/WorkspaceBrowser', () => ({
+  WorkspaceBrowser: ({ sessionId }: { sessionId?: string }) => (
+    <div data-testid="workspace-browser">{sessionId}</div>
+  ),
+}))
+
 const artifact: Artifact = {
   id: 'research-previous',
   type: 'research' as any,
@@ -141,7 +147,7 @@ describe('Canvas — docked artifact sidebar', () => {
     renderCanvas()
 
     const sidebar = screen.getByTestId('artifacts-sidebar')
-    const resizeHandle = screen.getByRole('separator', { name: /resize artifacts sidebar/i })
+    const resizeHandle = screen.getByRole('separator', { name: /resize right sidebar/i })
 
     fireEvent.keyDown(resizeHandle, { key: 'ArrowRight' })
     expect(sidebar).toHaveStyle({ width: '496px', flexBasis: '496px' })
@@ -154,7 +160,7 @@ describe('Canvas — docked artifact sidebar', () => {
     renderCanvas()
 
     const sidebar = screen.getByTestId('artifacts-sidebar')
-    const resizeHandle = screen.getByRole('separator', { name: /resize artifacts sidebar/i })
+    const resizeHandle = screen.getByRole('separator', { name: /resize right sidebar/i })
 
     fireEvent.pointerDown(resizeHandle, { clientX: 500, pointerId: 1 })
     fireEvent.pointerMove(window, { clientX: 450, pointerId: 1 })
@@ -162,5 +168,21 @@ describe('Canvas — docked artifact sidebar', () => {
 
     fireEvent.pointerUp(window, { pointerId: 1 })
     expect(localStorage.setItem).toHaveBeenLastCalledWith('artifacts-sidebar:width', '570')
+  })
+
+  it('switches between conversational artifacts and session workspace files', () => {
+    renderCanvas()
+
+    expect(screen.getByRole('button', { name: /show artifacts/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    fireEvent.click(screen.getByRole('button', { name: /show workspace/i }))
+
+    expect(screen.getByTestId('workspace-browser')).toHaveTextContent('session-1')
+    expect(screen.getByRole('button', { name: /show workspace/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
   })
 })

--- a/chatbot-app/frontend/__tests__/components/OfficeViewer.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/OfficeViewer.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { OfficeViewer } from '@/components/canvas/OfficeViewer'
+
+describe('OfficeViewer', () => {
+  it('uses a storage-neutral signed preview URL without another S3 lookup', async () => {
+    render(
+      <OfficeViewer
+        previewUrl="https://example.test/report.docx?signature=short-lived"
+        filename="report.docx"
+      />,
+    )
+
+    const frame = await screen.findByTitle('Preview: report.docx')
+    expect(frame).toHaveAttribute(
+      'src',
+      expect.stringContaining('https%3A%2F%2Fexample.test%2Freport.docx'),
+    )
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('reports an invalid legacy S3 URL instead of rendering a broken frame', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    render(<OfficeViewer s3Url="not-an-s3-url" filename="report.docx" />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid s3 url format/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByTitle('Preview: report.docx')).not.toBeInTheDocument()
+    consoleError.mockRestore()
+  })
+})

--- a/chatbot-app/frontend/__tests__/components/WorkspaceBrowser.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/WorkspaceBrowser.test.tsx
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { WorkspaceBrowser } from '@/components/canvas/WorkspaceBrowser'
+import { apiFetch } from '@/lib/api-client'
+
+vi.mock('@/lib/api-client', () => ({
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('@/components/ui/Markdown', () => ({
+  Markdown: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="markdown-preview">{children}</div>
+  ),
+}))
+
+vi.mock('@/components/canvas/OfficeViewer', () => ({
+  OfficeViewer: ({ filename }: { filename: string }) => (
+    <div data-testid="office-preview">{filename}</div>
+  ),
+}))
+
+const response = (body: unknown, ok = true) => ({
+  ok,
+  json: vi.fn().mockResolvedValue(body),
+})
+
+describe('WorkspaceBrowser', () => {
+  const mockApiFetch = vi.mocked(apiFetch)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiFetch.mockImplementation(async endpoint => {
+      if (endpoint === 'workspace/entries') {
+        return response({
+          entries: [{
+            id: 'documents',
+            path: 'documents',
+            parentPath: '',
+            name: 'Documents',
+            kind: 'directory',
+          }],
+        }) as any
+      }
+      if (endpoint === 'workspace/entries?path=documents') {
+        return response({
+          entries: [{
+            id: 'report',
+            path: 'documents/report.md',
+            parentPath: 'documents',
+            name: 'report.md',
+            kind: 'file',
+            size: 1200,
+            previewKind: 'markdown',
+          }],
+        }) as any
+      }
+      if (endpoint === 'workspace/preview?path=documents%2Freport.md') {
+        return response({
+          entry: {
+            id: 'report',
+            path: 'documents/report.md',
+            parentPath: 'documents',
+            name: 'report.md',
+            kind: 'file',
+          },
+          kind: 'markdown',
+          content: '# Session report',
+        }) as any
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`)
+    })
+  })
+
+  it('lazy-loads a directory and previews a selected file', async () => {
+    render(<WorkspaceBrowser sessionId="session-1" />)
+
+    const documents = await screen.findByRole('button', { name: /documents/i })
+    fireEvent.click(documents)
+
+    const report = await screen.findByRole('button', { name: /report\.md/i })
+    expect(report).toHaveTextContent('1.2 KB')
+    fireEvent.click(report)
+
+    expect(await screen.findByTestId('markdown-preview')).toHaveTextContent('# Session report')
+    expect(screen.getByText('documents/report.md')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /back to workspace files/i }))
+    expect(await screen.findByRole('button', { name: /documents/i })).toBeInTheDocument()
+  })
+
+  it('scopes every request to the active session', async () => {
+    render(<WorkspaceBrowser sessionId="session-1" />)
+    await screen.findByRole('button', { name: /documents/i })
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      'workspace/entries',
+      { headers: { 'X-Session-ID': 'session-1' } },
+    )
+  })
+
+  it('shows an explicit empty-session state', () => {
+    render(<WorkspaceBrowser />)
+    expect(screen.getByText(/start a conversation/i)).toBeInTheDocument()
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces list failures without discarding the browser', async () => {
+    mockApiFetch.mockResolvedValueOnce(response({}, false) as any)
+    render(<WorkspaceBrowser sessionId="session-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to load workspace')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /refresh workspace files/i })).toBeInTheDocument()
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/workspace-repository.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/workspace-repository.test.ts
@@ -120,6 +120,16 @@ describe('S3WorkspaceRepository', () => {
     ).rejects.toThrow(WorkspacePathError)
   })
 
+  it('normalizes long boundary slash sequences without accepting empty segments', () => {
+    const slashes = '/'.repeat(20_000)
+    expect(normalizeWorkspacePath(`${slashes}documents/report.md${slashes}`)).toBe(
+      'documents/report.md',
+    )
+    expect(() => normalizeWorkspacePath('documents//report.md')).toThrow(
+      WorkspacePathError,
+    )
+  })
+
   it('classifies common preview formats', () => {
     expect(getWorkspacePreviewKind('file.csv')).toBe('text')
     expect(getWorkspacePreviewKind('file.pdf')).toBe('pdf')

--- a/chatbot-app/frontend/__tests__/lib/workspace-repository.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/workspace-repository.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn().mockResolvedValue('https://example.test/preview'),
+}))
+
+import {
+  getWorkspacePreviewKind,
+  normalizeWorkspacePath,
+  S3WorkspaceRepository,
+  WorkspacePathError,
+} from '@/lib/workspace/s3-repository'
+
+describe('S3WorkspaceRepository', () => {
+  const send = vi.fn()
+  const repository = new S3WorkspaceRepository({ send } as any)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('ARTIFACT_BUCKET', 'workspace-bucket')
+  })
+
+  it('returns storage-neutral root namespaces without querying S3', async () => {
+    const page = await repository.list('user-1', 'session-1')
+
+    expect(page.entries.map(entry => entry.path)).toEqual([
+      'documents',
+      'code-interpreter',
+      'code-agent',
+    ])
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('lists directories before files and maps S3 keys to logical paths', async () => {
+    send.mockResolvedValue({
+      CommonPrefixes: [
+        { Prefix: 'documents/user-1/session-1/word/' },
+      ],
+      Contents: [
+        {
+          Key: 'documents/user-1/session-1/notes.md',
+          Size: 42,
+          LastModified: new Date('2026-08-09T12:00:00.000Z'),
+        },
+        {
+          Key: 'documents/user-1/session-1/.metadata',
+          Size: 3,
+          LastModified: new Date('2026-08-09T12:00:00.000Z'),
+        },
+      ],
+      NextContinuationToken: 'next-page',
+    })
+
+    const page = await repository.list('user-1', 'session-1', 'documents')
+
+    expect(page.entries).toMatchObject([
+      { kind: 'directory', path: 'documents/word', name: 'word' },
+      {
+        kind: 'file',
+        path: 'documents/notes.md',
+        name: 'notes.md',
+        previewKind: 'markdown',
+      },
+    ])
+    expect(page.nextCursor).toBeTruthy()
+    expect(send.mock.calls[0][0].input).toMatchObject({
+      Bucket: 'workspace-bucket',
+      Prefix: 'documents/user-1/session-1/',
+      Delimiter: '/',
+      MaxKeys: 200,
+    })
+  })
+
+  it('reads bounded text previews instead of loading the complete object', async () => {
+    send.mockResolvedValue({
+      Body: { transformToString: vi.fn().mockResolvedValue('# Report') },
+      ContentRange: 'bytes 0-8/2000000',
+    })
+
+    const preview = await repository.preview(
+      'user-1',
+      'session-1',
+      'documents/report.md',
+    )
+
+    expect(preview).toMatchObject({
+      kind: 'markdown',
+      content: '# Report',
+      truncated: true,
+      entry: {
+        path: 'documents/report.md',
+        size: 2000000,
+      },
+    })
+    expect(send.mock.calls[0][0].input).toMatchObject({
+      Bucket: 'workspace-bucket',
+      Key: 'documents/user-1/session-1/report.md',
+      Range: 'bytes=0-1048575',
+    })
+  })
+
+  it('generates a short-lived preview for binary files', async () => {
+    const preview = await repository.preview(
+      'user-1',
+      'session-1',
+      'code-interpreter/chart.png',
+    )
+
+    expect(preview).toMatchObject({
+      kind: 'image',
+      url: 'https://example.test/preview',
+    })
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('rejects traversal and unknown namespaces', async () => {
+    expect(() => normalizeWorkspacePath('documents/../secret')).toThrow(WorkspacePathError)
+    await expect(
+      repository.preview('user-1', 'session-1', 'unknown/file.txt'),
+    ).rejects.toThrow(WorkspacePathError)
+  })
+
+  it('classifies common preview formats', () => {
+    expect(getWorkspacePreviewKind('file.csv')).toBe('text')
+    expect(getWorkspacePreviewKind('file.pdf')).toBe('pdf')
+    expect(getWorkspacePreviewKind('file.xlsx')).toBe('office')
+    expect(getWorkspacePreviewKind('file.zip')).toBe('unsupported')
+  })
+})

--- a/chatbot-app/frontend/src/app/api/workspace/download/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/download/route.ts
@@ -1,30 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
-import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
-import { extractUserFromRequest, getSessionId } from '@/lib/auth-utils'
+import { extractUserFromRequest } from '@/lib/auth-utils'
+import {
+  resolveWorkspaceS3Location,
+  WorkspacePathError,
+} from '@/lib/workspace/s3-repository'
 
 const region = process.env.AWS_REGION || 'us-west-2'
-
-const NAMESPACE_MAP: [string, string][] = [
-  ['code-agent', 'code-agent-workspace/{userId}/{sessionId}/'],
-  ['code-interpreter', 'code-interpreter-workspace/{userId}/{sessionId}/'],
-  ['documents', 'documents/{userId}/{sessionId}/'],
-]
-
-function toS3Key(userId: string, sessionId: string, path: string): string {
-  const cleanPath = path.replace(/^\//, '')
-  for (const [prefix, template] of NAMESPACE_MAP) {
-    if (cleanPath.startsWith(prefix)) {
-      const suffix = cleanPath.slice(prefix.length).replace(/^\//, '')
-      const base = template
-        .replace('{userId}', userId)
-        .replace('{sessionId}', sessionId)
-      return base + suffix
-    }
-  }
-  return `documents/${userId}/${sessionId}/${cleanPath}`
-}
 
 /**
  * POST /api/workspace/download
@@ -41,7 +24,9 @@ function toS3Key(userId: string, sessionId: string, path: string): string {
  */
 export async function POST(request: NextRequest) {
   try {
-    const { path, sessionId } = await request.json()
+    const body = await request.json()
+    const path = body.path
+    const sessionId = request.headers.get('X-Session-ID') || body.sessionId
 
     if (!path || !sessionId) {
       return NextResponse.json(
@@ -52,26 +37,11 @@ export async function POST(request: NextRequest) {
 
     const user = await extractUserFromRequest(request)
     const userId = user.userId
-
-    let bucket = process.env.ARTIFACT_BUCKET
-    if (!bucket) {
-      const ssmClient = new SSMClient({ region })
-      const projectName = process.env.PROJECT_NAME || 'strands-agent-chatbot'
-      const environment = process.env.ENVIRONMENT || 'dev'
-      const paramName = `/${projectName}/${environment}/agentcore/artifact-bucket`
-      const paramResponse = await ssmClient.send(
-        new GetParameterCommand({ Name: paramName })
-      )
-      bucket = paramResponse.Parameter?.Value
-      if (!bucket) {
-        return NextResponse.json(
-          { error: 'Artifact bucket not configured' },
-          { status: 500 }
-        )
-      }
-    }
-
-    const s3Key = toS3Key(userId, sessionId, path)
+    const { bucket, key: s3Key } = await resolveWorkspaceS3Location(
+      userId,
+      sessionId,
+      path,
+    )
     const filename = path.split('/').pop() || 'download'
 
     const s3Client = new S3Client({ region })
@@ -85,6 +55,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ url, filename })
   } catch (error) {
+    if (error instanceof WorkspacePathError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
     console.error('[WorkspaceDownload] Error:', error)
     return NextResponse.json(
       { error: 'Failed to generate download URL' },

--- a/chatbot-app/frontend/src/app/api/workspace/entries/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/entries/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { extractUserFromRequest } from '@/lib/auth-utils'
+import {
+  S3WorkspaceRepository,
+  WorkspacePathError,
+} from '@/lib/workspace/s3-repository'
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionId = request.headers.get('X-Session-ID')
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Session ID required' }, { status: 400 })
+    }
+
+    const user = await extractUserFromRequest(request)
+    const repository = new S3WorkspaceRepository()
+    const page = await repository.list(
+      user.userId,
+      sessionId,
+      request.nextUrl.searchParams.get('path') || '',
+      request.nextUrl.searchParams.get('cursor') || undefined,
+    )
+    return NextResponse.json(page)
+  } catch (error) {
+    if (error instanceof WorkspacePathError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+    console.error('[WorkspaceEntries] Error:', error)
+    return NextResponse.json(
+      { error: 'Failed to list workspace entries' },
+      { status: 500 },
+    )
+  }
+}

--- a/chatbot-app/frontend/src/app/api/workspace/preview/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/preview/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { extractUserFromRequest } from '@/lib/auth-utils'
+import {
+  S3WorkspaceRepository,
+  WorkspacePathError,
+} from '@/lib/workspace/s3-repository'
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionId = request.headers.get('X-Session-ID')
+    const path = request.nextUrl.searchParams.get('path')
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Session ID required' }, { status: 400 })
+    }
+    if (!path) {
+      return NextResponse.json({ error: 'File path required' }, { status: 400 })
+    }
+
+    const user = await extractUserFromRequest(request)
+    const repository = new S3WorkspaceRepository()
+    const preview = await repository.preview(user.userId, sessionId, path)
+    return NextResponse.json(preview)
+  } catch (error) {
+    if (error instanceof WorkspacePathError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+    console.error('[WorkspacePreview] Error:', error)
+    return NextResponse.json(
+      { error: 'Failed to preview workspace file' },
+      { status: 500 },
+    )
+  }
+}

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -23,7 +23,7 @@ import { SidebarTrigger, SidebarInset, useSidebar } from "@/components/ui/sideba
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { Skeleton } from "@/components/ui/skeleton"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { ArrowDown, Loader2, PanelRightClose, PanelRightOpen } from "lucide-react"
+import { ArrowDown, Files, FolderTree, Loader2 } from "lucide-react"
 import { ModelConfigDialog } from "@/components/ModelConfigDialog"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { buildArtifactContext } from "@/lib/artifactContext"
@@ -229,6 +229,7 @@ export function ChatInterface() {
     reloadFromStorage,
     justUpdated: artifactJustUpdated,
   } = useArtifacts(sessionId)
+  const [rightSidebarView, setRightSidebarView] = useState<'artifacts' | 'workspace'>('artifacts')
 
   const researchInvocationCount = useMemo(() => {
     const invocationIds = new Set<string>()
@@ -356,6 +357,7 @@ export function ChatInterface() {
     // Opening canvas - close left sidebar
     setOpen(false)
     setOpenMobile(false)
+    setRightSidebarView('artifacts')
     openArtifactBase(id)
   }, [openArtifactBase, setOpen, setOpenMobile])
 
@@ -379,7 +381,10 @@ export function ChatInterface() {
   }, [addArtifact])
 
   useEffect(() => {
-    openCanvasRef.current = openCanvasBase
+    openCanvasRef.current = () => {
+      setRightSidebarView('artifacts')
+      openCanvasBase()
+    }
   }, [openCanvasBase])
 
   useEffect(() => {
@@ -387,14 +392,23 @@ export function ChatInterface() {
   }, [setBrowserArtifactId])
 
   // Wrapper functions to ensure mutual exclusivity between left sidebar and canvas
-  const toggleCanvas = useCallback(() => {
-    if (!isCanvasOpen) {
-      // Opening canvas - close left sidebar
-      setOpen(false)
-      setOpenMobile(false)
+  const toggleRightSidebar = useCallback((view: 'artifacts' | 'workspace') => {
+    if (isCanvasOpen && rightSidebarView === view) {
+      toggleCanvasBase()
+      return
     }
-    toggleCanvasBase()
-  }, [isCanvasOpen, toggleCanvasBase, setOpen, setOpenMobile])
+    setOpen(false)
+    setOpenMobile(false)
+    setRightSidebarView(view)
+    openCanvasBase()
+  }, [
+    isCanvasOpen,
+    openCanvasBase,
+    rightSidebarView,
+    setOpen,
+    setOpenMobile,
+    toggleCanvasBase,
+  ])
 
   const closeCanvas = useCallback(() => {
     closeCanvasBase()
@@ -404,6 +418,7 @@ export function ChatInterface() {
     // Opening canvas - close left sidebar
     setOpen(false)
     setOpenMobile(false)
+    setRightSidebarView('artifacts')
     openCanvasBase()
   }, [openCanvasBase, setOpen, setOpenMobile])
 
@@ -744,41 +759,73 @@ export function ChatInterface() {
     return hasActiveSwarmProgress && lastGroup?.type === 'assistant_turn';
   }, [swarmProgress, groupedMessages])
 
-  // Reusable artifact sidebar toggle (large variant for empty state, small for chat header)
-  const renderCanvasToggle = (large = false) => (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={toggleCanvas}
-            className={`${large ? 'h-9 w-9' : 'h-8 w-8'} relative p-0 hover:bg-muted/60 ${isCanvasOpen ? 'bg-muted text-foreground' : 'text-muted-foreground'}`}
-            aria-label={isCanvasOpen ? 'Close artifacts sidebar' : 'Open artifacts sidebar'}
-          >
-            {isCanvasOpen ? (
-              <PanelRightClose className={large ? 'h-5 w-5' : 'h-4 w-4'} />
-            ) : (
-              <PanelRightOpen className={large ? 'h-5 w-5' : 'h-4 w-4'} />
-            )}
-            {artifacts.length > 0 && (
-              <span className="absolute -top-1 -right-1 h-4 w-4 bg-primary text-primary-foreground text-[10px] font-bold rounded-full flex items-center justify-center">
-                {artifacts.length}
-              </span>
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>
-            {artifacts.length > 0
-              ? `${isCanvasOpen ? 'Close' : 'Open'} artifacts (${artifacts.length})`
-              : 'Open artifacts sidebar'
-            }
-          </p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )
+  const renderRightSidebarToggles = (large = false) => {
+    const buttonSize = large ? 'h-9 w-9' : 'h-8 w-8'
+    const iconSize = large ? 'h-5 w-5' : 'h-4 w-4'
+    const activeView = isCanvasOpen ? rightSidebarView : null
+
+    return (
+      <TooltipProvider delayDuration={300}>
+        <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => toggleRightSidebar('artifacts')}
+                className={`${buttonSize} relative p-0 hover:bg-muted/60 ${
+                  activeView === 'artifacts'
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground'
+                }`}
+                aria-label={
+                  activeView === 'artifacts'
+                    ? 'Close artifacts sidebar'
+                    : 'Open artifacts sidebar'
+                }
+                aria-pressed={activeView === 'artifacts'}
+              >
+                <Files className={iconSize} />
+                {artifacts.length > 0 && (
+                  <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+                    {artifacts.length}
+                  </span>
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{activeView === 'artifacts' ? 'Close artifacts' : 'Open artifacts'}</p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => toggleRightSidebar('workspace')}
+                className={`${buttonSize} p-0 hover:bg-muted/60 ${
+                  activeView === 'workspace'
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground'
+                }`}
+                aria-label={
+                  activeView === 'workspace'
+                    ? 'Close workspace sidebar'
+                    : 'Open workspace sidebar'
+                }
+                aria-pressed={activeView === 'workspace'}
+              >
+                <FolderTree className={iconSize} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{activeView === 'workspace' ? 'Close workspace' : 'Open workspace'}</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
+    )
+  }
 
   return (
     <>
@@ -805,7 +852,7 @@ export function ChatInterface() {
         {/* Artifact sidebar toggle - shown in top-right when no chat has started */}
         {groupedMessages.length === 0 && mounted && !isMobileView && (
           <div className={`absolute top-4 right-4 z-20`}>
-            {renderCanvasToggle(true)}
+            {renderRightSidebarToggles(true)}
           </div>
         )}
 
@@ -818,7 +865,7 @@ export function ChatInterface() {
 
             <div className="flex items-center gap-2">
               {/* Artifact sidebar toggle - hidden on mobile */}
-              {!isMobileView && renderCanvasToggle()}
+              {!isMobileView && renderRightSidebarToggles()}
             </div>
           </div>
         )}
@@ -1108,6 +1155,8 @@ export function ChatInterface() {
           } : undefined
         })()}
         sessionId={sessionId || undefined}
+        activeView={rightSidebarView}
+        onActiveViewChange={setRightSidebarView}
       />
     </>
   )

--- a/chatbot-app/frontend/src/components/canvas/Canvas.tsx
+++ b/chatbot-app/frontend/src/components/canvas/Canvas.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { FileText, Image as ImageIcon, Code, FileDown, Sparkles, Printer, Clock, Tag, GripHorizontal, GripVertical, Monitor, Database, Layers, Files, PanelRightClose } from 'lucide-react'
+import { FileText, Image as ImageIcon, Code, FileDown, Sparkles, Printer, Clock, Tag, GripHorizontal, GripVertical, Monitor, Database, Layers, Files, FolderTree, PanelRightClose } from 'lucide-react'
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
 import { Artifact } from '@/types/artifact'
 import { ResearchArtifact } from './ResearchArtifact'
@@ -13,6 +13,7 @@ import { ExcalidrawRenderer } from './ExcalidrawRenderer'
 import { marked } from 'marked'
 import { citationPrintCSS } from '@/components/ui/CitationLink'
 import { Markdown } from '@/components/ui/Markdown'
+import { WorkspaceBrowser } from './WorkspaceBrowser'
 
 interface BrowserState {
   sessionId: string
@@ -33,6 +34,8 @@ interface CanvasProps {
   browserState?: BrowserState // Live browser state
   justUpdated?: boolean // Flash effect trigger when artifact is updated
   sessionId?: string
+  activeView?: SidebarMode
+  onActiveViewChange?: (view: SidebarMode) => void
 }
 
 const SIDEBAR_MIN_WIDTH = 360
@@ -40,6 +43,7 @@ const SIDEBAR_MAX_WIDTH = 760
 const SIDEBAR_DEFAULT_WIDTH = 520
 const SIDEBAR_CHAT_MIN_WIDTH = 420
 const SIDEBAR_WIDTH_STORAGE_KEY = 'artifacts-sidebar:width'
+type SidebarMode = 'artifacts' | 'workspace'
 
 const getSidebarMaxWidth = () => {
   if (typeof window === 'undefined') return SIDEBAR_MAX_WIDTH
@@ -131,6 +135,8 @@ export function Canvas({
   browserState,
   justUpdated = false,
   sessionId,
+  activeView,
+  onActiveViewChange,
 }: CanvasProps) {
   const selectedArtifactRaw = artifacts.find(a => a.id === selectedArtifactId)
 
@@ -149,6 +155,12 @@ export function Canvas({
   const pendingSidebarWidth = useRef(SIDEBAR_DEFAULT_WIDTH)
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH)
   const [isSidebarResizing, setIsSidebarResizing] = useState(false)
+  const [internalSidebarMode, setInternalSidebarMode] = useState<SidebarMode>('artifacts')
+  const sidebarMode = activeView ?? internalSidebarMode
+  const setSidebarMode = useCallback((view: SidebarMode) => {
+    setInternalSidebarMode(view)
+    onActiveViewChange?.(view)
+  }, [onActiveViewChange])
 
   const displayArtifacts = artifacts
 
@@ -389,7 +401,7 @@ export function Canvas({
       {isOpen && (
         <div
           role="separator"
-          aria-label="Resize artifacts sidebar"
+          aria-label="Resize right sidebar"
           aria-orientation="vertical"
           aria-valuemin={SIDEBAR_MIN_WIDTH}
           aria-valuemax={getSidebarMaxWidth()}
@@ -400,7 +412,7 @@ export function Canvas({
           }`}
           onPointerDown={handleSidebarResizeStart}
           onKeyDown={handleSidebarResizeKeyDown}
-          title="Drag to resize artifacts sidebar"
+          title="Drag to resize right sidebar"
         >
           <span className="h-full w-px bg-transparent group-hover:bg-primary/50 group-focus:bg-primary/50" />
           <span className="absolute flex h-8 w-3 items-center justify-center rounded-sm border border-border bg-background opacity-0 shadow-xs group-hover:opacity-100 group-focus:opacity-100">
@@ -412,26 +424,63 @@ export function Canvas({
       {/* Header */}
       <div className="flex-shrink-0 border-b border-sidebar-border px-4 py-2">
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Files className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium text-sidebar-foreground">Artifacts</span>
-            {displayArtifacts.length > 0 && (
-              <span className="text-xs text-muted-foreground">{displayArtifacts.length}</span>
-            )}
+          <div
+            className="flex items-center rounded-md bg-sidebar-accent/70 p-0.5"
+            role="group"
+            aria-label="Right sidebar view"
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSidebarMode('artifacts')}
+              className={`h-7 gap-1.5 px-2 text-xs ${
+                sidebarMode === 'artifacts'
+                  ? 'bg-sidebar text-sidebar-foreground shadow-xs'
+                  : 'text-muted-foreground hover:text-sidebar-foreground'
+              }`}
+              aria-label="Show artifacts"
+              aria-pressed={sidebarMode === 'artifacts'}
+            >
+              <Files className="h-3.5 w-3.5" />
+              Artifacts
+              {displayArtifacts.length > 0 && (
+                <span className="text-[11px] text-muted-foreground">
+                  {displayArtifacts.length}
+                </span>
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSidebarMode('workspace')}
+              className={`h-7 gap-1.5 px-2 text-xs ${
+                sidebarMode === 'workspace'
+                  ? 'bg-sidebar text-sidebar-foreground shadow-xs'
+                  : 'text-muted-foreground hover:text-sidebar-foreground'
+              }`}
+              aria-label="Show workspace"
+              aria-pressed={sidebarMode === 'workspace'}
+            >
+              <FolderTree className="h-3.5 w-3.5" />
+              Workspace
+            </Button>
           </div>
           <Button
             variant="ghost"
             size="sm"
             onClick={handleClose}
             className="h-8 w-8 p-0"
-            title="Close artifacts sidebar"
-            aria-label="Close artifacts sidebar"
+            title="Close right sidebar"
+            aria-label="Close right sidebar"
           >
             <PanelRightClose className="h-4 w-4" />
           </Button>
         </div>
       </div>
 
+      {sidebarMode === 'workspace' ? (
+        <WorkspaceBrowser sessionId={sessionId} />
+      ) : (
       <div className="flex-1 min-h-0 flex flex-col">
         {/* Preview Area */}
         <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
@@ -642,6 +691,7 @@ export function Canvas({
           </div>
         </div>
       </div>
+      )}
     </div>
   )
 }

--- a/chatbot-app/frontend/src/components/canvas/OfficeViewer.tsx
+++ b/chatbot-app/frontend/src/components/canvas/OfficeViewer.tsx
@@ -4,14 +4,15 @@ import React, { useState, useEffect } from 'react'
 import { Loader2, AlertCircle } from 'lucide-react'
 
 interface OfficeViewerProps {
-  s3Url: string  // s3://bucket/path/file.docx
+  s3Url?: string  // s3://bucket/path/file.docx
+  previewUrl?: string
   filename: string
 }
 
 /**
  * Office document viewer using Microsoft Office Online.
  */
-export function OfficeViewer({ s3Url, filename }: OfficeViewerProps) {
+export function OfficeViewer({ s3Url, previewUrl, filename }: OfficeViewerProps) {
   const [viewerUrl, setViewerUrl] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -22,7 +23,13 @@ export function OfficeViewer({ s3Url, filename }: OfficeViewerProps) {
       setError(null)
 
       try {
-        if (!s3Url || !s3Url.startsWith('s3://')) {
+        if (previewUrl) {
+          const officeViewerUrl = `https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(previewUrl)}`
+          setViewerUrl(officeViewerUrl)
+          return
+        }
+
+        if (!s3Url?.startsWith('s3://')) {
           throw new Error(`Invalid S3 URL format: ${s3Url}`)
         }
 
@@ -60,10 +67,10 @@ export function OfficeViewer({ s3Url, filename }: OfficeViewerProps) {
       }
     }
 
-    if (s3Url) {
+    if (s3Url || previewUrl) {
       loadDocument()
     }
-  }, [s3Url])
+  }, [previewUrl, s3Url])
 
   if (loading) {
     return (

--- a/chatbot-app/frontend/src/components/canvas/WorkspaceBrowser.tsx
+++ b/chatbot-app/frontend/src/components/canvas/WorkspaceBrowser.tsx
@@ -1,0 +1,450 @@
+"use client"
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  AlertCircle,
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  Download,
+  File,
+  FileCode2,
+  FileImage,
+  FileText,
+  Folder,
+  FolderOpen,
+  Loader2,
+  RefreshCw,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Markdown } from '@/components/ui/Markdown'
+import { apiFetch } from '@/lib/api-client'
+import type {
+  WorkspaceEntry,
+  WorkspacePage,
+  WorkspacePreview,
+} from '@/lib/workspace/types'
+import { OfficeViewer } from './OfficeViewer'
+
+interface WorkspaceBrowserProps {
+  sessionId?: string
+}
+
+interface DirectoryState {
+  entries: WorkspaceEntry[]
+  nextCursor?: string
+  loading?: boolean
+  error?: string
+}
+
+function formatSize(size?: number): string {
+  if (size === undefined) return ''
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function FileIcon({ entry }: { entry: WorkspaceEntry }) {
+  if (entry.kind === 'directory') return <Folder className="h-4 w-4" />
+  if (entry.previewKind === 'image') return <FileImage className="h-4 w-4" />
+  if (entry.previewKind === 'text' || entry.previewKind === 'markdown') {
+    return <FileCode2 className="h-4 w-4" />
+  }
+  if (entry.previewKind === 'pdf' || entry.previewKind === 'office') {
+    return <FileText className="h-4 w-4" />
+  }
+  return <File className="h-4 w-4" />
+}
+
+export function WorkspaceBrowser({ sessionId }: WorkspaceBrowserProps) {
+  const [directories, setDirectories] = useState<Record<string, DirectoryState>>({})
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [selected, setSelected] = useState<WorkspacePreview | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [downloading, setDownloading] = useState(false)
+  const workspaceGeneration = useRef(0)
+  const previewRequestId = useRef(0)
+
+  const loadDirectory = useCallback(async (
+    path: string,
+    cursor?: string,
+    append = false,
+  ) => {
+    if (!sessionId) return
+    const generation = workspaceGeneration.current
+    setDirectories(current => ({
+      ...current,
+      [path]: {
+        ...(current[path] || { entries: [] }),
+        loading: true,
+        error: undefined,
+      },
+    }))
+
+    try {
+      const query = new URLSearchParams()
+      if (path) query.set('path', path)
+      if (cursor) query.set('cursor', cursor)
+      const queryString = query.toString()
+      const response = await apiFetch(
+        `workspace/entries${queryString ? `?${queryString}` : ''}`,
+        { headers: { 'X-Session-ID': sessionId } },
+      )
+      if (!response.ok) throw new Error('Unable to load workspace')
+      const page = await response.json() as WorkspacePage
+      if (generation !== workspaceGeneration.current) return
+      setDirectories(current => ({
+        ...current,
+        [path]: {
+          entries: append
+            ? [...(current[path]?.entries || []), ...page.entries]
+            : page.entries,
+          nextCursor: page.nextCursor,
+          loading: false,
+        },
+      }))
+    } catch (error) {
+      if (generation !== workspaceGeneration.current) return
+      setDirectories(current => ({
+        ...current,
+        [path]: {
+          ...(current[path] || { entries: [] }),
+          loading: false,
+          error: error instanceof Error ? error.message : 'Unable to load workspace',
+        },
+      }))
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    workspaceGeneration.current += 1
+    previewRequestId.current += 1
+    setDirectories({})
+    setExpanded(new Set())
+    setSelected(null)
+    setPreviewLoading(false)
+    setPreviewError(null)
+    setDownloading(false)
+    if (sessionId) void loadDirectory('')
+  }, [loadDirectory, sessionId])
+
+  const toggleDirectory = useCallback((entry: WorkspaceEntry) => {
+    const shouldLoad = !expanded.has(entry.path) && !directories[entry.path]
+    setExpanded(current => {
+      const next = new Set(current)
+      if (next.has(entry.path)) {
+        next.delete(entry.path)
+      } else {
+        next.add(entry.path)
+      }
+      return next
+    })
+    if (shouldLoad) void loadDirectory(entry.path)
+  }, [directories, expanded, loadDirectory])
+
+  const openFile = useCallback(async (entry: WorkspaceEntry) => {
+    if (!sessionId) return
+    const requestId = ++previewRequestId.current
+    setPreviewLoading(true)
+    setPreviewError(null)
+    try {
+      const response = await apiFetch(
+        `workspace/preview?path=${encodeURIComponent(entry.path)}`,
+        { headers: { 'X-Session-ID': sessionId } },
+      )
+      if (!response.ok) throw new Error('Preview is not available')
+      const preview = await response.json() as WorkspacePreview
+      if (requestId !== previewRequestId.current) return
+      setSelected(preview)
+    } catch (error) {
+      if (requestId !== previewRequestId.current) return
+      setPreviewError(error instanceof Error ? error.message : 'Preview is not available')
+    } finally {
+      if (requestId === previewRequestId.current) setPreviewLoading(false)
+    }
+  }, [sessionId])
+
+  const downloadSelected = useCallback(async () => {
+    if (!selected || !sessionId) return
+    setDownloading(true)
+    try {
+      const response = await apiFetch('workspace/download', {
+        method: 'POST',
+        headers: { 'X-Session-ID': sessionId },
+        body: JSON.stringify({ path: selected.entry.path, sessionId }),
+      })
+      if (!response.ok) throw new Error('Download is not available')
+      const { url, filename } = await response.json()
+      const link = document.createElement('a')
+      link.href = url
+      link.download = filename || selected.entry.name
+      link.rel = 'noopener noreferrer'
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch (error) {
+      setPreviewError(error instanceof Error ? error.message : 'Download is not available')
+    } finally {
+      setDownloading(false)
+    }
+  }, [selected, sessionId])
+
+  const refresh = useCallback(() => {
+    workspaceGeneration.current += 1
+    previewRequestId.current += 1
+    setDirectories({})
+    setExpanded(new Set())
+    setSelected(null)
+    setPreviewLoading(false)
+    setPreviewError(null)
+    setDownloading(false)
+    if (sessionId) void loadDirectory('')
+  }, [loadDirectory, sessionId])
+
+  const renderDirectory = useCallback((path: string, depth = 0): React.ReactNode => {
+    const directory = directories[path]
+    if (!directory) return null
+
+    return (
+      <>
+        {directory.entries.map(entry => {
+          const isExpanded = expanded.has(entry.path)
+          return (
+            <React.Fragment key={entry.id}>
+              <button
+                type="button"
+                className="flex h-8 w-full items-center gap-2 rounded-sm pr-2 text-left text-sm text-sidebar-foreground hover:bg-sidebar-accent/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                style={{ paddingLeft: `${8 + depth * 16}px` }}
+                onClick={() => (
+                  entry.kind === 'directory' ? toggleDirectory(entry) : void openFile(entry)
+                )}
+                aria-expanded={entry.kind === 'directory' ? isExpanded : undefined}
+              >
+                {entry.kind === 'directory' ? (
+                  <>
+                    {isExpanded
+                      ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+                    {isExpanded
+                      ? <FolderOpen className="h-4 w-4 shrink-0 text-primary" />
+                      : <Folder className="h-4 w-4 shrink-0 text-primary" />}
+                  </>
+                ) : (
+                  <>
+                    <span className="w-3.5 shrink-0" />
+                    <span className="shrink-0 text-muted-foreground">
+                      <FileIcon entry={entry} />
+                    </span>
+                  </>
+                )}
+                <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+                {entry.kind === 'file' && entry.size !== undefined && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {formatSize(entry.size)}
+                  </span>
+                )}
+              </button>
+              {entry.kind === 'directory' && isExpanded && (
+                <>
+                  {directories[entry.path]?.loading && (
+                    <div
+                      className="flex h-8 items-center gap-2 text-xs text-muted-foreground"
+                      style={{ paddingLeft: `${40 + depth * 16}px` }}
+                    >
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Loading
+                    </div>
+                  )}
+                  {directories[entry.path]?.error && (
+                    <div
+                      className="py-2 pr-2 text-xs text-destructive"
+                      style={{ paddingLeft: `${40 + depth * 16}px` }}
+                    >
+                      {directories[entry.path]?.error}
+                    </div>
+                  )}
+                  {!directories[entry.path]?.loading
+                    && !directories[entry.path]?.error
+                    && directories[entry.path]?.entries.length === 0 && (
+                    <div
+                      className="h-8 py-1 text-xs text-muted-foreground"
+                      style={{ paddingLeft: `${40 + depth * 16}px` }}
+                    >
+                      Empty folder
+                    </div>
+                  )}
+                  {renderDirectory(entry.path, depth + 1)}
+                </>
+              )}
+            </React.Fragment>
+          )
+        })}
+        {directory.nextCursor && (
+          <button
+            type="button"
+            className="h-8 text-xs text-primary hover:underline"
+            style={{ marginLeft: `${32 + depth * 16}px` }}
+            disabled={directory.loading}
+            onClick={() => void loadDirectory(path, directory.nextCursor, true)}
+          >
+            Load more
+          </button>
+        )}
+      </>
+    )
+  }, [directories, expanded, loadDirectory, openFile, toggleDirectory])
+
+  const previewContent = useMemo(() => {
+    if (!selected) return null
+    if (selected.kind === 'markdown') {
+      return (
+        <div className="p-4">
+          <Markdown sessionId={sessionId}>{selected.content || ''}</Markdown>
+        </div>
+      )
+    }
+    if (selected.kind === 'text') {
+      return (
+        <pre className="min-h-full overflow-auto p-4 font-mono text-xs leading-5 text-sidebar-foreground whitespace-pre-wrap">
+          {selected.content || ''}
+        </pre>
+      )
+    }
+    if (selected.kind === 'image' && selected.url) {
+      return (
+        <div className="flex min-h-full items-start justify-center p-4">
+          <img
+            src={selected.url}
+            alt={selected.entry.name}
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
+      )
+    }
+    if (selected.kind === 'pdf' && selected.url) {
+      return (
+        <iframe
+          src={selected.url}
+          title={`Preview: ${selected.entry.name}`}
+          className="h-full w-full border-0"
+        />
+      )
+    }
+    if (selected.kind === 'office' && selected.url) {
+      return <OfficeViewer previewUrl={selected.url} filename={selected.entry.name} />
+    }
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center text-muted-foreground">
+        <File className="h-8 w-8" />
+        <p className="text-sm">Preview is not available for this file.</p>
+      </div>
+    )
+  }, [selected, sessionId])
+
+  if (!sessionId) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        Start a conversation to create a session workspace.
+      </div>
+    )
+  }
+
+  if (selected) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex h-12 shrink-0 items-center gap-2 border-b border-sidebar-border px-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={() => {
+              setSelected(null)
+              setPreviewError(null)
+            }}
+            aria-label="Back to workspace files"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{selected.entry.name}</div>
+            <div className="truncate text-xs text-muted-foreground">
+              {selected.entry.path}
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={() => void downloadSelected()}
+            disabled={downloading}
+            aria-label={`Download ${selected.entry.name}`}
+          >
+            {downloading
+              ? <Loader2 className="h-4 w-4 animate-spin" />
+              : <Download className="h-4 w-4" />}
+          </Button>
+        </div>
+        {selected.truncated && (
+          <div className="border-b border-sidebar-border bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+            Showing the first 1 MB. Download the file to view the rest.
+          </div>
+        )}
+        {previewError && (
+          <div className="flex items-center gap-2 border-b border-destructive/20 bg-destructive/5 px-4 py-2 text-xs text-destructive">
+            <AlertCircle className="h-3.5 w-3.5" />
+            {previewError}
+          </div>
+        )}
+        <div className="min-h-0 flex-1 overflow-auto">{previewContent}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex h-11 shrink-0 items-center justify-between border-b border-sidebar-border/60 px-3">
+        <div>
+          <div className="text-sm font-medium">Session files</div>
+          <div className="text-xs text-muted-foreground">Persistent workspace</div>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0"
+          onClick={refresh}
+          aria-label="Refresh workspace files"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </Button>
+      </div>
+      {previewLoading && (
+        <div className="flex items-center gap-2 border-b border-sidebar-border/60 px-4 py-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Opening file
+        </div>
+      )}
+      {previewError && (
+        <div className="flex items-center gap-2 border-b border-destructive/20 bg-destructive/5 px-4 py-2 text-xs text-destructive">
+          <AlertCircle className="h-3.5 w-3.5" />
+          {previewError}
+        </div>
+      )}
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="p-2">
+          {directories['']?.loading && (
+            <div className="flex h-20 items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading workspace
+            </div>
+          )}
+          {directories['']?.error && (
+            <div className="p-4 text-sm text-destructive">{directories[''].error}</div>
+          )}
+          {renderDirectory('')}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
+++ b/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
@@ -77,7 +77,12 @@ export function normalizeWorkspacePath(path = ''): string {
     throw new WorkspacePathError('Invalid workspace path')
   }
 
-  const clean = path.replace(/^\/+|\/+$/g, '')
+  let start = 0
+  let end = path.length
+  while (start < end && path.charCodeAt(start) === 47) start += 1
+  while (end > start && path.charCodeAt(end - 1) === 47) end -= 1
+
+  const clean = path.slice(start, end)
   if (!clean) return ''
 
   const segments = clean.split('/')

--- a/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
+++ b/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
@@ -1,0 +1,339 @@
+import {
+  GetObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3'
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import type {
+  WorkspaceEntry,
+  WorkspacePage,
+  WorkspacePreview,
+  WorkspacePreviewKind,
+  WorkspaceRepository,
+} from './types'
+
+const region = process.env.AWS_REGION || 'us-west-2'
+const TEXT_PREVIEW_LIMIT = 1024 * 1024
+
+interface Namespace {
+  logicalPath: string
+  label: string
+  prefix: (userId: string, sessionId: string) => string
+}
+
+const NAMESPACES: Namespace[] = [
+  {
+    logicalPath: 'documents',
+    label: 'Documents',
+    prefix: (userId, sessionId) => `documents/${userId}/${sessionId}/`,
+  },
+  {
+    logicalPath: 'code-interpreter',
+    label: 'Code Interpreter',
+    prefix: (userId, sessionId) => `code-interpreter-workspace/${userId}/${sessionId}/`,
+  },
+  {
+    logicalPath: 'code-agent',
+    label: 'Code Agent',
+    prefix: (userId, sessionId) => `code-agent-workspace/${userId}/${sessionId}/`,
+  },
+]
+
+const MIME_TYPES: Record<string, string> = {
+  csv: 'text/csv',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  gif: 'image/gif',
+  html: 'text/html',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  js: 'text/javascript',
+  json: 'application/json',
+  md: 'text/markdown',
+  pdf: 'application/pdf',
+  png: 'image/png',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  py: 'text/x-python',
+  svg: 'image/svg+xml',
+  ts: 'text/typescript',
+  tsx: 'text/tsx',
+  txt: 'text/plain',
+  webp: 'image/webp',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  xml: 'application/xml',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+}
+
+let bucketPromise: Promise<string> | undefined
+
+export class WorkspacePathError extends Error {}
+
+export function normalizeWorkspacePath(path = ''): string {
+  if (path.includes('\0') || path.includes('\\')) {
+    throw new WorkspacePathError('Invalid workspace path')
+  }
+
+  const clean = path.replace(/^\/+|\/+$/g, '')
+  if (!clean) return ''
+
+  const segments = clean.split('/')
+  if (segments.some(segment => !segment || segment === '.' || segment === '..')) {
+    throw new WorkspacePathError('Invalid workspace path')
+  }
+  return segments.join('/')
+}
+
+export function getWorkspaceMimeType(path: string): string {
+  const extension = path.split('.').pop()?.toLowerCase() || ''
+  return MIME_TYPES[extension] || 'application/octet-stream'
+}
+
+export function getWorkspacePreviewKind(path: string): WorkspacePreviewKind {
+  const mimeType = getWorkspaceMimeType(path)
+  if (mimeType === 'text/markdown') return 'markdown'
+  if (
+    mimeType.startsWith('text/')
+    || mimeType === 'application/json'
+    || mimeType === 'application/xml'
+    || mimeType === 'application/yaml'
+  ) return 'text'
+  if (mimeType.startsWith('image/')) return 'image'
+  if (mimeType === 'application/pdf') return 'pdf'
+  if (
+    mimeType.includes('officedocument')
+    || mimeType === 'application/msword'
+    || mimeType === 'application/vnd.ms-excel'
+    || mimeType === 'application/vnd.ms-powerpoint'
+  ) return 'office'
+  return 'unsupported'
+}
+
+function encodeCursor(path: string, token: string): string {
+  return Buffer.from(JSON.stringify({ path, token }), 'utf8').toString('base64url')
+}
+
+function decodeCursor(path: string, cursor?: string): string | undefined {
+  if (!cursor) return undefined
+  try {
+    const decoded = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
+    if (decoded.path !== path || typeof decoded.token !== 'string') {
+      throw new Error('Cursor does not match path')
+    }
+    return decoded.token
+  } catch {
+    throw new WorkspacePathError('Invalid workspace cursor')
+  }
+}
+
+async function getWorkspaceBucket(): Promise<string> {
+  const configuredBucket = process.env.ARTIFACT_BUCKET
+  if (configuredBucket) return configuredBucket
+
+  if (!bucketPromise) {
+    bucketPromise = (async () => {
+      const projectName = process.env.PROJECT_NAME || 'strands-agent-chatbot'
+      const environment = process.env.ENVIRONMENT || 'dev'
+      const parameterName = `/${projectName}/${environment}/agentcore/artifact-bucket`
+      const response = await new SSMClient({ region }).send(
+        new GetParameterCommand({ Name: parameterName }),
+      )
+      const bucket = response.Parameter?.Value
+      if (!bucket) throw new Error('Artifact bucket not configured')
+      return bucket
+    })().catch(error => {
+      bucketPromise = undefined
+      throw error
+    })
+  }
+  return bucketPromise
+}
+
+function namespaceForPath(path: string): {
+  namespace: Namespace
+  relativePath: string
+} {
+  const [root, ...rest] = path.split('/')
+  const namespace = NAMESPACES.find(candidate => candidate.logicalPath === root)
+  if (!namespace) throw new WorkspacePathError('Unknown workspace namespace')
+  return { namespace, relativePath: rest.join('/') }
+}
+
+function entryId(path: string): string {
+  return Buffer.from(path, 'utf8').toString('base64url')
+}
+
+function directoryEntry(path: string, name: string): WorkspaceEntry {
+  const parentPath = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : ''
+  return {
+    id: entryId(path),
+    path,
+    parentPath,
+    name,
+    kind: 'directory',
+  }
+}
+
+export async function resolveWorkspaceS3Location(
+  userId: string,
+  sessionId: string,
+  logicalPath: string,
+): Promise<{ bucket: string; key: string }> {
+  const path = normalizeWorkspacePath(logicalPath)
+  const { namespace, relativePath } = namespaceForPath(path)
+  if (!relativePath) throw new WorkspacePathError('A file path is required')
+  return {
+    bucket: await getWorkspaceBucket(),
+    key: `${namespace.prefix(userId, sessionId)}${relativePath}`,
+  }
+}
+
+async function bodyToString(body: unknown): Promise<string> {
+  if (!body) return ''
+  if (
+    typeof body === 'object'
+    && body !== null
+    && 'transformToString' in body
+    && typeof body.transformToString === 'function'
+  ) {
+    return body.transformToString()
+  }
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body)
+  throw new Error('Unsupported S3 response body')
+}
+
+export class S3WorkspaceRepository implements WorkspaceRepository {
+  private readonly s3: S3Client
+
+  constructor(s3 = new S3Client({ region })) {
+    this.s3 = s3
+  }
+
+  async list(
+    userId: string,
+    sessionId: string,
+    rawPath = '',
+    cursor?: string,
+  ): Promise<WorkspacePage> {
+    const path = normalizeWorkspacePath(rawPath)
+
+    if (!path) {
+      return {
+        entries: NAMESPACES.map(namespace => (
+          directoryEntry(namespace.logicalPath, namespace.label)
+        )),
+      }
+    }
+
+    const { namespace, relativePath } = namespaceForPath(path)
+    const bucket = await getWorkspaceBucket()
+    const basePrefix = namespace.prefix(userId, sessionId)
+    const prefix = relativePath ? `${basePrefix}${relativePath}/` : basePrefix
+    const continuationToken = decodeCursor(path, cursor)
+    const response = await this.s3.send(new ListObjectsV2Command({
+      Bucket: bucket,
+      Prefix: prefix,
+      Delimiter: '/',
+      ContinuationToken: continuationToken,
+      MaxKeys: 200,
+    }))
+
+    const entries: WorkspaceEntry[] = []
+    for (const commonPrefix of response.CommonPrefixes || []) {
+      if (!commonPrefix.Prefix) continue
+      const relative = commonPrefix.Prefix.slice(basePrefix.length).replace(/\/$/, '')
+      const name = relative.split('/').pop()
+      if (!name || name.startsWith('.')) continue
+      const logicalPath = `${namespace.logicalPath}/${relative}`
+      entries.push(directoryEntry(logicalPath, name))
+    }
+
+    for (const object of response.Contents || []) {
+      if (!object.Key || object.Key === prefix) continue
+      const relative = object.Key.slice(basePrefix.length)
+      const name = relative.split('/').pop()
+      if (!name || name.startsWith('.')) continue
+      const logicalPath = `${namespace.logicalPath}/${relative}`
+      entries.push({
+        id: entryId(logicalPath),
+        path: logicalPath,
+        parentPath: path,
+        name,
+        kind: 'file',
+        size: object.Size,
+        modifiedAt: object.LastModified?.toISOString(),
+        mimeType: getWorkspaceMimeType(logicalPath),
+        previewKind: getWorkspacePreviewKind(logicalPath),
+      })
+    }
+
+    entries.sort((left, right) => {
+      if (left.kind !== right.kind) return left.kind === 'directory' ? -1 : 1
+      return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
+    })
+
+    return {
+      entries,
+      nextCursor: response.NextContinuationToken
+        ? encodeCursor(path, response.NextContinuationToken)
+        : undefined,
+    }
+  }
+
+  async preview(
+    userId: string,
+    sessionId: string,
+    rawPath: string,
+  ): Promise<WorkspacePreview> {
+    const path = normalizeWorkspacePath(rawPath)
+    const { bucket, key } = await resolveWorkspaceS3Location(userId, sessionId, path)
+    const name = path.split('/').pop() || path
+    const parentPath = path.slice(0, Math.max(0, path.lastIndexOf('/')))
+    const kind = getWorkspacePreviewKind(path)
+    const mimeType = getWorkspaceMimeType(path)
+    const entry: WorkspaceEntry = {
+      id: entryId(path),
+      path,
+      parentPath,
+      name,
+      kind: 'file',
+      mimeType,
+      previewKind: kind,
+    }
+
+    if (kind === 'text' || kind === 'markdown') {
+      const response = await this.s3.send(new GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Range: `bytes=0-${TEXT_PREVIEW_LIMIT - 1}`,
+      }))
+      const content = await bodyToString(response.Body)
+      const totalSize = response.ContentRange
+        ? Number(response.ContentRange.split('/').pop())
+        : response.ContentLength
+      return {
+        entry: { ...entry, size: totalSize },
+        kind,
+        content,
+        truncated: typeof totalSize === 'number' && totalSize > TEXT_PREVIEW_LIMIT,
+      }
+    }
+
+    const command = new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      ResponseContentDisposition: `inline; filename="${name.replace(/"/g, '')}"`,
+      ResponseContentType: mimeType,
+    })
+    const url = await getSignedUrl(this.s3, command, { expiresIn: 900 })
+
+    return {
+      entry,
+      kind,
+      url,
+    }
+  }
+}

--- a/chatbot-app/frontend/src/lib/workspace/types.ts
+++ b/chatbot-app/frontend/src/lib/workspace/types.ts
@@ -1,0 +1,48 @@
+export type WorkspaceEntryKind = 'file' | 'directory'
+
+export type WorkspacePreviewKind =
+  | 'text'
+  | 'markdown'
+  | 'image'
+  | 'pdf'
+  | 'office'
+  | 'unsupported'
+
+export interface WorkspaceEntry {
+  id: string
+  path: string
+  parentPath: string
+  name: string
+  kind: WorkspaceEntryKind
+  size?: number
+  modifiedAt?: string
+  mimeType?: string
+  previewKind?: WorkspacePreviewKind
+}
+
+export interface WorkspacePage {
+  entries: WorkspaceEntry[]
+  nextCursor?: string
+}
+
+export interface WorkspacePreview {
+  entry: WorkspaceEntry
+  kind: WorkspacePreviewKind
+  content?: string
+  url?: string
+  truncated?: boolean
+}
+
+export interface WorkspaceRepository {
+  list(
+    userId: string,
+    sessionId: string,
+    path?: string,
+    cursor?: string,
+  ): Promise<WorkspacePage>
+  preview(
+    userId: string,
+    sessionId: string,
+    path: string,
+  ): Promise<WorkspacePreview>
+}

--- a/docs/architecture/session-workspace.md
+++ b/docs/architecture/session-workspace.md
@@ -1,0 +1,91 @@
+# Session Workspace
+
+## Status
+
+Accepted for incremental implementation.
+
+## Context
+
+Agent tools currently use an S3 bucket as a workspace, but each integration
+implements its own object synchronization. Code Interpreter downloads objects,
+injects them into its filesystem, and uploads results again. Code Agent restores
+and synchronizes a separate prefix. The frontend discovers only selected
+document types after a tool finishes.
+
+This makes S3 object keys part of several client and tool contracts and prevents
+the session from feeling like one persistent workspace.
+
+## Decision
+
+The application exposes one logical workspace per authenticated user and chat
+session. Consumers use logical paths and never depend on S3 keys or a particular
+filesystem implementation.
+
+The initial repository maps existing S3 prefixes into these namespaces:
+
+| Logical path | Current storage prefix |
+| --- | --- |
+| `documents/` | `documents/{userId}/{sessionId}/` |
+| `code-interpreter/` | `code-interpreter-workspace/{userId}/{sessionId}/` |
+| `code-agent/` | `code-agent-workspace/{userId}/{sessionId}/` |
+
+The repository contract supports directory listing, file metadata, preview, and
+download. Directory listing is paginated and scoped by both authenticated user
+and explicit session ID. Paths containing traversal segments, backslashes, or
+NUL bytes are rejected.
+
+The right sidebar has two views:
+
+- **Artifacts** are conversational projections such as research reports and
+  browser sessions.
+- **Workspace** is the durable file tree for the chat session.
+
+Selecting a workspace file opens its preview in the same sidebar. Download is a
+secondary action.
+
+## API Contract
+
+```text
+GET /api/workspace/entries?path=&cursor=
+GET /api/workspace/preview?path=
+POST /api/workspace/download
+```
+
+All requests require `X-Session-ID`; authenticated identity determines the user
+scope. The frontend consumes `WorkspaceEntry` and `WorkspacePreview` objects
+defined in `src/lib/workspace/types.ts`.
+
+## Storage Evolution
+
+The S3 repository is a compatibility implementation. A later phase will attach
+Amazon S3 Files to AgentCore Runtime and Code Interpreter and implement the same
+repository contract over the mounted filesystem.
+
+Arbitrary-code environments must receive a session-rooted access point. A
+shared root access point must not be exposed to Code Interpreter or Code Agent.
+The intended mounted layout is:
+
+```text
+/mnt/workspace
+├── uploads/
+├── projects/
+├── outputs/
+├── tools/
+└── .system/
+```
+
+The `.system` namespace is never shown in the user-facing browser.
+
+## Retention
+
+The active workspace follows the chat session lifecycle. Long-lived or shared
+outputs are explicitly published or archived. Session deletion must eventually
+remove the corresponding workspace root and access point.
+
+## Consequences
+
+- Existing tools continue to work while the UI gains a unified file browser.
+- Storage migration does not require another frontend protocol change.
+- Artifacts and files remain separate concepts.
+- Real-time file change events, upload, rename, delete, and S3 Files mounts are
+  follow-up phases rather than implicit behavior in the initial slice.


### PR DESCRIPTION
## Summary
- define a storage-neutral session workspace contract and S3 compatibility repository
- add paginated workspace list and bounded preview APIs with path validation
- add direct Artifacts and Workspace sidebar controls, lazy file tree, inline previews, and secondary downloads
- document the S3 Files migration boundary and session isolation model

## Validation
- frontend: 48 files / 684 tests
- TypeScript type-check and production build
- dev ECS revision 56 rollout completed
- workspace root API returns logical namespaces; traversal requests return 400
- root and health endpoints return 200 with no deployment errors