### PR TITLE
fix(deps): resolve npm security advisories

### DIFF
--- a/chatbot-app/frontend/package-lock.json
+++ b/chatbot-app/frontend/package-lock.json
@@ -2946,9 +2946,9 @@
       }
     },
     "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -10503,9 +10503,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -13033,9 +13033,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -14087,9 +14087,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "10.9.6",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.6.tgz",
-      "integrity": "sha512-XRjjRaI4aPCAMpVaOhxIwLYdx3U4Cb6mN0M268ggFAfFRqsvyFW8zxWbEZazN/mPkqsVWThb0oa1UawWK+XMNg==",
+      "version": "10.9.8",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.8.tgz",
+      "integrity": "sha512-gmIhmkmD/3DL5lErDV71E/cFUkEbBW4VTFpsJH1HSYjeBICRKOoc4AZem+RNz/FhhCXKBMZiD75bIfBlb2A4yA==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.1",
@@ -15342,9 +15342,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/chatbot-app/frontend/package.json
+++ b/chatbot-app/frontend/package.json
@@ -85,7 +85,8 @@
     "fast-xml-parser": "^5.3.6",
     "ajv": "^8.18.0",
     "brace-expansion": ">=5.0.8",
-    "dompurify": ">=3.2.4",
+    "dompurify": ">=3.4.13",
+    "js-yaml": "^4.3.1",
     "@ag-ui/client": {
       "uuid": ">=11.1.1"
     },
@@ -96,10 +97,10 @@
     "@aws-amplify/api-graphql": {
       "uuid": ">=11.1.1"
     },
-    "nanoid": "^3.3.8",
+    "nanoid": "^3.3.17",
     "@excalidraw/mermaid-to-excalidraw": {
-      "nanoid": "^5.0.9",
-      "mermaid": "^10.9.5"
+      "nanoid": "^5.1.16",
+      "mermaid": "^10.9.8"
     },
     "@babel/core": "^7.29.6",
     "vite": "^7.3.4",

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -11207,9 +11207,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -60,6 +60,7 @@
     "js-yaml": "~4.3.0",
     "linkify-it": "~5.0.2",
     "markdown-it": "~14.2.0",
+    "nanoid": "^3.3.17",
     "postcss": ">=8.5.18",
     "shell-quote": "~1.9.0",
     "svgo": "~3.3.4",


### PR DESCRIPTION
## Summary
- update frontend DOMPurify, js-yaml, nanoid, and Mermaid transitive dependencies to patched releases
- update mobile nanoid to a patched release
- consolidate and supersede Dependabot PRs #228 and #229

## Security impact
Resolves 9 of 11 open Dependabot alerts. The remaining two alerts affect `image-size`, which is only present through Metro build tooling and has no patched upstream release. The repository contains no ICNS, JXL, HEIF, or HEIC assets that exercise the vulnerable parsers.

## Validation
- Frontend: `npm ci`, `npm run type-check`, 714 tests, production build, `npm audit` (0 vulnerabilities)
- Mobile: `npm ci`, `npx tsc --noEmit`
- Verified installed versions: DOMPurify 3.4.13, js-yaml 4.3.1, Mermaid 10.9.8, nanoid 3.3.18/5.1.16