### PR TITLE
feat: add persistent S3 Files session workspace

### DIFF
--- a/chatbot-app/agentcore/skills/code-agent/SKILL.md
+++ b/chatbot-app/agentcore/skills/code-agent/SKILL.md
@@ -21,8 +21,8 @@ Brief it like you'd brief a capable engineer: describe what you want to achieve,
 |---|---|---|
 | **Nature** | Autonomous agent (Claude Code) | Sandboxed execution environment |
 | **Best for** | Multi-file projects, refactoring, test suites | Quick scripts, data analysis, prototyping |
-| **File persistence** | All files auto-synced to S3, accessible via workspace tools | Only when `output_filename` is set |
-| **Session state** | Files + conversation persist across sessions | Variables persist within session only |
+| **File persistence** | All files auto-synced to S3, accessible via workspace tools | Files in `/mnt/workspace` persist across interpreter restarts |
+| **Session state** | Files + conversation persist across sessions | Variables persist within one interpreter session; workspace files persist for the chat session |
 | **Autonomy** | Plans, writes, runs, and iterates independently | You write the code it executes |
 | **Use when** | You need an engineer to solve a problem end-to-end | You need to run a specific piece of code |
 

--- a/chatbot-app/agentcore/skills/code-interpreter/SKILL.md
+++ b/chatbot-app/agentcore/skills/code-interpreter/SKILL.md
@@ -12,7 +12,7 @@ A general-purpose code execution environment powered by AWS Bedrock AgentCore Co
 - **execute_code(code, language, output_filename)**: Execute Python, JavaScript, or TypeScript code.
 - **execute_command(command)**: Execute shell commands.
 - **file_operations(operation, paths, content)**: Read, write, list, or remove files in the sandbox.
-- **ci_push_to_workspace(paths)**: Save sandbox files to the shared workspace (S3). Omit `paths` to save all files in the sandbox root.
+- **ci_push_to_workspace(paths)**: Compatibility helper for environments without a mounted workspace. Do not call it when `/mnt/workspace` is available.
 
 ## Tool Parameters
 
@@ -131,31 +131,37 @@ For production tasks (creating documents, charts, presentations), prefer special
 |---|---|---|
 | **Nature** | Sandboxed execution environment | Autonomous agent (Claude Code) |
 | **Best for** | Quick scripts, data analysis, prototyping | Multi-file projects, refactoring, test suites |
-| **File persistence** | Only when `output_filename` is set | All files auto-synced to S3 |
-| **Session state** | Variables persist within session | Files + conversation persist across sessions |
+| **File persistence** | Files in `/mnt/workspace` persist across interpreter restarts | All files auto-synced to S3 |
+| **Session state** | Variables persist within one interpreter session; workspace files persist for the chat session | Files + conversation persist across sessions |
 | **Autonomy** | You write the code | Agent plans, writes, runs, and iterates |
 | **Use when** | You need to run a specific piece of code | You need an engineer to solve a problem end-to-end |
 
 ## Workspace Integration
 
-All files go to the `code-interpreter/` namespace — a flat, session-isolated space separate from office documents.
+The chat session has a persistent filesystem mounted at `/mnt/workspace`.
+Relative file paths used by Code Interpreter tools resolve inside this directory.
+Files written there are immediately available in the Workspace panel under the
+`code-interpreter/` namespace and remain available when the interpreter session
+is restarted.
 
-**Sandbox → Workspace (save outputs):**
+**Create persistent files directly:**
 
 ```json
-// Save a specific file after execution
-{ "tool": "ci_push_to_workspace", "paths": ["chart.png", "results.json"] }
-
-// Save everything in the sandbox root
-{ "tool": "ci_push_to_workspace" }
-
-// Alternative: save a single file inline during execute_code
-{ "tool": "execute_code", "output_filename": "chart.png", "code": "..." }
+{
+  "tool": "execute_code",
+  "code": "from pathlib import Path\nPath('/mnt/workspace/results.json').write_text('{\"ok\": true}')"
+}
 ```
 
-**Uploaded files (auto-preloaded):**
+`output_filename` may still be used when a generated file should be surfaced as
+an explicit artifact. It is not required for persistence. Do not call
+`ci_push_to_workspace` when the mount is available; that tool remains only for
+legacy fallback deployments.
 
-Files uploaded by the user (e.g. ZIP archives) are automatically available in the sandbox — no manual loading needed. Just use them directly in `execute_code`.
+**Uploaded files:**
+
+Files uploaded by the user are available in the mounted workspace without
+manual loading or base64 transfer.
 
 **Read saved files via workspace skill:**
 ```
@@ -164,15 +170,15 @@ workspace_read("code-interpreter/results.json")
 workspace_list("code-interpreter/")
 ```
 
-> Text files (`.py`, `.csv`, `.json`, `.txt`, etc.) are transferred as-is.
-> Binary files (`.png`, `.pdf`, `.xlsx`, etc.) are handled via base64 encoding automatically.
+Text and binary files use the same mounted filesystem; no transfer step is
+required.
 
 ## Environment
 
 - **Languages:** Python (recommended, 200+ libraries), JavaScript, TypeScript
 - **Shell:** Full shell access via `execute_command`
-- **File system:** Persistent within session; use `file_operations` to manage files
-- **Session state:** Variables and files persist across multiple calls within the same session
+- **File system:** `/mnt/workspace` persists across Code Interpreter restarts for the chat session
+- **Session state:** Variables persist within one interpreter session; files persist in the mounted workspace
 - **Network:** Internet access available (can use `requests`, `urllib`, `curl`)
 
 ## Supported Languages

--- a/chatbot-app/agentcore/src/agent/processor/file_processor.py
+++ b/chatbot-app/agentcore/src/agent/processor/file_processor.py
@@ -215,11 +215,11 @@ def auto_store_files(
     session_id: str,
 ) -> None:
     """
-    Store uploaded files to S3 workspace (always) and Code Interpreter (if configured).
+    Store uploaded files to the durable S3 workspace.
 
     S3 is the single source of truth — all workspace tools (word, excel, etc.) read
-    from S3. Code Interpreter sync is optional and only happens when CODE_INTERPRETER_ID
-    is available.
+    from S3. When S3 Files is enabled, a second object is written into the mounted
+    Code Interpreter input directory and imported on first filesystem access.
 
     Args:
         uploaded_files: List of dicts with 'filename', 'bytes', 'content_type'
@@ -277,6 +277,44 @@ def auto_store_files(
                     logger.debug(f"Saved to S3 (raw): {file_info['filename']}")
                 except Exception as e:
                     logger.error(f"Failed to save {file_info['filename']} to S3: {e}")
+
+        if os.getenv("S3_FILES_FILE_SYSTEM_ID"):
+            import boto3
+
+            from workspace.config import get_workspace_bucket
+
+            s3 = boto3.client(
+                "s3",
+                region_name=os.getenv(EnvVars.AWS_REGION, DEFAULT_AWS_REGION),
+            )
+            bucket = get_workspace_bucket()
+            for file_info in uploaded_files:
+                key = (
+                    f"code-interpreter-workspace/{user_id}/{session_id}/"
+                    f"inputs/{file_info['filename']}"
+                )
+                try:
+                    s3.put_object(
+                        Bucket=bucket,
+                        Key=key,
+                        Body=file_info["bytes"],
+                        ContentType=file_info.get(
+                            "content_type",
+                            "application/octet-stream",
+                        ),
+                        Metadata={
+                            "user_id": user_id,
+                            "session_id": session_id,
+                            "source": "chat_upload",
+                        },
+                    )
+                    logger.debug("Saved mounted CI input: %s", key)
+                except Exception as error:
+                    logger.error(
+                        "Failed to save mounted CI input %s: %s",
+                        file_info["filename"],
+                        error,
+                    )
 
     except Exception as e:
         logger.error(f"Failed to auto-store files: {e}")

--- a/chatbot-app/agentcore/src/builtin_tools/code_interpreter_tool.py
+++ b/chatbot-app/agentcore/src/builtin_tools/code_interpreter_tool.py
@@ -29,13 +29,14 @@ logger = logging.getLogger(__name__)
 # The actual session_id is stored in agent.state for cross-turn persistence.
 _ci_clients: Dict[str, Any] = {}
 
-# Tracks which S3 keys have been synced to each CI session to avoid re-downloading.
+# Tracks which S3 keys have been synced to legacy CI sessions to avoid re-downloading.
 # Key: session_key (user_id-session_id), Value: set of S3 object keys already loaded.
 _synced_s3_keys: Dict[str, set] = {}
 
 # agent.state keys for CI session persistence
 _STATE_CI_SESSION_ID = "ci_session_id"
 _STATE_CI_IDENTIFIER = "ci_identifier"
+_STATE_CI_MOUNTED_WORKSPACE = "ci_mounted_workspace"
 
 # Session timeout in seconds (1 hour; max is 28800 = 8 hours)
 _SESSION_TIMEOUT_SECONDS = 3600
@@ -124,7 +125,8 @@ def get_ci_session(tool_context: ToolContext) -> Optional[Any]:
         stored_id = ci.session_id
         stored_identifier = ci.identifier
         if stored_id and stored_identifier and _is_session_alive(ci, stored_identifier, stored_id):
-            _sync_new_workspace_files(ci, user_id, session_id)
+            if tool_context.agent.state.get(_STATE_CI_MOUNTED_WORKSPACE) is not True:
+                _sync_new_workspace_files(ci, user_id, session_id)
             return ci
         # Session expired — remove stale cache
         logger.info(f"Cached CI session expired: {session_key}")
@@ -142,7 +144,8 @@ def get_ci_session(tool_context: ToolContext) -> Optional[Any]:
         if _is_session_alive(ci, stored_identifier, stored_session_id):
             logger.info(f"Reattached to existing CI session: {stored_session_id}")
             _ci_clients[session_key] = ci
-            _sync_new_workspace_files(ci, user_id, session_id)
+            if agent_state.get(_STATE_CI_MOUNTED_WORKSPACE) is not True:
+                _sync_new_workspace_files(ci, user_id, session_id)
             return ci
         logger.info(f"Stored CI session expired ({stored_session_id}), creating new one")
 
@@ -152,20 +155,103 @@ def get_ci_session(tool_context: ToolContext) -> Optional[Any]:
         return None
 
     ci = CodeInterpreter(region)
-    ci.start(identifier=identifier, session_timeout_seconds=_SESSION_TIMEOUT_SECONDS)
+    mounted_workspace = False
+    try:
+        from workspace.s3_files import get_or_create_session_access_point
+
+        workspace = get_or_create_session_access_point(
+            agent_state,
+            user_id,
+            session_id,
+        )
+        if workspace:
+            response = ci.data_plane_client.start_code_interpreter_session(
+                codeInterpreterIdentifier=identifier,
+                name=f"workspace-{session_id[:32]}",
+                sessionTimeoutSeconds=_SESSION_TIMEOUT_SECONDS,
+                filesystemConfigurations=[{
+                    "s3FilesConfiguration": {
+                        "fileSystemArn": workspace["file_system_arn"],
+                        "accessPointArn": workspace["access_point_arn"],
+                        "mountPath": workspace["mount_path"],
+                    },
+                }],
+            )
+            ci.identifier = response["codeInterpreterIdentifier"]
+            ci.session_id = response["sessionId"]
+            mounted_workspace = True
+    except Exception as error:
+        logger.exception(
+            "Could not start Code Interpreter with S3 Files; using legacy sync: %s",
+            error,
+        )
+
+    if not mounted_workspace:
+        ci.start(
+            identifier=identifier,
+            session_timeout_seconds=_SESSION_TIMEOUT_SECONDS,
+        )
     logger.info(f"Created new CI session: {ci.session_id} (identifier: {identifier}, timeout: {_SESSION_TIMEOUT_SECONDS}s)")
 
     # Store in agent.state for cross-turn persistence
     agent_state.set(_STATE_CI_SESSION_ID, ci.session_id)
     agent_state.set(_STATE_CI_IDENTIFIER, identifier)
+    agent_state.set(_STATE_CI_MOUNTED_WORKSPACE, mounted_workspace)
 
     # Cache in-process
     _ci_clients[session_key] = ci
 
-    # Preload workspace files into the new sandbox
-    _preload_workspace_files(ci, user_id, session_id)
+    if mounted_workspace:
+        _prepare_mounted_workspace(ci)
+    else:
+        _preload_workspace_files(ci, user_id, session_id)
 
     return ci
+
+
+def _prepare_mounted_workspace(ci: Any) -> None:
+    """Set the Code Interpreter working directory and trigger input import."""
+    mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
+    code = (
+        "import os\n"
+        f"os.makedirs({mount_path!r}, exist_ok=True)\n"
+        f"os.chdir({mount_path!r})\n"
+        "_inputs = os.path.join(os.getcwd(), 'inputs')\n"
+        "if os.path.isdir(_inputs):\n"
+        "    list(os.scandir(_inputs))\n"
+    )
+    response = ci.invoke("executeCode", {
+        "code": code,
+        "language": "python",
+        "clearContext": False,
+    })
+    _, stderr, has_error = _parse_stream(response)
+    if has_error:
+        raise RuntimeError(f"Could not initialize mounted workspace: {stderr}")
+
+
+def _uses_mounted_workspace(tool_context: ToolContext) -> bool:
+    return tool_context.agent.state.get(_STATE_CI_MOUNTED_WORKSPACE) is True
+
+
+def _mounted_path(path: str) -> str:
+    mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
+    normalized = os.path.normpath(path)
+    if os.path.isabs(normalized):
+        if normalized != mount_path and not normalized.startswith(f"{mount_path}/"):
+            raise ValueError("Path must stay inside the session workspace")
+        return normalized
+    if normalized == ".." or normalized.startswith("../"):
+        raise ValueError("Path must stay inside the session workspace")
+    return os.path.join(mount_path, normalized)
+
+
+def _prepare_code_for_mounted_workspace(code: str, language: str) -> str:
+    """Run JavaScript and TypeScript from the mounted workspace."""
+    if language.lower() not in {"javascript", "typescript"}:
+        return code
+    mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
+    return f"Deno.chdir({json.dumps(mount_path)});\n{code}"
 
 
 def _get_ci_from_context(tool_context: ToolContext) -> Optional[Any]:
@@ -413,6 +499,10 @@ def execute_code(
         })
 
     try:
+        mounted = _uses_mounted_workspace(tool_context)
+        if mounted:
+            _prepare_mounted_workspace(ci)
+            code = _prepare_code_for_mounted_workspace(code, language)
         response = ci.invoke("executeCode", {
             "code": code,
             "language": language,
@@ -431,7 +521,8 @@ def execute_code(
             return stdout or "(no output)"
 
         # Download output file
-        download_response = ci.invoke("readFiles", {"paths": [output_filename]})
+        output_path = _mounted_path(output_filename) if mounted else output_filename
+        download_response = ci.invoke("readFiles", {"paths": [output_path]})
         for event in download_response.get("stream", []):
             result = event.get("result", {})
             for item in result.get("content", []):
@@ -439,9 +530,15 @@ def execute_code(
                     continue
                 blob = item.get("data") or item.get("resource", {}).get("blob")
                 if blob:
-                    _save_to_workspace(tool_context, output_filename, blob)
+                    if not mounted:
+                        _save_to_workspace(tool_context, output_filename, blob)
                     size_kb = len(blob) / 1024
-                    summary = f"Code executed. File saved: {output_filename} ({size_kb:.1f} KB)"
+                    workspace_path = (
+                        f"code-interpreter/{output_filename}"
+                        if mounted
+                        else output_filename
+                    )
+                    summary = f"Code executed. File saved: {workspace_path} ({size_kb:.1f} KB)"
                     if stdout:
                         summary += f"\n\nstdout:\n{stdout[:500]}"
 
@@ -498,6 +595,9 @@ def execute_command(
         })
 
     try:
+        if _uses_mounted_workspace(tool_context):
+            mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
+            command = f"cd {json.dumps(mount_path)} && {command}"
         response = ci.invoke("executeCommand", {"command": command})
         stdout, stderr, has_error = _parse_stream(response)
         if has_error:
@@ -545,7 +645,12 @@ def file_operations(
         if operation == "read":
             if not paths:
                 return json.dumps({"error": "paths required for read operation", "status": "error"})
-            download_response = ci.invoke("readFiles", {"paths": paths})
+            resolved_paths = (
+                [_mounted_path(path) for path in paths]
+                if _uses_mounted_workspace(tool_context)
+                else paths
+            )
+            download_response = ci.invoke("readFiles", {"paths": resolved_paths})
             parts = []
             for event in download_response.get("stream", []):
                 result = event.get("result", {})
@@ -562,9 +667,16 @@ def file_operations(
                 return json.dumps({"error": "content required for write operation", "status": "error"})
             results = []
             for entry in content:
-                path = entry["path"]
-                text = entry["text"].replace("'", "\\'")
-                code = f"with open('{path}', 'w') as _f:\n    _f.write('{text}')\nprint('Written: {path}')\n"
+                path = (
+                    _mounted_path(entry["path"])
+                    if _uses_mounted_workspace(tool_context)
+                    else entry["path"]
+                )
+                code = (
+                    f"with open({path!r}, 'w') as _f:\n"
+                    f"    _f.write({entry['text']!r})\n"
+                    f"print('Written: {path}')\n"
+                )
                 response = ci.invoke("executeCode", {"code": code, "language": "python", "clearContext": False})
                 stdout, stderr, has_error = _parse_stream(response)
                 if has_error:
@@ -574,10 +686,12 @@ def file_operations(
             return "\n".join(results)
 
         elif operation == "list":
-            list_path = (paths[0] if paths else ".").replace("'", "\\'")
+            list_path = paths[0] if paths else "."
+            if _uses_mounted_workspace(tool_context):
+                list_path = _mounted_path(list_path)
             code = (
                 "import os, json\n"
-                f"_p = '{list_path}'\n"
+                f"_p = {list_path!r}\n"
                 "_entries = []\n"
                 "for _n in sorted(os.listdir(_p)):\n"
                 "    _full = os.path.join(_p, _n)\n"
@@ -593,7 +707,12 @@ def file_operations(
         elif operation == "remove":
             if not paths:
                 return json.dumps({"error": "paths required for remove operation", "status": "error"})
-            escaped = json.dumps(paths)
+            resolved_paths = (
+                [_mounted_path(path) for path in paths]
+                if _uses_mounted_workspace(tool_context)
+                else paths
+            )
+            escaped = json.dumps(resolved_paths)
             code = (
                 f"import os\n"
                 f"for _p in {escaped}:\n"
@@ -626,10 +745,11 @@ def ci_push_to_workspace(
     paths: list = None,
     tool_context: ToolContext = None,
 ) -> str:
-    """Save files from the CI sandbox to the shared workspace (S3).
+    """Persist files for legacy Code Interpreter deployments.
 
-    Use this after code execution to persist output files so other skills
-    (or a future session) can access them via workspace_read / workspace_list.
+    Mounted workspace deployments persist files automatically. In that mode,
+    this helper only verifies that the requested files exist. It copies files
+    to S3 only when the session is using the legacy sandbox configuration.
 
     Args:
         paths: Sandbox file paths to save (e.g. ["chart.png", "results.json"]).
@@ -643,6 +763,50 @@ def ci_push_to_workspace(
         return json.dumps({"error": "Code Interpreter not available.", "status": "error"})
 
     try:
+        if _uses_mounted_workspace(tool_context):
+            if not paths:
+                code = (
+                    "import os, json\n"
+                    "_root = os.getcwd()\n"
+                    "print(json.dumps([name for name in os.listdir(_root) "
+                    "if os.path.isfile(os.path.join(_root, name))]))\n"
+                )
+                response = ci.invoke("executeCode", {
+                    "code": code,
+                    "language": "python",
+                    "clearContext": False,
+                })
+                stdout, _, _ = _parse_stream(response)
+                paths = json.loads(stdout.strip()) if stdout.strip() else []
+
+            saved = []
+            for path in paths or []:
+                resolved = _mounted_path(path)
+                code = (
+                    "import os\n"
+                    f"_p = {resolved!r}\n"
+                    "print('ok' if os.path.isfile(_p) else 'missing')\n"
+                )
+                response = ci.invoke("executeCode", {
+                    "code": code,
+                    "language": "python",
+                    "clearContext": False,
+                })
+                stdout, _, has_error = _parse_stream(response)
+                if not has_error and stdout.strip() == "ok":
+                    relative = os.path.relpath(resolved, os.getenv(
+                        "S3_FILES_MOUNT_PATH",
+                        "/mnt/workspace",
+                    ))
+                    saved.append(f"code-interpreter/{relative}")
+
+            return json.dumps({
+                "files_saved": saved,
+                "count": len(saved),
+                "status": "ok",
+                "storage": "mounted",
+            })
+
         # Discover files if no paths given
         if not paths:
             code = "import os, json; print(json.dumps([f for f in os.listdir('.') if os.path.isfile(f)]))\n"

--- a/chatbot-app/agentcore/src/workspace/s3_files.py
+++ b/chatbot-app/agentcore/src/workspace/s3_files.py
@@ -1,0 +1,147 @@
+"""Session-scoped S3 Files access points for Code Interpreter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Dict, Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+_SAFE_ID = re.compile(r"^[A-Za-z0-9_-]+$")
+_STATE_ACCESS_POINT_ID = "ci_workspace_access_point_id"
+_STATE_ACCESS_POINT_ARN = "ci_workspace_access_point_arn"
+
+
+def get_s3_files_configuration() -> Optional[Dict[str, str]]:
+    file_system_id = os.getenv("S3_FILES_FILE_SYSTEM_ID", "").strip()
+    file_system_arn = os.getenv("S3_FILES_FILE_SYSTEM_ARN", "").strip()
+    mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace").strip()
+    if not file_system_id or not file_system_arn:
+        return None
+    return {
+        "file_system_id": file_system_id,
+        "file_system_arn": file_system_arn,
+        "mount_path": mount_path or "/mnt/workspace",
+    }
+
+
+def _validate_identity(value: str, label: str) -> None:
+    if not value or not _SAFE_ID.fullmatch(value):
+        raise ValueError(f"Invalid {label} for S3 Files workspace")
+
+
+def _wait_for_access_point(client: Any, access_point_id: str) -> Dict[str, Any]:
+    deadline = time.monotonic() + 90
+    while time.monotonic() < deadline:
+        response = client.get_access_point(accessPointId=access_point_id)
+        status = str(response.get("status", "")).upper()
+        if status == "AVAILABLE":
+            return response
+        if status in {"FAILED", "ERROR", "DELETED"}:
+            raise RuntimeError(
+                f"S3 Files access point {access_point_id} entered {status}"
+            )
+        time.sleep(2)
+    raise TimeoutError(f"S3 Files access point {access_point_id} was not ready")
+
+
+def _persist_access_point_registry(
+    user_id: str,
+    session_id: str,
+    access_point_id: str,
+    access_point_arn: str,
+) -> None:
+    from workspace.config import get_workspace_bucket
+
+    region = os.getenv("AWS_REGION", "us-west-2")
+    boto3.client("s3", region_name=region).put_object(
+        Bucket=get_workspace_bucket(),
+        Key=f".workspace-access-points/{user_id}/{session_id}.json",
+        Body=json.dumps({
+            "accessPointId": access_point_id,
+            "accessPointArn": access_point_arn,
+        }).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def get_or_create_session_access_point(
+    agent_state: Any,
+    user_id: str,
+    session_id: str,
+) -> Optional[Dict[str, str]]:
+    config = get_s3_files_configuration()
+    if not config:
+        return None
+
+    _validate_identity(user_id, "user_id")
+    _validate_identity(session_id, "session_id")
+
+    region = os.getenv("AWS_REGION", "us-west-2")
+    client = boto3.client("s3files", region_name=region)
+    stored_id = agent_state.get(_STATE_ACCESS_POINT_ID)
+    stored_arn = agent_state.get(_STATE_ACCESS_POINT_ARN)
+
+    if stored_id and stored_arn:
+        try:
+            response = client.get_access_point(accessPointId=stored_id)
+            if str(response.get("status", "")).upper() == "AVAILABLE":
+                _persist_access_point_registry(
+                    user_id,
+                    session_id,
+                    stored_id,
+                    stored_arn,
+                )
+                return {
+                    **config,
+                    "access_point_id": stored_id,
+                    "access_point_arn": stored_arn,
+                }
+        except Exception as error:
+            logger.info("Stored S3 Files access point is unavailable: %s", error)
+
+    token_source = (
+        f"{config['file_system_id']}:{user_id}:{session_id}:code-interpreter"
+    )
+    client_token = hashlib.sha256(token_source.encode("utf-8")).hexdigest()
+    root_path = f"/code-interpreter-workspace/{user_id}/{session_id}"
+    response = client.create_access_point(
+        clientToken=client_token,
+        fileSystemId=config["file_system_id"],
+        posixUser={"uid": 1000, "gid": 1000},
+        rootDirectory={
+            "path": root_path,
+            "creationPermissions": {
+                "ownerUid": 1000,
+                "ownerGid": 1000,
+                "permissions": "0750",
+            },
+        },
+    )
+    access_point_id = response["accessPointId"]
+    ready = _wait_for_access_point(client, access_point_id)
+    access_point_arn = ready.get("accessPointArn") or response["accessPointArn"]
+    agent_state.set(_STATE_ACCESS_POINT_ID, access_point_id)
+    agent_state.set(_STATE_ACCESS_POINT_ARN, access_point_arn)
+    _persist_access_point_registry(
+        user_id,
+        session_id,
+        access_point_id,
+        access_point_arn,
+    )
+    logger.info(
+        "Created S3 Files access point %s for session workspace",
+        access_point_id,
+    )
+    return {
+        **config,
+        "access_point_id": access_point_id,
+        "access_point_arn": access_point_arn,
+    }

--- a/chatbot-app/agentcore/tests/unit/test_ci_workspace_sync.py
+++ b/chatbot-app/agentcore/tests/unit/test_ci_workspace_sync.py
@@ -7,8 +7,7 @@ and the ci_pull_from_workspace tool were removed in a refactor that simplified
 the CI tools to use ci.invoke() directly.  These tests cover the current API.
 """
 import json
-import pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, patch
 
 
 def _make_context(user_id="user1", session_id="sess1"):
@@ -37,6 +36,33 @@ def _exec_code_invoke_response(stdout: str) -> dict:
             }
         }]
     }
+
+
+def test_mounted_javascript_runs_from_workspace(monkeypatch):
+    monkeypatch.setenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
+
+    from builtin_tools.code_interpreter_tool import (
+        _prepare_code_for_mounted_workspace,
+    )
+
+    prepared = _prepare_code_for_mounted_workspace(
+        "await Deno.writeTextFile('output.txt', 'ok')",
+        "javascript",
+    )
+
+    assert prepared.startswith('Deno.chdir("/mnt/workspace");\n')
+    assert prepared.endswith("await Deno.writeTextFile('output.txt', 'ok')")
+
+
+def test_mounted_python_code_is_not_rewritten():
+    from builtin_tools.code_interpreter_tool import (
+        _prepare_code_for_mounted_workspace,
+    )
+
+    assert _prepare_code_for_mounted_workspace(
+        "open('output.txt', 'w').write('ok')",
+        "python",
+    ) == "open('output.txt', 'w').write('ok')"
 
 
 # ============================================================

--- a/chatbot-app/agentcore/tests/unit/test_s3_files_workspace.py
+++ b/chatbot-app/agentcore/tests/unit/test_s3_files_workspace.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _state():
+    values = {}
+    state = MagicMock()
+    state.get.side_effect = values.get
+    state.set.side_effect = values.__setitem__
+    return state, values
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "S3_FILES_FILE_SYSTEM_ID": "fs-123",
+        "S3_FILES_FILE_SYSTEM_ARN": "arn:aws:s3files:us-west-2:123:file-system/fs-123",
+        "S3_FILES_MOUNT_PATH": "/mnt/workspace",
+    },
+    clear=False,
+)
+@patch("workspace.s3_files.time.sleep")
+@patch("workspace.s3_files.boto3.client")
+def test_creates_session_scoped_access_point(mock_client, _sleep):
+    client = mock_client.return_value
+    client.create_access_point.return_value = {
+        "accessPointId": "ap-123",
+        "accessPointArn": "arn:aws:s3files:us-west-2:123:access-point/ap-123",
+    }
+    client.get_access_point.return_value = {
+        "status": "available",
+        "accessPointArn": "arn:aws:s3files:us-west-2:123:access-point/ap-123",
+    }
+    state, values = _state()
+
+    from workspace.s3_files import get_or_create_session_access_point
+
+    result = get_or_create_session_access_point(state, "user-1", "session-1")
+
+    assert result["access_point_id"] == "ap-123"
+    assert result["mount_path"] == "/mnt/workspace"
+    request = client.create_access_point.call_args.kwargs
+    assert request["fileSystemId"] == "fs-123"
+    assert request["rootDirectory"]["path"] == (
+        "/code-interpreter-workspace/user-1/session-1"
+    )
+    assert "tags" not in request
+    assert values["ci_workspace_access_point_id"] == "ap-123"
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "S3_FILES_FILE_SYSTEM_ID": "fs-123",
+        "S3_FILES_FILE_SYSTEM_ARN": "arn:aws:s3files:us-west-2:123:file-system/fs-123",
+    },
+    clear=False,
+)
+def test_rejects_identity_that_can_escape_root():
+    from workspace.s3_files import get_or_create_session_access_point
+
+    with pytest.raises(ValueError):
+        get_or_create_session_access_point(MagicMock(), "user/other", "session-1")
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_returns_none_when_s3_files_is_disabled():
+    from workspace.s3_files import get_or_create_session_access_point
+
+    assert get_or_create_session_access_point(
+        MagicMock(),
+        "user-1",
+        "session-1",
+    ) is None

--- a/chatbot-app/frontend/__tests__/components/CanvasResearchApproval.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/CanvasResearchApproval.test.tsx
@@ -156,6 +156,30 @@ describe('Canvas — docked artifact sidebar', () => {
     expect(sidebar).toHaveStyle({ width: '360px', flexBasis: '360px' })
   })
 
+  it('allows a wider preview while preserving the minimum chat width', () => {
+    const originalWidth = window.innerWidth
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1440,
+    })
+
+    try {
+      renderCanvas()
+
+      const sidebar = screen.getByTestId('artifacts-sidebar')
+      const resizeHandle = screen.getByRole('separator', { name: /resize right sidebar/i })
+
+      fireEvent.keyDown(resizeHandle, { key: 'End' })
+      expect(sidebar).toHaveStyle({ width: '960px', flexBasis: '960px' })
+      expect(resizeHandle).toHaveAttribute('aria-valuemax', '960')
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: originalWidth,
+      })
+    }
+  })
+
   it('resizes from the left edge without turning the panel into an overlay', () => {
     renderCanvas()
 

--- a/chatbot-app/frontend/__tests__/lib/mounted-workspace-repository.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/mounted-workspace-repository.test.ts
@@ -1,0 +1,84 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+describe('mounted Code Interpreter workspace', () => {
+  let mountPath: string
+  let sessionRoot: string
+
+  beforeEach(async () => {
+    mountPath = await mkdtemp(join(tmpdir(), 'workspace-mount-'))
+    sessionRoot = join(mountPath, 'user-1', 'session-1')
+    await mkdir(sessionRoot, { recursive: true })
+    vi.stubEnv('S3_FILES_MOUNT_PATH', mountPath)
+    vi.stubEnv('ARTIFACT_BUCKET', 'workspace-bucket')
+    vi.resetModules()
+  })
+
+  afterEach(async () => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+    await rm(mountPath, { recursive: true, force: true })
+  })
+
+  it('lists and previews files directly from the mounted session root', async () => {
+    await writeFile(join(sessionRoot, 'report.md'), '# Mounted report')
+    const {
+      S3WorkspaceRepository,
+    } = await import('@/lib/workspace/s3-repository')
+    const repository = new S3WorkspaceRepository({ send: vi.fn() } as any)
+
+    const page = await repository.list(
+      'user-1',
+      'session-1',
+      'code-interpreter',
+    )
+    expect(page.entries).toMatchObject([
+      {
+        name: 'report.md',
+        path: 'code-interpreter/report.md',
+        kind: 'file',
+      },
+    ])
+
+    const preview = await repository.preview(
+      'user-1',
+      'session-1',
+      'code-interpreter/report.md',
+    )
+    expect(preview).toMatchObject({
+      kind: 'markdown',
+      content: '# Mounted report',
+    })
+  })
+
+  it('rejects symlinks that escape the authenticated session root', async () => {
+    const outside = join(mountPath, 'outside.txt')
+    await writeFile(outside, 'secret')
+    await symlink(outside, join(sessionRoot, 'escape.txt'))
+    const {
+      resolveMountedWorkspaceFile,
+      WorkspacePathError,
+    } = await import('@/lib/workspace/s3-repository')
+
+    await expect(resolveMountedWorkspaceFile(
+      'user-1',
+      'session-1',
+      'code-interpreter/escape.txt',
+    )).rejects.toThrow(WorkspacePathError)
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/mounted-workspace-repository.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/mounted-workspace-repository.test.ts
@@ -71,11 +71,11 @@ describe('mounted Code Interpreter workspace', () => {
     await writeFile(outside, 'secret')
     await symlink(outside, join(sessionRoot, 'escape.txt'))
     const {
-      resolveMountedWorkspaceFile,
+      openMountedWorkspaceFile,
       WorkspacePathError,
     } = await import('@/lib/workspace/s3-repository')
 
-    await expect(resolveMountedWorkspaceFile(
+    await expect(openMountedWorkspaceFile(
       'user-1',
       'session-1',
       'code-interpreter/escape.txt',

--- a/chatbot-app/frontend/__tests__/lib/session-lifecycle.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/session-lifecycle.test.ts
@@ -1,0 +1,39 @@
+import {
+  DynamoDBClient,
+  QueryCommand,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('session orchestration lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('uses DynamoDB for anonymous sessions in AWS mode', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
+    vi.stubEnv('SESSION_ORCHESTRATION_TABLE', 'orchestration-table')
+    const send = vi
+      .spyOn(DynamoDBClient.prototype, 'send')
+      .mockImplementation(async command => {
+        if (command instanceof UpdateItemCommand) return {}
+        if (command instanceof QueryCommand) return { Items: [] }
+        throw new Error(`Unexpected command: ${command.constructor.name}`)
+      })
+
+    const { tombstoneSessionOrchestration } = await import(
+      '@/lib/session-lifecycle'
+    )
+    await tombstoneSessionOrchestration('anonymous', 'session-1')
+
+    expect(send).toHaveBeenCalledTimes(5)
+    expect(send.mock.calls[0][0]).toBeInstanceOf(UpdateItemCommand)
+    expect(
+      send.mock.calls.slice(1).every(([command]) =>
+        command instanceof QueryCommand
+      ),
+    ).toBe(true)
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/workspace-access-point-lifecycle.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/workspace-access-point-lifecycle.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const s3Send = vi.fn()
+const s3FilesSend = vi.fn()
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  DeleteObjectCommand: class DeleteObjectCommand {
+    input: unknown
+    constructor(input: unknown) {
+      this.input = input
+    }
+  },
+  GetObjectCommand: class GetObjectCommand {
+    input: unknown
+    constructor(input: unknown) {
+      this.input = input
+    }
+  },
+  S3Client: class S3Client {
+    send = s3Send
+  },
+}))
+
+vi.mock('@aws-sdk/client-s3files', () => ({
+  DeleteAccessPointCommand: class DeleteAccessPointCommand {
+    input: unknown
+    constructor(input: unknown) {
+      this.input = input
+    }
+  },
+  S3FilesClient: class S3FilesClient {
+    send = s3FilesSend
+  },
+}))
+
+describe('session workspace access point lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('AWS_REGION', 'us-west-2')
+    vi.stubEnv('ARTIFACT_BUCKET', 'workspace-bucket')
+    vi.stubEnv('S3_FILES_FILE_SYSTEM_ID', 'fs-123')
+  })
+
+  it('deletes the access point before removing its registry record', async () => {
+    s3Send
+      .mockResolvedValueOnce({
+        Body: {
+          transformToString: vi.fn().mockResolvedValue(JSON.stringify({
+            accessPointId: 'ap-123',
+            accessPointArn: 'arn:aws:s3files:us-west-2:123:access-point/ap-123',
+          })),
+        },
+      })
+      .mockResolvedValueOnce({})
+    s3FilesSend.mockResolvedValue({})
+
+    const {
+      deleteSessionWorkspaceAccessPoint,
+    } = await import('@/lib/workspace/access-point-lifecycle')
+
+    await deleteSessionWorkspaceAccessPoint('user-1', 'session-1')
+
+    expect(s3FilesSend).toHaveBeenCalledTimes(1)
+    expect(s3FilesSend.mock.calls[0][0].input).toEqual({
+      accessPointId: 'ap-123',
+    })
+    expect(s3Send.mock.calls[1][0].input).toEqual({
+      Bucket: 'workspace-bucket',
+      Key: '.workspace-access-points/user-1/session-1.json',
+    })
+  })
+
+  it('is a no-op when the registry record does not exist', async () => {
+    const notFound = new Error('missing')
+    notFound.name = 'NoSuchKey'
+    s3Send.mockRejectedValue(notFound)
+
+    const {
+      deleteSessionWorkspaceAccessPoint,
+    } = await import('@/lib/workspace/access-point-lifecycle')
+
+    await expect(
+      deleteSessionWorkspaceAccessPoint('user-1', 'session-1'),
+    ).resolves.toBeUndefined()
+    expect(s3FilesSend).not.toHaveBeenCalled()
+  })
+})

--- a/chatbot-app/frontend/package-lock.json
+++ b/chatbot-app/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@aws-sdk/client-bedrock-agentcore": "^3.1101.0",
         "@aws-sdk/client-dynamodb": "^3.1101.0",
         "@aws-sdk/client-s3": "^3.1101.0",
+        "@aws-sdk/client-s3files": "^3.1106.0",
         "@aws-sdk/client-ssm": "^3.1101.0",
         "@aws-sdk/credential-providers": "^3.1101.0",
         "@aws-sdk/s3-request-presigner": "^3.1101.0",
@@ -664,6 +665,25 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3files": {
+      "version": "3.1106.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3files/-/client-s3files-3.1106.0.tgz",
+      "integrity": "sha512-gCvZZUE76QsChVlwqm7S9Z1/bqMukkmdzs4oGl1FrcvrdnM1gO3V24q9wzV4UdqJEZsxy5r/PRJAmB4W697uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ssm": {
       "version": "3.1101.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1101.0.tgz",
@@ -684,9 +704,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
-      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -733,12 +753,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
-      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -749,12 +769,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
-      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -767,19 +787,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
-      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-login": "^3.972.72",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -791,13 +811,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
-      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -808,17 +828,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
-      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-ini": "^3.973.10",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -830,12 +850,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
-      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -846,14 +866,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
-      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/token-providers": "3.1100.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -864,13 +884,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
-      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -969,12 +989,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
-      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -1034,13 +1054,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1100.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
-      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",

--- a/chatbot-app/frontend/package.json
+++ b/chatbot-app/frontend/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/client-bedrock-agentcore": "^3.1101.0",
     "@aws-sdk/client-dynamodb": "^3.1101.0",
     "@aws-sdk/client-s3": "^3.1101.0",
+    "@aws-sdk/client-s3files": "^3.1106.0",
     "@aws-sdk/client-ssm": "^3.1101.0",
     "@aws-sdk/credential-providers": "^3.1101.0",
     "@aws-sdk/s3-request-presigner": "^3.1101.0",

--- a/chatbot-app/frontend/src/app/api/session/[sessionId]/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/[sessionId]/route.ts
@@ -262,6 +262,15 @@ export async function DELETE(
       }
     }
 
+    try {
+      const { deleteSessionWorkspaceAccessPoint } = await import(
+        '@/lib/workspace/access-point-lifecycle'
+      )
+      await deleteSessionWorkspaceAccessPoint(userId, sessionId)
+    } catch (error) {
+      console.error('[API] Failed to remove workspace access point:', error)
+    }
+
     return NextResponse.json({
       success: true,
       message: 'Session deleted successfully',

--- a/chatbot-app/frontend/src/app/api/session/delete/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/delete/route.ts
@@ -61,6 +61,15 @@ export async function DELETE(request: NextRequest) {
       }
     }
 
+    try {
+      const { deleteSessionWorkspaceAccessPoint } = await import(
+        '@/lib/workspace/access-point-lifecycle'
+      )
+      await deleteSessionWorkspaceAccessPoint(userId, sessionId)
+    } catch (error) {
+      console.error('[API] Failed to remove workspace access point:', error)
+    }
+
     return NextResponse.json({
       success: true,
       message: 'Session deleted successfully',

--- a/chatbot-app/frontend/src/app/api/workspace/content/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/content/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createReadStream } from 'node:fs'
-import { stat } from 'node:fs/promises'
 import { Readable } from 'node:stream'
 import { extractUserFromRequest } from '@/lib/auth-utils'
 import {
-  resolveMountedWorkspaceFile,
+  openMountedWorkspaceFile,
   WorkspacePathError,
 } from '@/lib/workspace/s3-repository'
 
@@ -19,12 +17,12 @@ export async function GET(request: NextRequest) {
     }
 
     const user = await extractUserFromRequest(request)
-    const file = await resolveMountedWorkspaceFile(user.userId, sessionId, path)
+    const file = await openMountedWorkspaceFile(user.userId, sessionId, path)
     if (!file) {
       return NextResponse.json({ error: 'Mounted workspace unavailable' }, { status: 404 })
     }
 
-    const metadata = await stat(file.path)
+    const metadata = file.metadata
     const rangeHeader = request.headers.get('range')
     let start = 0
     let end = metadata.size - 1
@@ -33,6 +31,7 @@ export async function GET(request: NextRequest) {
     if (rangeHeader) {
       const match = /^bytes=(\d+)-(\d*)$/.exec(rangeHeader)
       if (!match) {
+        await file.handle.close()
         return new NextResponse(null, {
           status: 416,
           headers: { 'Content-Range': `bytes */${metadata.size}` },
@@ -41,6 +40,7 @@ export async function GET(request: NextRequest) {
       start = Number(match[1])
       end = match[2] ? Number(match[2]) : end
       if (start > end || end >= metadata.size) {
+        await file.handle.close()
         return new NextResponse(null, {
           status: 416,
           headers: { 'Content-Range': `bytes */${metadata.size}` },
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
       status = 206
     }
 
-    const stream = createReadStream(file.path, { start, end })
+    const stream = file.handle.createReadStream({ start, end, autoClose: true })
     const headers = new Headers({
       'Accept-Ranges': 'bytes',
       'Cache-Control': 'private, no-store',

--- a/chatbot-app/frontend/src/app/api/workspace/content/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/content/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { Readable } from 'node:stream'
+import { extractUserFromRequest } from '@/lib/auth-utils'
+import {
+  resolveMountedWorkspaceFile,
+  WorkspacePathError,
+} from '@/lib/workspace/s3-repository'
+
+export const runtime = 'nodejs'
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionId = request.nextUrl.searchParams.get('sessionId')
+    const path = request.nextUrl.searchParams.get('path')
+    if (!sessionId || !path) {
+      return NextResponse.json({ error: 'Missing sessionId or path' }, { status: 400 })
+    }
+
+    const user = await extractUserFromRequest(request)
+    const file = await resolveMountedWorkspaceFile(user.userId, sessionId, path)
+    if (!file) {
+      return NextResponse.json({ error: 'Mounted workspace unavailable' }, { status: 404 })
+    }
+
+    const metadata = await stat(file.path)
+    const rangeHeader = request.headers.get('range')
+    let start = 0
+    let end = metadata.size - 1
+    let status = 200
+
+    if (rangeHeader) {
+      const match = /^bytes=(\d+)-(\d*)$/.exec(rangeHeader)
+      if (!match) {
+        return new NextResponse(null, {
+          status: 416,
+          headers: { 'Content-Range': `bytes */${metadata.size}` },
+        })
+      }
+      start = Number(match[1])
+      end = match[2] ? Number(match[2]) : end
+      if (start > end || end >= metadata.size) {
+        return new NextResponse(null, {
+          status: 416,
+          headers: { 'Content-Range': `bytes */${metadata.size}` },
+        })
+      }
+      status = 206
+    }
+
+    const stream = createReadStream(file.path, { start, end })
+    const headers = new Headers({
+      'Accept-Ranges': 'bytes',
+      'Cache-Control': 'private, no-store',
+      'Content-Length': String(end - start + 1),
+      'Content-Type': file.mimeType,
+    })
+    if (status === 206) {
+      headers.set('Content-Range', `bytes ${start}-${end}/${metadata.size}`)
+    }
+    if (request.nextUrl.searchParams.get('download') === '1') {
+      headers.set(
+        'Content-Disposition',
+        `attachment; filename="${file.name.replace(/"/g, '')}"`,
+      )
+    }
+
+    return new NextResponse(Readable.toWeb(stream) as ReadableStream, {
+      status,
+      headers,
+    })
+  } catch (error) {
+    if (error instanceof WorkspacePathError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+    console.error('[WorkspaceContent] Error:', error)
+    return NextResponse.json({ error: 'Failed to read workspace file' }, { status: 500 })
+  }
+}

--- a/chatbot-app/frontend/src/app/api/workspace/download/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/download/route.ts
@@ -3,7 +3,7 @@ import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { extractUserFromRequest } from '@/lib/auth-utils'
 import {
-  resolveMountedWorkspaceFile,
+  openMountedWorkspaceFile,
   resolveWorkspaceS3Location,
   WorkspacePathError,
 } from '@/lib/workspace/s3-repository'
@@ -38,13 +38,14 @@ export async function POST(request: NextRequest) {
 
     const user = await extractUserFromRequest(request)
     const userId = user.userId
-    const mounted = await resolveMountedWorkspaceFile(userId, sessionId, path)
+    const mounted = await openMountedWorkspaceFile(userId, sessionId, path)
       .catch(error => {
         if (error instanceof WorkspacePathError) throw error
         return undefined
       })
     const filename = path.split('/').pop() || 'download'
     if (mounted) {
+      await mounted.handle.close()
       const url = `/api/workspace/content?sessionId=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(path)}&download=1`
       return NextResponse.json({ url, filename })
     }

--- a/chatbot-app/frontend/src/app/api/workspace/download/route.ts
+++ b/chatbot-app/frontend/src/app/api/workspace/download/route.ts
@@ -3,6 +3,7 @@ import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { extractUserFromRequest } from '@/lib/auth-utils'
 import {
+  resolveMountedWorkspaceFile,
   resolveWorkspaceS3Location,
   WorkspacePathError,
 } from '@/lib/workspace/s3-repository'
@@ -37,12 +38,22 @@ export async function POST(request: NextRequest) {
 
     const user = await extractUserFromRequest(request)
     const userId = user.userId
+    const mounted = await resolveMountedWorkspaceFile(userId, sessionId, path)
+      .catch(error => {
+        if (error instanceof WorkspacePathError) throw error
+        return undefined
+      })
+    const filename = path.split('/').pop() || 'download'
+    if (mounted) {
+      const url = `/api/workspace/content?sessionId=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(path)}&download=1`
+      return NextResponse.json({ url, filename })
+    }
+
     const { bucket, key: s3Key } = await resolveWorkspaceS3Location(
       userId,
       sessionId,
       path,
     )
-    const filename = path.split('/').pop() || 'download'
 
     const s3Client = new S3Client({ region })
     const command = new GetObjectCommand({

--- a/chatbot-app/frontend/src/components/canvas/Canvas.tsx
+++ b/chatbot-app/frontend/src/components/canvas/Canvas.tsx
@@ -39,7 +39,7 @@ interface CanvasProps {
 }
 
 const SIDEBAR_MIN_WIDTH = 360
-const SIDEBAR_MAX_WIDTH = 760
+const SIDEBAR_MAX_WIDTH = 960
 const SIDEBAR_DEFAULT_WIDTH = 520
 const SIDEBAR_CHAT_MIN_WIDTH = 420
 const SIDEBAR_WIDTH_STORAGE_KEY = 'artifacts-sidebar:width'

--- a/chatbot-app/frontend/src/lib/session-lifecycle.ts
+++ b/chatbot-app/frontend/src/lib/session-lifecycle.ts
@@ -217,7 +217,7 @@ export async function advanceSessionConversationEpoch(
   sessionId: string,
   cutoff: string,
 ): Promise<number> {
-  if (IS_LOCAL || userId === 'anonymous') {
+  if (IS_LOCAL) {
     return advanceLocalConversationEpoch(userId, sessionId, cutoff)
   }
   if (!TABLE_NAME) {
@@ -335,7 +335,7 @@ export async function tombstoneSessionOrchestration(
   sessionId: string,
 ): Promise<void> {
   const deletedAt = new Date().toISOString()
-  if (IS_LOCAL || userId === 'anonymous') {
+  if (IS_LOCAL) {
     tombstoneLocalSession(userId, sessionId, deletedAt)
     return
   }

--- a/chatbot-app/frontend/src/lib/workspace/access-point-lifecycle.ts
+++ b/chatbot-app/frontend/src/lib/workspace/access-point-lifecycle.ts
@@ -1,0 +1,48 @@
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
+import { S3FilesClient, DeleteAccessPointCommand } from '@aws-sdk/client-s3files'
+
+const region = process.env.AWS_REGION || 'us-west-2'
+const SAFE_ID = /^[A-Za-z0-9_-]+$/
+
+interface AccessPointRegistry {
+  accessPointId: string
+  accessPointArn: string
+}
+
+export async function deleteSessionWorkspaceAccessPoint(
+  userId: string,
+  sessionId: string,
+): Promise<void> {
+  if (!process.env.S3_FILES_FILE_SYSTEM_ID) return
+  if (!SAFE_ID.test(userId) || !SAFE_ID.test(sessionId)) {
+    throw new Error('Invalid workspace identity')
+  }
+
+  const bucket = process.env.ARTIFACT_BUCKET
+  if (!bucket) throw new Error('Artifact bucket is not configured')
+
+  const key = `.workspace-access-points/${userId}/${sessionId}.json`
+  const s3 = new S3Client({ region })
+  let registry: AccessPointRegistry
+  try {
+    const response = await s3.send(new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    }))
+    registry = JSON.parse(await response.Body!.transformToString())
+  } catch (error) {
+    const name = error instanceof Error ? error.name : ''
+    if (name === 'NoSuchKey' || name === 'NotFound') return
+    throw error
+  }
+
+  if (!registry.accessPointId) return
+  await new S3FilesClient({ region }).send(new DeleteAccessPointCommand({
+    accessPointId: registry.accessPointId,
+  }))
+  await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }))
+}

--- a/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
+++ b/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
@@ -5,6 +5,8 @@ import {
 } from '@aws-sdk/client-s3'
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { lstat, open, readdir, realpath, stat } from 'node:fs/promises'
+import { join, resolve, sep } from 'node:path'
 import type {
   WorkspaceEntry,
   WorkspacePage,
@@ -15,6 +17,9 @@ import type {
 
 const region = process.env.AWS_REGION || 'us-west-2'
 const TEXT_PREVIEW_LIMIT = 1024 * 1024
+const PAGE_SIZE = 200
+const MOUNT_PATH = process.env.S3_FILES_MOUNT_PATH || ''
+const SAFE_ID = /^[A-Za-z0-9_-]+$/
 
 interface Namespace {
   logicalPath: string
@@ -171,6 +176,112 @@ function entryId(path: string): string {
   return Buffer.from(path, 'utf8').toString('base64url')
 }
 
+function mountedSessionRoot(userId: string, sessionId: string): string | undefined {
+  if (!MOUNT_PATH) return undefined
+  if (!SAFE_ID.test(userId) || !SAFE_ID.test(sessionId)) {
+    throw new WorkspacePathError('Invalid workspace identity')
+  }
+  return resolve(MOUNT_PATH, userId, sessionId)
+}
+
+async function resolveMountedPath(
+  userId: string,
+  sessionId: string,
+  logicalPath: string,
+): Promise<string | undefined> {
+  const path = normalizeWorkspacePath(logicalPath)
+  const { namespace, relativePath } = namespaceForPath(path)
+  if (namespace.logicalPath !== 'code-interpreter') return undefined
+  const root = mountedSessionRoot(userId, sessionId)
+  if (!root) return undefined
+
+  const candidate = resolve(root, relativePath)
+  if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
+    throw new WorkspacePathError('Invalid mounted workspace path')
+  }
+
+  const resolvedRoot = await realpath(root).catch(() => root)
+  const resolvedCandidate = await realpath(candidate).catch(() => candidate)
+  if (
+    resolvedCandidate !== resolvedRoot
+    && !resolvedCandidate.startsWith(`${resolvedRoot}${sep}`)
+  ) {
+    throw new WorkspacePathError('Workspace symlink escapes the session root')
+  }
+  return resolvedCandidate
+}
+
+export async function resolveMountedWorkspaceFile(
+  userId: string,
+  sessionId: string,
+  logicalPath: string,
+): Promise<{ path: string; mimeType: string; name: string } | undefined> {
+  const path = await resolveMountedPath(userId, sessionId, logicalPath)
+  if (!path) return undefined
+  const metadata = await lstat(path)
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new WorkspacePathError('Workspace path is not a regular file')
+  }
+  return {
+    path,
+    mimeType: getWorkspaceMimeType(logicalPath),
+    name: logicalPath.split('/').pop() || 'download',
+  }
+}
+
+async function listMountedWorkspace(
+  userId: string,
+  sessionId: string,
+  logicalPath: string,
+  cursor?: string,
+): Promise<WorkspacePage | undefined> {
+  const directory = await resolveMountedPath(userId, sessionId, logicalPath)
+  if (!directory) return undefined
+  const metadata = await stat(directory).catch(() => undefined)
+  if (!metadata) return { entries: [] }
+  if (!metadata.isDirectory()) throw new WorkspacePathError('Path is not a directory')
+
+  const offsetToken = decodeCursor(logicalPath, cursor)
+  const offset = offsetToken ? Number(offsetToken) : 0
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    throw new WorkspacePathError('Invalid workspace cursor')
+  }
+
+  const children = (await readdir(directory, { withFileTypes: true }))
+    .filter(child => !child.name.startsWith('.') && !child.isSymbolicLink())
+    .sort((left, right) => {
+      if (left.isDirectory() !== right.isDirectory()) {
+        return left.isDirectory() ? -1 : 1
+      }
+      return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
+    })
+  const page = children.slice(offset, offset + PAGE_SIZE)
+  const entries = await Promise.all(page.map(async child => {
+    const childPath = `${logicalPath}/${child.name}`
+    if (child.isDirectory()) return directoryEntry(childPath, child.name)
+    const childStat = await stat(join(directory, child.name))
+    return {
+      id: entryId(childPath),
+      path: childPath,
+      parentPath: logicalPath,
+      name: child.name,
+      kind: 'file' as const,
+      size: childStat.size,
+      modifiedAt: childStat.mtime.toISOString(),
+      mimeType: getWorkspaceMimeType(childPath),
+      previewKind: getWorkspacePreviewKind(childPath),
+    }
+  }))
+
+  const nextOffset = offset + page.length
+  return {
+    entries,
+    nextCursor: nextOffset < children.length
+      ? encodeCursor(logicalPath, String(nextOffset))
+      : undefined,
+  }
+}
+
 function directoryEntry(path: string, name: string): WorkspaceEntry {
   const parentPath = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : ''
   return {
@@ -231,6 +342,16 @@ export class S3WorkspaceRepository implements WorkspaceRepository {
           directoryEntry(namespace.logicalPath, namespace.label)
         )),
       }
+    }
+
+    if (path === 'code-interpreter' || path.startsWith('code-interpreter/')) {
+      const mounted = await listMountedWorkspace(
+        userId,
+        sessionId,
+        path,
+        cursor,
+      )
+      if (mounted) return mounted
     }
 
     const { namespace, relativePath } = namespaceForPath(path)
@@ -294,6 +415,52 @@ export class S3WorkspaceRepository implements WorkspaceRepository {
     rawPath: string,
   ): Promise<WorkspacePreview> {
     const path = normalizeWorkspacePath(rawPath)
+    const mounted = await resolveMountedWorkspaceFile(userId, sessionId, path)
+      .catch(error => {
+        if (error instanceof WorkspacePathError) throw error
+        return undefined
+      })
+    if (mounted) {
+      const kind = getWorkspacePreviewKind(path)
+      const fileStat = await stat(mounted.path)
+      const entry: WorkspaceEntry = {
+        id: entryId(path),
+        path,
+        parentPath: path.slice(0, Math.max(0, path.lastIndexOf('/'))),
+        name: mounted.name,
+        kind: 'file',
+        size: fileStat.size,
+        modifiedAt: fileStat.mtime.toISOString(),
+        mimeType: mounted.mimeType,
+        previewKind: kind,
+      }
+      if (kind === 'text' || kind === 'markdown') {
+        const handle = await open(mounted.path, 'r')
+        try {
+          const bytesToRead = Math.min(fileStat.size, TEXT_PREVIEW_LIMIT)
+          const buffer = Buffer.alloc(bytesToRead)
+          await handle.read(buffer, 0, bytesToRead, 0)
+          return {
+            entry,
+            kind,
+            content: buffer.toString('utf8'),
+            truncated: fileStat.size > TEXT_PREVIEW_LIMIT,
+          }
+        } finally {
+          await handle.close()
+        }
+      }
+      if (kind !== 'office') {
+        return {
+          entry,
+          kind,
+          url: `/api/workspace/content?sessionId=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(path)}`,
+        }
+      }
+      // Office Online requires a public URL, so use the exported S3 object.
+      // The object may take up to a minute to appear after the final write.
+    }
+
     const { bucket, key } = await resolveWorkspaceS3Location(userId, sessionId, path)
     const name = path.split('/').pop() || path
     const parentPath = path.slice(0, Math.max(0, path.lastIndexOf('/')))

--- a/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
+++ b/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
@@ -5,7 +5,9 @@ import {
 } from '@aws-sdk/client-s3'
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
-import { lstat, open, readdir, realpath, stat } from 'node:fs/promises'
+import { constants as fsConstants, type Stats } from 'node:fs'
+import type { FileHandle } from 'node:fs/promises'
+import { open, readdir, realpath, stat } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
 import type {
   WorkspaceEntry,
@@ -176,56 +178,111 @@ function entryId(path: string): string {
   return Buffer.from(path, 'utf8').toString('base64url')
 }
 
-function mountedSessionRoot(userId: string, sessionId: string): string | undefined {
+async function findMountedEntry(
+  parentPath: string,
+  requestedName: string,
+  kind: 'directory' | 'any',
+): Promise<string | undefined> {
+  const entries = await readdir(parentPath, { withFileTypes: true }).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  })
+  const entry = entries.find(candidate => candidate.name === requestedName)
+  if (!entry) return undefined
+  if (entry.isSymbolicLink()) {
+    throw new WorkspacePathError('Workspace symlinks are not accessible')
+  }
+  if (kind === 'directory' && !entry.isDirectory()) {
+    throw new WorkspacePathError('Workspace path is not a directory')
+  }
+  return join(parentPath, entry.name)
+}
+
+async function mountedSessionRoot(
+  userId: string,
+  sessionId: string,
+): Promise<string | undefined> {
   if (!MOUNT_PATH) return undefined
   if (!SAFE_ID.test(userId) || !SAFE_ID.test(sessionId)) {
     throw new WorkspacePathError('Invalid workspace identity')
   }
-  return resolve(MOUNT_PATH, userId, sessionId)
+
+  const mountRoot = await realpath(resolve(MOUNT_PATH)).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  })
+  if (!mountRoot) return undefined
+  const userRoot = await findMountedEntry(mountRoot, userId, 'directory')
+  if (!userRoot) return undefined
+  const sessionRoot = await findMountedEntry(userRoot, sessionId, 'directory')
+  if (!sessionRoot) return undefined
+  return realpath(sessionRoot)
 }
 
 async function resolveMountedPath(
   userId: string,
   sessionId: string,
   logicalPath: string,
-): Promise<string | undefined> {
+): Promise<{ path: string; root: string } | undefined> {
   const path = normalizeWorkspacePath(logicalPath)
   const { namespace, relativePath } = namespaceForPath(path)
   if (namespace.logicalPath !== 'code-interpreter') return undefined
-  const root = mountedSessionRoot(userId, sessionId)
+  const root = await mountedSessionRoot(userId, sessionId)
   if (!root) return undefined
 
-  const candidate = resolve(root, relativePath)
-  if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
-    throw new WorkspacePathError('Invalid mounted workspace path')
+  let candidate = root
+  if (relativePath) {
+    for (const segment of relativePath.split('/')) {
+      if (segment.startsWith('.')) {
+        throw new WorkspacePathError('Hidden workspace paths are not accessible')
+      }
+      const matchedPath = await findMountedEntry(candidate, segment, 'any')
+      if (!matchedPath) return undefined
+      candidate = matchedPath
+    }
   }
 
-  const resolvedRoot = await realpath(root).catch(() => root)
-  const resolvedCandidate = await realpath(candidate).catch(() => candidate)
-  if (
-    resolvedCandidate !== resolvedRoot
-    && !resolvedCandidate.startsWith(`${resolvedRoot}${sep}`)
-  ) {
-    throw new WorkspacePathError('Workspace symlink escapes the session root')
-  }
-  return resolvedCandidate
+  return { path: candidate, root }
 }
 
-export async function resolveMountedWorkspaceFile(
+export async function openMountedWorkspaceFile(
   userId: string,
   sessionId: string,
   logicalPath: string,
-): Promise<{ path: string; mimeType: string; name: string } | undefined> {
-  const path = await resolveMountedPath(userId, sessionId, logicalPath)
-  if (!path) return undefined
-  const metadata = await lstat(path)
-  if (!metadata.isFile() || metadata.isSymbolicLink()) {
-    throw new WorkspacePathError('Workspace path is not a regular file')
-  }
-  return {
-    path,
-    mimeType: getWorkspaceMimeType(logicalPath),
-    name: logicalPath.split('/').pop() || 'download',
+): Promise<{
+  handle: FileHandle
+  metadata: Stats
+  mimeType: string
+  name: string
+} | undefined> {
+  const resolvedPath = await resolveMountedPath(userId, sessionId, logicalPath)
+  if (!resolvedPath) return undefined
+
+  const handle = await open(
+    resolvedPath.path,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+  )
+  try {
+    const metadata = await handle.stat()
+    if (!metadata.isFile()) {
+      throw new WorkspacePathError('Workspace path is not a regular file')
+    }
+    const openedPath = await realpath(`/proc/self/fd/${handle.fd}`)
+    if (
+      openedPath !== resolvedPath.root
+      && !openedPath.startsWith(`${resolvedPath.root}${sep}`)
+    ) {
+      throw new WorkspacePathError('Workspace file escapes the session root')
+    }
+    return {
+      handle,
+      metadata,
+      mimeType: getWorkspaceMimeType(logicalPath),
+      name: logicalPath.split('/').pop() || 'download',
+    }
+  } catch (error) {
+    await handle.close()
+    throw error
   }
 }
 
@@ -235,8 +292,9 @@ async function listMountedWorkspace(
   logicalPath: string,
   cursor?: string,
 ): Promise<WorkspacePage | undefined> {
-  const directory = await resolveMountedPath(userId, sessionId, logicalPath)
-  if (!directory) return undefined
+  const resolvedDirectory = await resolveMountedPath(userId, sessionId, logicalPath)
+  if (!resolvedDirectory) return undefined
+  const directory = resolvedDirectory.path
   const metadata = await stat(directory).catch(() => undefined)
   if (!metadata) return { entries: [] }
   if (!metadata.isDirectory()) throw new WorkspacePathError('Path is not a directory')
@@ -415,47 +473,45 @@ export class S3WorkspaceRepository implements WorkspaceRepository {
     rawPath: string,
   ): Promise<WorkspacePreview> {
     const path = normalizeWorkspacePath(rawPath)
-    const mounted = await resolveMountedWorkspaceFile(userId, sessionId, path)
+    const mounted = await openMountedWorkspaceFile(userId, sessionId, path)
       .catch(error => {
         if (error instanceof WorkspacePathError) throw error
         return undefined
       })
     if (mounted) {
       const kind = getWorkspacePreviewKind(path)
-      const fileStat = await stat(mounted.path)
       const entry: WorkspaceEntry = {
         id: entryId(path),
         path,
         parentPath: path.slice(0, Math.max(0, path.lastIndexOf('/'))),
         name: mounted.name,
         kind: 'file',
-        size: fileStat.size,
-        modifiedAt: fileStat.mtime.toISOString(),
+        size: mounted.metadata.size,
+        modifiedAt: mounted.metadata.mtime.toISOString(),
         mimeType: mounted.mimeType,
         previewKind: kind,
       }
-      if (kind === 'text' || kind === 'markdown') {
-        const handle = await open(mounted.path, 'r')
-        try {
-          const bytesToRead = Math.min(fileStat.size, TEXT_PREVIEW_LIMIT)
+      try {
+        if (kind === 'text' || kind === 'markdown') {
+          const bytesToRead = Math.min(mounted.metadata.size, TEXT_PREVIEW_LIMIT)
           const buffer = Buffer.alloc(bytesToRead)
-          await handle.read(buffer, 0, bytesToRead, 0)
+          await mounted.handle.read(buffer, 0, bytesToRead, 0)
           return {
             entry,
             kind,
             content: buffer.toString('utf8'),
-            truncated: fileStat.size > TEXT_PREVIEW_LIMIT,
+            truncated: mounted.metadata.size > TEXT_PREVIEW_LIMIT,
           }
-        } finally {
-          await handle.close()
         }
-      }
-      if (kind !== 'office') {
-        return {
-          entry,
-          kind,
-          url: `/api/workspace/content?sessionId=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(path)}`,
+        if (kind !== 'office') {
+          return {
+            entry,
+            kind,
+            url: `/api/workspace/content?sessionId=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(path)}`,
+          }
         }
+      } finally {
+        await mounted.handle.close()
       }
       // Office Online requires a public URL, so use the exported S3 object.
       // The object may take up to a minute to appear after the final write.

--- a/docs/architecture/session-workspace.md
+++ b/docs/architecture/session-workspace.md
@@ -55,26 +55,74 @@ All requests require `X-Session-ID`; authenticated identity determines the user
 scope. The frontend consumes `WorkspaceEntry` and `WorkspacePreview` objects
 defined in `src/lib/workspace/types.ts`.
 
-## Storage Evolution
+## S3 Files Integration
 
-The S3 repository is a compatibility implementation. A later phase will attach
-Amazon S3 Files to AgentCore Runtime and Code Interpreter and implement the same
-repository contract over the mounted filesystem.
+The artifact bucket remains the durable source of truth. Amazon S3 Files exposes
+the Code Interpreter namespace as a filesystem without changing the logical
+workspace API.
 
-Arbitrary-code environments must receive a session-rooted access point. A
-shared root access point must not be exposed to Code Interpreter or Code Agent.
-The intended mounted layout is:
+Code Interpreter receives a dynamically created access point rooted at:
 
 ```text
-/mnt/workspace
-├── uploads/
-├── projects/
-├── outputs/
-├── tools/
-└── .system/
+/code-interpreter-workspace/{userId}/{sessionId}
 ```
 
-The `.system` namespace is never shown in the user-facing browser.
+That access point is mounted at `/mnt/workspace`. The access point root is the
+security boundary; path validation or a working directory is not treated as an
+isolation mechanism. A Code Interpreter session cannot traverse to another
+user or chat session.
+
+The trusted frontend task mounts an access point rooted at
+`/code-interpreter-workspace` read-only. Workspace API authorization still
+scopes every request by authenticated user and explicit chat session. Mounted
+paths are resolved with `realpath`, and symlinks that escape the session root
+are rejected.
+
+This read-only mount is intentional. S3 Files can take up to its export
+inactivity window to synchronize a newly closed file back to the backing S3
+bucket. Reading the mount allows the Workspace sidebar and Canvas preview to
+see Code Interpreter outputs immediately instead of waiting for object export.
+
+Existing logical namespaces remain unchanged:
+
+```text
+documents/          S3 API
+code-interpreter/   S3 Files mount, with S3 API fallback
+code-agent/         S3 API
+```
+
+Uploads are written to the existing documents prefix and copied once to the
+Code Interpreter workspace `inputs/` directory through the backing bucket.
+S3 Files imports that prefix on first directory access. Code Interpreter output
+files are created directly in `/mnt/workspace`; the previous base64 preload and
+push path remains only as a rollout fallback.
+
+Access point metadata is stored under the hidden
+`.workspace-access-points/{userId}/{sessionId}.json` prefix. Session deletion
+removes the access point best-effort before removing this registry object. File
+data follows the existing workspace retention policy.
+
+The dev rollout is controlled by `enable_s3_files_workspace`. Disabling it
+removes S3 Files IAM permissions, mounts, and environment configuration and
+returns Code Interpreter to the legacy synchronization path.
+
+## Network Boundary
+
+S3 Files requires Code Interpreter VPC mode and mount targets in compatible
+subnets. `code_interpreter_supported_az_ids` identifies the stable availability
+zone IDs supported by the service. S3 Files mount targets remain available in
+every ECS subnet.
+
+Code Interpreter uses dedicated private subnets and a single public NAT Gateway
+for outbound HTTP, package installation, and external APIs. The NAT route is
+attached only to Code Interpreter subnets; the frontend and other runtimes keep
+their existing network paths.
+
+The single NAT is intentional for dev cost control. It creates a cross-AZ path
+for Code Interpreter sessions outside the NAT availability zone and is not an
+AZ-resilient production topology. A production environment should use one NAT
+per Code Interpreter availability zone or an approved centralized egress
+design.
 
 ## Retention
 
@@ -87,5 +135,6 @@ remove the corresponding workspace root and access point.
 - Existing tools continue to work while the UI gains a unified file browser.
 - Storage migration does not require another frontend protocol change.
 - Artifacts and files remain separate concepts.
-- Real-time file change events, upload, rename, delete, and S3 Files mounts are
-  follow-up phases rather than implicit behavior in the initial slice.
+- Real-time file change events and Workspace-panel upload, rename, and delete
+  remain follow-up phases. Chat attachment uploads are already imported into
+  the session workspace.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -40,6 +40,23 @@ module "agentcore_shared" {
   aws_region             = var.aws_region
   account_id             = local.account_id
   nova_act_workflow_name = var.nova_act_workflow_name
+  code_interpreter_execution_role_arn = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].code_interpreter_execution_role_arn
+    : ""
+  )
+  code_interpreter_subnet_ids = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].code_interpreter_subnet_ids
+    : []
+  )
+  code_interpreter_security_group_ids = (
+    var.enable_s3_files_workspace
+    ? [module.session_workspace[0].mount_target_security_group_id]
+    : []
+  )
+
+  depends_on = [module.session_workspace]
 }
 
 # ============================================================
@@ -120,6 +137,14 @@ locals {
 resource "aws_s3_bucket" "artifacts" {
   bucket        = "${var.project_name}-${var.environment}-artifacts-${local.account_id}"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_cors_configuration" "artifacts" {
@@ -226,6 +251,16 @@ module "runtime_code_agent" {
 
   artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
   artifact_bucket_name = aws_s3_bucket.artifacts.id
+  workspace_file_system_id = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].file_system_id
+    : ""
+  )
+  workspace_file_system_arn = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].file_system_arn
+    : ""
+  )
 
   extra_env_vars = {
     CLAUDE_CODE_USE_BEDROCK = "1"
@@ -309,6 +344,16 @@ module "runtime_orchestrator" {
 
   artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
   artifact_bucket_name = aws_s3_bucket.artifacts.id
+  workspace_file_system_id = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].file_system_id
+    : ""
+  )
+  workspace_file_system_arn = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].file_system_arn
+    : ""
+  )
 
   extra_env_vars = merge(
     {
@@ -322,6 +367,9 @@ module "runtime_orchestrator" {
       RESEARCH_AGENT_RUNTIME_ARN            = module.runtime_research_agent.runtime_arn
       MCP_3LO_RUNTIME_ARN                   = module.runtime_mcp_3lo.runtime_arn
       CODE_INTERPRETER_ID                   = module.agentcore_shared.code_interpreter_id
+      S3_FILES_FILE_SYSTEM_ID               = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_id : ""
+      S3_FILES_FILE_SYSTEM_ARN              = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_arn : ""
+      S3_FILES_MOUNT_PATH                   = "/mnt/workspace"
       BROWSER_ID                            = module.agentcore_shared.browser_id
       BROWSER_NAME                          = module.agentcore_shared.browser_name
       NOVA_ACT_WORKFLOW_DEFINITION_NAME     = module.agentcore_shared.nova_act_workflow_name
@@ -446,6 +494,53 @@ data "aws_subnets" "default" {
     name   = "vpc-id"
     values = [data.aws_vpc.default.id]
   }
+
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+check "code_interpreter_has_supported_subnet" {
+  assert {
+    condition = (
+      !var.enable_s3_files_workspace ||
+      length(var.code_interpreter_private_subnets) > 0
+    )
+    error_message = "code_interpreter_private_subnets must configure at least one supported availability zone."
+  }
+}
+
+check "code_interpreter_private_subnets_match_supported_azs" {
+  assert {
+    condition = alltrue([
+      for availability_zone_id in keys(var.code_interpreter_private_subnets) :
+      length(var.code_interpreter_supported_az_ids) == 0 ||
+      contains(var.code_interpreter_supported_az_ids, availability_zone_id)
+    ])
+    error_message = "Every Code Interpreter private subnet must use an availability zone ID supported by AgentCore."
+  }
+}
+
+module "session_workspace" {
+  source = "../../modules/session-workspace"
+  count  = var.enable_s3_files_workspace ? 1 : 0
+
+  project_name         = var.project_name
+  environment          = var.environment
+  aws_region           = var.aws_region
+  account_id           = local.account_id
+  artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
+  artifact_bucket_name = aws_s3_bucket.artifacts.id
+  vpc_id               = data.aws_vpc.default.id
+  subnet_ids           = data.aws_subnets.default.ids
+  code_interpreter_private_subnets = (
+    var.enable_s3_files_workspace
+    ? var.code_interpreter_private_subnets
+    : {}
+  )
+
+  depends_on = [aws_s3_bucket_versioning.artifacts]
 }
 
 module "chat" {
@@ -475,6 +570,16 @@ module "chat" {
   gateway_url          = module.gateway.gateway_url
   artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
   artifact_bucket_name = aws_s3_bucket.artifacts.id
+  workspace_file_system_arn = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].file_system_arn
+    : ""
+  )
+  workspace_access_point_arn = (
+    var.enable_s3_files_workspace
+    ? module.session_workspace[0].frontend_access_point_arn
+    : ""
+  )
 
   orchestrator_runtime_arn = module.runtime_orchestrator.runtime_arn
   orchestrator_runtime_url = module.runtime_orchestrator.runtime_invocation_url
@@ -490,7 +595,7 @@ module "chat" {
 
   depends_on = [
     module.auth, module.data, module.memory, module.gateway,
-    module.runtime_orchestrator, aws_s3_bucket.artifacts,
+    module.runtime_orchestrator, aws_s3_bucket.artifacts, module.session_workspace,
   ]
 }
 
@@ -557,12 +662,13 @@ module "observability_memory" {
 }
 
 module "observability_code_interpreter" {
-  source        = "../../modules/observability"
-  resource_name = "code-interpreter"
-  resource_arn  = module.agentcore_shared.code_interpreter_arn
-  aws_region    = var.aws_region
-  project_name  = var.project_name
-  environment   = var.environment
+  source             = "../../modules/observability"
+  resource_name      = "code-interpreter"
+  resource_arn       = module.agentcore_shared.code_interpreter_arn
+  source_name_suffix = substr(sha1(module.agentcore_shared.code_interpreter_arn), 0, 8)
+  aws_region         = var.aws_region
+  project_name       = var.project_name
+  environment        = var.environment
 
   depends_on = [module.agentcore_shared, aws_xray_trace_segment_destination.transaction_search, aws_xray_indexing_rule.default]
 }

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -3,3 +3,13 @@ project_name              = "strands-agent-chatbot"
 environment               = "dev"
 network_mode              = "PUBLIC"
 telegram_allowed_user_ids = "8795210678,8680518374"
+code_interpreter_supported_az_ids = [
+  "usw2-az1",
+  "usw2-az2",
+  "usw2-az3",
+]
+code_interpreter_private_subnets = {
+  "usw2-az1" = "172.31.64.0/24"
+  "usw2-az2" = "172.31.65.0/24"
+  "usw2-az3" = "172.31.66.0/24"
+}

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -37,6 +37,24 @@ variable "enable_mantle_models" {
   default     = false
 }
 
+variable "enable_s3_files_workspace" {
+  description = "Mount the artifact bucket through S3 Files for session Code Interpreter workspaces."
+  type        = bool
+  default     = true
+}
+
+variable "code_interpreter_supported_az_ids" {
+  description = "Stable availability zone IDs supported by AgentCore Code Interpreter VPC mode. Empty uses every subnet in the selected VPC."
+  type        = list(string)
+  default     = []
+}
+
+variable "code_interpreter_private_subnets" {
+  description = "Availability zone ID to private subnet CIDR mapping used by Code Interpreter for NAT egress."
+  type        = map(string)
+  default     = {}
+}
+
 variable "code_agent_model_id" {
   description = "Claude model used by the Claude Agent SDK based Code Agent."
   type        = string

--- a/infra/modules/agentcore-shared/main.tf
+++ b/infra/modules/agentcore-shared/main.tf
@@ -1,5 +1,10 @@
 locals {
   name_prefix = replace("${var.project_name}_${var.environment}", "-", "_")
+  code_interpreter_config_suffix = substr(sha1(jsonencode({
+    execution_role_arn = var.code_interpreter_execution_role_arn
+    subnet_ids         = sort(var.code_interpreter_subnet_ids)
+    security_group_ids = sort(var.code_interpreter_security_group_ids)
+  })), 0, 8)
 }
 
 # Dedicated role the Browser assumes for navigation logging / bot-auth.
@@ -34,11 +39,20 @@ resource "aws_iam_role_policy" "browser" {
 }
 
 resource "aws_bedrockagentcore_code_interpreter" "this" {
-  name        = "${local.name_prefix}_code_interpreter"
-  description = "Shared Code Interpreter for ${var.project_name} ${var.environment}"
+  name               = "${local.name_prefix}_ci_${local.code_interpreter_config_suffix}"
+  description        = "Shared Code Interpreter for ${var.project_name} ${var.environment}"
+  execution_role_arn = var.code_interpreter_execution_role_arn != "" ? var.code_interpreter_execution_role_arn : null
 
   network_configuration {
-    network_mode = "PUBLIC"
+    network_mode = length(var.code_interpreter_subnet_ids) > 0 ? "VPC" : "PUBLIC"
+
+    dynamic "vpc_config" {
+      for_each = length(var.code_interpreter_subnet_ids) > 0 ? [1] : []
+      content {
+        subnets         = var.code_interpreter_subnet_ids
+        security_groups = var.code_interpreter_security_group_ids
+      }
+    }
   }
 }
 

--- a/infra/modules/agentcore-shared/variables.tf
+++ b/infra/modules/agentcore-shared/variables.tf
@@ -14,6 +14,21 @@ variable "account_id" {
   type = string
 }
 
+variable "code_interpreter_execution_role_arn" {
+  type    = string
+  default = ""
+}
+
+variable "code_interpreter_subnet_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "code_interpreter_security_group_ids" {
+  type    = list(string)
+  default = []
+}
+
 variable "nova_act_workflow_name" {
   description = "Nova Act Workflow Definition Name. Create via: aws nova-act create-workflow-definition --name <name>."
   type        = string

--- a/infra/modules/chat/main.tf
+++ b/infra/modules/chat/main.tf
@@ -286,85 +286,109 @@ resource "aws_iam_role_policy" "ecs_task" {
   role = aws_iam_role.ecs_task.id
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "bedrock-agentcore:InvokeAgentRuntime",
-          "bedrock-agentcore:InvokeAgentRuntimeForUser",
-          "bedrock-agentcore:*",
-        ]
-        Resource = [
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:runtime/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:memory/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:gateway/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:browser/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:browser-custom/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:code-interpreter/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:code-interpreter-custom/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:workload-identity-directory/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:token-vault/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:registry/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream", "bedrock:Converse", "bedrock:ConverseStream"]
-        Resource = [
-          "arn:aws:bedrock:*::foundation-model/*",
-          "arn:aws:bedrock:${var.aws_region}:${var.account_id}:*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = ["bedrock-agentcore:CompleteResourceTokenAuth"]
-        Resource = [
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:token-vault/*",
-          "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:workload-identity-directory/*",
-        ]
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["secretsmanager:GetSecretValue"]
-        Resource = "arn:aws:secretsmanager:${var.aws_region}:${var.account_id}:secret:bedrock-agentcore-*"
-      },
-      {
-        Effect = "Allow"
-        Action = ["ssm:GetParameter", "ssm:GetParameters"]
-        Resource = [
-          "arn:aws:ssm:${var.aws_region}:${var.account_id}:parameter/${var.project_name}/${var.environment}/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          var.users_table_arn,
-          var.sessions_table_arn,
-          "${var.sessions_table_arn}/index/*",
-          var.session_orchestration_table_arn,
-        ]
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["bedrock-agentcore:InvokeGateway", "bedrock-agentcore:GetGateway", "bedrock-agentcore:ListGateways"]
-        Resource = "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:gateway/*"
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:PutObject", "s3:ListBucket"]
-        Resource = [var.artifact_bucket_arn, "${var.artifact_bucket_arn}/*"]
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["logs:CreateLogStream", "logs:PutLogEvents", "cloudwatch:PutMetricData"]
-        Resource = "*"
-      },
-    ]
+    Statement = concat(
+      [
+        {
+          Effect = "Allow"
+          Action = [
+            "bedrock-agentcore:InvokeAgentRuntime",
+            "bedrock-agentcore:InvokeAgentRuntimeForUser",
+            "bedrock-agentcore:*",
+          ]
+          Resource = [
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:runtime/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:memory/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:gateway/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:browser/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:browser-custom/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:code-interpreter/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:code-interpreter-custom/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:workload-identity-directory/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:token-vault/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:registry/*",
+          ]
+        },
+        {
+          Effect = "Allow"
+          Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream", "bedrock:Converse", "bedrock:ConverseStream"]
+          Resource = [
+            "arn:aws:bedrock:*::foundation-model/*",
+            "arn:aws:bedrock:${var.aws_region}:${var.account_id}:*",
+          ]
+        },
+        {
+          Effect = "Allow"
+          Action = ["bedrock-agentcore:CompleteResourceTokenAuth"]
+          Resource = [
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:token-vault/*",
+            "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:workload-identity-directory/*",
+          ]
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["secretsmanager:GetSecretValue"]
+          Resource = "arn:aws:secretsmanager:${var.aws_region}:${var.account_id}:secret:bedrock-agentcore-*"
+        },
+        {
+          Effect = "Allow"
+          Action = ["ssm:GetParameter", "ssm:GetParameters"]
+          Resource = [
+            "arn:aws:ssm:${var.aws_region}:${var.account_id}:parameter/${var.project_name}/${var.environment}/*",
+          ]
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+            "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+            "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+          ]
+          Resource = [
+            var.users_table_arn,
+            var.sessions_table_arn,
+            "${var.sessions_table_arn}/index/*",
+            var.session_orchestration_table_arn,
+          ]
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["bedrock-agentcore:InvokeGateway", "bedrock-agentcore:GetGateway", "bedrock-agentcore:ListGateways"]
+          Resource = "arn:aws:bedrock-agentcore:${var.aws_region}:${var.account_id}:gateway/*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
+          Resource = [var.artifact_bucket_arn, "${var.artifact_bucket_arn}/*"]
+        },
+      ],
+      [
+        for statement in [
+          {
+            Effect   = "Allow"
+            Action   = ["s3files:ClientMount", "s3files:GetAccessPoint"]
+            Resource = var.workspace_file_system_arn
+            Condition = {
+              ArnEquals = {
+                "s3files:AccessPointArn" = var.workspace_access_point_arn
+              }
+            }
+          },
+          {
+            Effect   = "Allow"
+            Action   = ["s3files:DeleteAccessPoint", "s3files:GetAccessPoint"]
+            Resource = "${var.workspace_file_system_arn}/access-point/*"
+          },
+        ] : statement
+        if var.workspace_file_system_arn != "" && var.workspace_access_point_arn != ""
+      ],
+      [
+        {
+          Effect   = "Allow"
+          Action   = ["logs:CreateLogStream", "logs:PutLogEvents", "cloudwatch:PutMetricData"]
+          Resource = "*"
+        },
+      ],
+    )
   })
 }
 
@@ -395,6 +419,8 @@ resource "aws_ecs_task_definition" "frontend" {
       { name = "DYNAMODB_SESSIONS_TABLE", value = var.sessions_table_name },
       { name = "SESSION_ORCHESTRATION_TABLE", value = var.session_orchestration_table_name },
       { name = "ARTIFACT_BUCKET", value = var.artifact_bucket_name },
+      { name = "S3_FILES_MOUNT_PATH", value = var.workspace_file_system_arn != "" ? "/mnt/session-workspaces" : "" },
+      { name = "S3_FILES_FILE_SYSTEM_ID", value = var.workspace_file_system_arn != "" ? split("/", var.workspace_file_system_arn)[1] : "" },
       { name = "MEMORY_ID", value = var.memory_id },
       { name = "MCP_GATEWAY_URL", value = var.gateway_url },
       { name = "ORCHESTRATOR_RUNTIME_ARN", value = var.orchestrator_runtime_arn },
@@ -406,6 +432,11 @@ resource "aws_ecs_task_definition" "frontend" {
       name      = "AWS_BEARER_TOKEN_BEDROCK"
       valueFrom = var.bedrock_api_key_secret_arn
     }] : []
+    mountPoints = var.workspace_file_system_arn != "" ? [{
+      sourceVolume  = "session-workspace"
+      containerPath = "/mnt/session-workspaces"
+      readOnly      = true
+    }] : []
     logConfiguration = {
       logDriver = "awslogs"
       options = {
@@ -415,6 +446,18 @@ resource "aws_ecs_task_definition" "frontend" {
       }
     }
   }])
+
+  dynamic "volume" {
+    for_each = var.workspace_file_system_arn != "" ? [1] : []
+    content {
+      name = "session-workspace"
+
+      s3files_volume_configuration {
+        file_system_arn  = var.workspace_file_system_arn
+        access_point_arn = var.workspace_access_point_arn
+      }
+    }
+  }
 
   depends_on = [
     null_resource.codebuild_trigger,

--- a/infra/modules/chat/variables.tf
+++ b/infra/modules/chat/variables.tf
@@ -87,6 +87,16 @@ variable "artifact_bucket_name" {
   type = string
 }
 
+variable "workspace_file_system_arn" {
+  type    = string
+  default = ""
+}
+
+variable "workspace_access_point_arn" {
+  type    = string
+  default = ""
+}
+
 variable "orchestrator_runtime_arn" {
   type = string
 }

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -1,7 +1,8 @@
 # AgentCore Observability — CloudWatch Vended Logs + X-Ray Traces
 
 locals {
-  prefix = "${var.project_name}-${var.environment}-${var.resource_name}"
+  prefix        = "${var.project_name}-${var.environment}-${var.resource_name}"
+  source_suffix = var.source_name_suffix != "" ? "-${var.source_name_suffix}" : ""
 }
 
 # ============================================================
@@ -18,15 +19,23 @@ resource "aws_cloudwatch_log_group" "logs" {
 # ============================================================
 
 resource "aws_cloudwatch_log_delivery_source" "logs" {
-  name         = "${local.prefix}-logs"
+  name         = "${local.prefix}-logs${local.source_suffix}"
   log_type     = "APPLICATION_LOGS"
   resource_arn = var.resource_arn
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_log_delivery_source" "traces" {
-  name         = "${local.prefix}-traces"
+  name         = "${local.prefix}-traces${local.source_suffix}"
   log_type     = "TRACES"
   resource_arn = var.resource_arn
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # ============================================================

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -8,6 +8,12 @@ variable "resource_arn" {
   type        = string
 }
 
+variable "source_name_suffix" {
+  description = "Optional suffix used to rotate delivery sources when the resource ARN changes"
+  type        = string
+  default     = ""
+}
+
 variable "aws_region" {
   type = string
 }

--- a/infra/modules/runtime/main.tf
+++ b/infra/modules/runtime/main.tf
@@ -482,6 +482,35 @@ resource "aws_iam_role_policy" "orchestrator_artifacts" {
   })
 }
 
+resource "aws_iam_role_policy" "orchestrator_workspace_access_points" {
+  count = var.runtime_type == "orchestrator" && var.workspace_file_system_id != "" ? 1 : 0
+  name  = "workspace-access-points"
+  role  = aws_iam_role.execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3files:CreateAccessPoint",
+          "s3files:ListAccessPoints",
+        ]
+        Resource = var.workspace_file_system_arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3files:DeleteAccessPoint",
+          "s3files:GetAccessPoint",
+          "s3files:ListTagsForResource",
+        ]
+        Resource = "${var.workspace_file_system_arn}/access-point/*"
+      },
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "a2a_agent_extra" {
   count = contains(["a2a_agent", "http_agent"], var.runtime_type) ? 1 : 0
   name  = "processing-agent-extra"

--- a/infra/modules/runtime/variables.tf
+++ b/infra/modules/runtime/variables.tf
@@ -126,6 +126,16 @@ variable "artifact_bucket_name" {
   default = ""
 }
 
+variable "workspace_file_system_id" {
+  type    = string
+  default = ""
+}
+
+variable "workspace_file_system_arn" {
+  type    = string
+  default = ""
+}
+
 variable "read_only_bucket_arns" {
   type    = list(string)
   default = []

--- a/infra/modules/session-workspace/main.tf
+++ b/infra/modules/session-workspace/main.tf
@@ -1,0 +1,355 @@
+locals {
+  prefix = "${var.project_name}-${var.environment}-workspace"
+}
+
+data "aws_vpc" "this" {
+  id = var.vpc_id
+}
+
+data "aws_subnet" "existing" {
+  for_each = toset(var.subnet_ids)
+  id       = each.value
+}
+
+locals {
+  code_interpreter_nat_enabled = length(var.code_interpreter_private_subnets) > 0
+  public_subnet_by_az = {
+    for subnet_id, subnet in data.aws_subnet.existing :
+    subnet.availability_zone_id => subnet_id
+    if contains(keys(var.code_interpreter_private_subnets), subnet.availability_zone_id)
+  }
+  nat_availability_zone_id = local.code_interpreter_nat_enabled ? sort(keys(var.code_interpreter_private_subnets))[0] : ""
+  nat_public_subnet_id = (
+    local.code_interpreter_nat_enabled
+    ? lookup(local.public_subnet_by_az, local.nat_availability_zone_id, "")
+    : ""
+  )
+}
+
+resource "aws_eip" "code_interpreter_nat" {
+  count  = local.code_interpreter_nat_enabled ? 1 : 0
+  domain = "vpc"
+
+  tags = {
+    Name        = "${local.prefix}-code-interpreter-nat"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_nat_gateway" "code_interpreter" {
+  count         = local.code_interpreter_nat_enabled ? 1 : 0
+  allocation_id = aws_eip.code_interpreter_nat[0].id
+  subnet_id     = local.nat_public_subnet_id
+
+  tags = {
+    Name        = "${local.prefix}-code-interpreter"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.nat_public_subnet_id != ""
+      error_message = "A public subnet is required in the first configured Code Interpreter availability zone."
+    }
+  }
+}
+
+resource "aws_subnet" "code_interpreter_private" {
+  for_each = var.code_interpreter_private_subnets
+
+  vpc_id                  = var.vpc_id
+  availability_zone_id    = each.key
+  cidr_block              = each.value
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name        = "${local.prefix}-code-interpreter-${each.key}"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_route_table" "code_interpreter_private" {
+  count  = local.code_interpreter_nat_enabled ? 1 : 0
+  vpc_id = var.vpc_id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.code_interpreter[0].id
+  }
+
+  tags = {
+    Name        = "${local.prefix}-code-interpreter-private"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_route_table_association" "code_interpreter_private" {
+  for_each = aws_subnet.code_interpreter_private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.code_interpreter_private[0].id
+}
+
+resource "aws_iam_role" "s3files" {
+  name = "${local.prefix}-s3files"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "AllowS3FilesAssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "elasticfilesystem.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = var.account_id
+        }
+        ArnLike = {
+          "aws:SourceArn" = "arn:aws:s3files:${var.aws_region}:${var.account_id}:file-system/*"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "s3files" {
+  name = "backing-bucket"
+  role = aws_iam_role.s3files.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3BucketPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:ListBucketVersions",
+        ]
+        Resource = var.artifact_bucket_arn
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = var.account_id
+          }
+        }
+      },
+      {
+        Sid    = "S3ObjectPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject*",
+          "s3:GetObject*",
+          "s3:List*",
+          "s3:PutObject*",
+        ]
+        Resource = "${var.artifact_bucket_arn}/*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = var.account_id
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeManage"
+        Effect = "Allow"
+        Action = [
+          "events:DeleteRule",
+          "events:DisableRule",
+          "events:EnableRule",
+          "events:PutRule",
+          "events:PutTargets",
+          "events:RemoveTargets",
+        ]
+        Resource = "arn:aws:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+        Condition = {
+          StringEquals = {
+            "events:ManagedBy" = "elasticfilesystem.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeRead"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:ListRuleNamesByTarget",
+          "events:ListRules",
+          "events:ListTargetsByRule",
+        ]
+        Resource = "arn:aws:events:*:*:rule/*"
+      },
+    ]
+  })
+}
+
+resource "aws_s3files_file_system" "this" {
+  bucket                = var.artifact_bucket_arn
+  role_arn              = aws_iam_role.s3files.arn
+  accept_bucket_warning = true
+
+  tags = {
+    Name        = local.prefix
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# S3 objects written by the upload path are imported when the mounted
+# directory is first accessed. Files written through the mount are exported
+# back to the same bucket automatically by S3 Files.
+resource "aws_s3files_synchronization_configuration" "this" {
+  file_system_id = aws_s3files_file_system.this.id
+
+  # S3 Files requires a catch-all rule rooted at the empty prefix. Keep its
+  # import threshold minimal so unrelated artifact namespaces are not staged
+  # into the filesystem; the workspace-specific rule below takes precedence.
+  import_data_rule {
+    prefix         = ""
+    size_less_than = 1
+    trigger        = "ON_DIRECTORY_FIRST_ACCESS"
+  }
+
+  import_data_rule {
+    prefix         = "code-interpreter-workspace/"
+    size_less_than = 5368709120
+    trigger        = "ON_DIRECTORY_FIRST_ACCESS"
+  }
+
+  # Expiration removes cold data from the filesystem cache only after it has
+  # synchronized to S3. A later access imports the durable object again.
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+}
+
+resource "aws_security_group" "mount_target" {
+  name        = "${local.prefix}-mount"
+  description = "NFS access to the session workspace S3 Files mount targets"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "NFS from workspace clients in the VPC"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.this.cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_s3files_mount_target" "this" {
+  for_each = toset(var.subnet_ids)
+
+  file_system_id = aws_s3files_file_system.this.id
+  subnet_id      = each.value
+  security_groups = [
+    aws_security_group.mount_target.id,
+  ]
+}
+
+# The frontend is trusted and enforces user/session authorization in the API.
+# It mounts only the Code Interpreter namespace and never executes user code.
+resource "aws_s3files_access_point" "frontend" {
+  file_system_id = aws_s3files_file_system.this.id
+
+  posix_user {
+    uid = 1000
+    gid = 1000
+  }
+
+  root_directory {
+    path = "/code-interpreter-workspace"
+
+    creation_permissions {
+      owner_uid   = 1000
+      owner_gid   = 1000
+      permissions = "0750"
+    }
+  }
+
+  tags = {
+    Name        = "${local.prefix}-frontend"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+
+  depends_on = [aws_s3files_mount_target.this]
+}
+
+resource "aws_iam_role" "code_interpreter" {
+  name = "${local.prefix}-code-interpreter"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "bedrock-agentcore.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = var.account_id
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "code_interpreter" {
+  name = "session-workspace"
+  role = aws_iam_role.code_interpreter.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "MountSessionAccessPoints"
+        Effect = "Allow"
+        Action = [
+          "s3files:ClientMount",
+          "s3files:ClientWrite",
+          "s3files:GetAccessPoint",
+        ]
+        Resource = aws_s3files_file_system.this.arn
+        Condition = {
+          ArnLike = {
+            "s3files:AccessPointArn" = "${aws_s3files_file_system.this.arn}/access-point/*"
+          }
+        }
+      },
+      {
+        Sid    = "ReadWorkspaceObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+        ]
+        Resource = "${var.artifact_bucket_arn}/code-interpreter-workspace/*"
+      },
+      {
+        Sid      = "ListWorkspaceObjects"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = var.artifact_bucket_arn
+        Condition = {
+          StringLike = {
+            "s3:prefix" = [
+              "code-interpreter-workspace",
+              "code-interpreter-workspace/*",
+            ]
+          }
+        }
+      },
+    ]
+  })
+}

--- a/infra/modules/session-workspace/outputs.tf
+++ b/infra/modules/session-workspace/outputs.tf
@@ -1,0 +1,27 @@
+output "file_system_id" {
+  value = aws_s3files_file_system.this.id
+}
+
+output "file_system_arn" {
+  value = aws_s3files_file_system.this.arn
+}
+
+output "frontend_access_point_arn" {
+  value = aws_s3files_access_point.frontend.arn
+}
+
+output "mount_target_security_group_id" {
+  value = aws_security_group.mount_target.id
+}
+
+output "code_interpreter_execution_role_arn" {
+  value = aws_iam_role.code_interpreter.arn
+}
+
+output "code_interpreter_subnet_ids" {
+  value = sort([for subnet in aws_subnet.code_interpreter_private : subnet.id])
+}
+
+output "code_interpreter_nat_gateway_id" {
+  value = try(aws_nat_gateway.code_interpreter[0].id, "")
+}

--- a/infra/modules/session-workspace/variables.tf
+++ b/infra/modules/session-workspace/variables.tf
@@ -1,0 +1,37 @@
+variable "project_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "account_id" {
+  type = string
+}
+
+variable "artifact_bucket_arn" {
+  type = string
+}
+
+variable "artifact_bucket_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "code_interpreter_private_subnets" {
+  description = "Availability zone ID to private subnet CIDR mapping for Code Interpreter NAT egress. Empty disables managed NAT egress."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

- persist Code Interpreter files in session-scoped S3 Files access points mounted at `/mnt/workspace`
- expose the mounted workspace to the frontend as a read-only file browser and preview source
- clean up session access points when chat sessions are deleted
- run Code Interpreter in dedicated private subnets with a single dev NAT Gateway for external HTTP and package installation
- widen the Artifacts sidebar preview while preserving the minimum chat width

## Architecture

- S3 remains the durable workspace source of truth.
- Code Interpreter receives a session-rooted access point, which is the filesystem isolation boundary.
- The frontend ECS task mounts a trusted read-only access point and validates resolved paths before serving content.
- The existing S3 preload/push path remains as a rollout fallback.
- Dev uses one NAT Gateway to control cost; this is intentionally not multi-AZ egress.

## Verification

- Frontend: 51 files / 691 tests
- Frontend TypeScript check and production build
- AgentCore: 562 unit tests
- Ruff on all changed Python sources and tests
- Terraform format and validation
- `git diff --check`
- Dev end-to-end:
  - authenticated Orchestrator -> Code Interpreter file creation
  - immediate Workspace API/Canvas read
  - file reuse from a new Code Interpreter session
  - external HTTP and `pip install`
  - access point cleanup on session deletion

## Dev deployment

- AgentCore Runtime v41: READY
- Frontend ECS revision 59: COMPLETED
- Code Interpreter: READY in VPC mode
- NAT Gateway: available
