### PR TITLE
feat(agent): route delegated work by task complexity

### DIFF
--- a/agentcore/a2a-agents/code-agent/src/main.py
+++ b/agentcore/a2a-agents/code-agent/src/main.py
@@ -42,6 +42,7 @@ from claude_agent_sdk import (
     ProcessError,
     CLIJSONDecodeError,
 )
+from .model_runtime import effective_model_id, needs_model_switch
 from .session_workspace import restore_s3_prefix, sync_session_inputs
 
 # Claude Agent SDK cannot run inside an existing Claude Code session.
@@ -71,12 +72,13 @@ PORT = int(os.getenv("PORT", "9000"))
 PROJECT_NAME = os.getenv("PROJECT_NAME", "strands-agent-chatbot")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "dev")
 WORKSPACE_BASE = os.getenv("WORKSPACE_BASE", "/tmp/workspaces")
-CODE_AGENT_MODEL_ID = os.getenv(
-    "CODE_AGENT_MODEL_ID",
-    os.getenv("ANTHROPIC_MODEL", "us.anthropic.claude-sonnet-5"),
+CODE_AGENT_MODEL_ID = os.getenv("CODE_AGENT_MODEL_ID") or os.getenv(
+    "ANTHROPIC_MODEL"
 )
-# Claude Code reads this variable when its subprocess starts. Set it once at
-# process startup; mutating it per request would race across concurrent users.
+if not CODE_AGENT_MODEL_ID:
+    raise RuntimeError("CODE_AGENT_MODEL_ID or ANTHROPIC_MODEL is required")
+# Keep a process default for direct calls. A2A requests pass an explicit model
+# through ClaudeAgentOptions so concurrent sessions do not mutate global state.
 os.environ["ANTHROPIC_MODEL"] = CODE_AGENT_MODEL_ID
 
 
@@ -130,6 +132,7 @@ _sdk_sessions: dict = {}
 # In-memory map: "{user_id}-{session_id}" → ClaudeSDKClient instance
 # Keeps the Claude Code subprocess alive across A2A task calls (warm start)
 _sdk_clients: dict[str, ClaudeSDKClient] = {}
+_sdk_client_models: dict[str, str] = {}
 
 # In-memory map: a2a task_id → asyncio.Event
 # Set by cancel() to signal execute() to stop consuming messages gracefully
@@ -348,6 +351,7 @@ def _build_client_options(
     sdk_session_id: Optional[str] = None,
     workspace: Optional[Path] = None,
     max_turns: int = 100,
+    model_id: Optional[str] = None,
 ) -> ClaudeAgentOptions:
     """Build ClaudeAgentOptions with common settings."""
     return ClaudeAgentOptions(
@@ -358,12 +362,14 @@ def _build_client_options(
         system_prompt={"type": "preset", "preset": "claude_code"},
         setting_sources=["user", "project"],
         max_turns=max_turns,
+        model=model_id,
     )
 
 
 async def _get_or_create_client(
     sdk_key: str,
     options: ClaudeAgentOptions,
+    model_id: str,
 ) -> ClaudeSDKClient:
     """Get an existing connected client or create a new one.
 
@@ -372,10 +378,35 @@ async def _get_or_create_client(
     """
     existing = _sdk_clients.get(sdk_key)
     if existing and existing._query is not None:
-        logger.info(f"[Client] Reusing existing client for {sdk_key}")
-        return existing
+        cached_model_id = _sdk_client_models.get(sdk_key, "")
+        if needs_model_switch(cached_model_id, model_id):
+            try:
+                await existing.set_model(model_id)
+                _sdk_client_models[sdk_key] = model_id
+                logger.info(
+                    "[Client] Switched model for %s from %s to %s",
+                    sdk_key,
+                    cached_model_id,
+                    model_id,
+                )
+            except Exception:
+                logger.exception(
+                    "[Client] Model switch failed for %s; recreating client",
+                    sdk_key,
+                )
+                try:
+                    await existing.disconnect()
+                except Exception:
+                    pass
+                _sdk_clients.pop(sdk_key, None)
+                _sdk_client_models.pop(sdk_key, None)
+            else:
+                return existing
+        else:
+            logger.info(f"[Client] Reusing existing client for {sdk_key}")
+            return existing
 
-    # Discard stale client if any
+    existing = _sdk_clients.get(sdk_key)
     if existing:
         logger.info(f"[Client] Discarding disconnected client for {sdk_key}")
         try:
@@ -383,18 +414,21 @@ async def _get_or_create_client(
         except Exception:
             pass
         _sdk_clients.pop(sdk_key, None)
+        _sdk_client_models.pop(sdk_key, None)
 
     # Create and connect new client
     client = ClaudeSDKClient(options=options)
     await client.connect()
     _sdk_clients[sdk_key] = client
-    logger.info(f"[Client] Created new client for {sdk_key}")
+    _sdk_client_models[sdk_key] = model_id
+    logger.info(f"[Client] Created new client for {sdk_key} with model {model_id}")
     return client
 
 
 async def _disconnect_client(sdk_key: str) -> None:
     """Disconnect and remove a cached client."""
     client = _sdk_clients.pop(sdk_key, None)
+    _sdk_client_models.pop(sdk_key, None)
     if client:
         try:
             await client.disconnect()
@@ -458,11 +492,12 @@ class ClaudeCodeExecutor(AgentExecutor):
         user_id = metadata.get("user_id", "default_user")
 
         orchestrator_model_id = metadata.get("orchestrator_model_id")
+        model_id = effective_model_id(metadata, CODE_AGENT_MODEL_ID)
         logger.info(
             "[ClaudeCodeExecutor] session=%s, user=%s, model=%s, orchestrator_model=%s",
             session_id,
             user_id,
-            CODE_AGENT_MODEL_ID,
+            model_id,
             orchestrator_model_id,
         )
         logger.info(f"[ClaudeCodeExecutor] task={task_text[:200]}")
@@ -539,9 +574,13 @@ class ClaudeCodeExecutor(AgentExecutor):
         last_todos: list = []        # most recent TodoWrite state
 
         # --- Get or create streaming client ---
-        options = _build_client_options(sdk_session_id, workspace)
+        options = _build_client_options(
+            sdk_session_id,
+            workspace,
+            model_id=model_id,
+        )
         try:
-            client = await _get_or_create_client(sdk_key, options)
+            client = await _get_or_create_client(sdk_key, options, model_id)
         except CLINotFoundError as e:
             logger.exception("[ClaudeCodeExecutor] Claude CLI not found — check container setup")
             await updater.add_artifact(

--- a/agentcore/a2a-agents/code-agent/src/model_runtime.py
+++ b/agentcore/a2a-agents/code-agent/src/model_runtime.py
@@ -1,0 +1,16 @@
+"""Pure helpers for request-scoped Code Agent model selection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def effective_model_id(metadata: dict[str, Any], default_model_id: str) -> str:
+    return str(metadata.get("model_id") or default_model_id)
+
+
+def needs_model_switch(
+    cached_model_id: str,
+    requested_model_id: str,
+) -> bool:
+    return cached_model_id != requested_model_id

--- a/agentcore/a2a-agents/code-agent/tests/test_a2a_contract.py
+++ b/agentcore/a2a-agents/code-agent/tests/test_a2a_contract.py
@@ -7,6 +7,7 @@ invocations and format tool progress steps — no SDK or AWS calls required.
 import re
 from unittest.mock import MagicMock
 
+from src.model_runtime import effective_model_id, needs_model_switch
 
 # ============================================================
 # Helpers replicated from main.py (pure functions, no deps)
@@ -215,6 +216,24 @@ class TestExtractMetadata:
         }
         assert _extract_metadata(ctx)["orchestrator_model_id"] == "openai.gpt-5.6-terra"
         assert "model_id" not in _extract_metadata(ctx)
+
+
+class TestModelRuntime:
+    def test_request_model_overrides_process_default(self):
+        assert effective_model_id(
+            {"model_id": "us.anthropic.claude-opus-5"},
+            "us.anthropic.claude-sonnet-5",
+        ) == "us.anthropic.claude-opus-5"
+
+    def test_missing_request_model_uses_process_default(self):
+        assert effective_model_id(
+            {},
+            "us.anthropic.claude-sonnet-5",
+        ) == "us.anthropic.claude-sonnet-5"
+
+    def test_model_switch_only_when_requested_model_changes(self):
+        assert not needs_model_switch("sonnet", "sonnet")
+        assert needs_model_switch("sonnet", "opus")
 
 
 # ============================================================

--- a/chatbot-app/agentcore/Dockerfile
+++ b/chatbot-app/agentcore/Dockerfile
@@ -31,6 +31,7 @@ RUN pip install --no-cache-dir --no-deps nova-act==3.1.263
 # Copy application code and skill definitions
 COPY src/ ./src/
 COPY skills/ ./skills/
+COPY config/ ./config/
 
 # Expose port (AgentCore Runtime will map this)
 EXPOSE 8080

--- a/chatbot-app/agentcore/Dockerfile.subagent
+++ b/chatbot-app/agentcore/Dockerfile.subagent
@@ -14,6 +14,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ ./src/
 COPY skills/ ./skills/
+COPY config/ ./config/
 
 EXPOSE 9000
 

--- a/chatbot-app/agentcore/config/model-catalog.json
+++ b/chatbot-app/agentcore/config/model-catalog.json
@@ -1,0 +1,197 @@
+{
+  "schemaVersion": 1,
+  "revision": "2026-08-11.1",
+  "providerMatchers": {
+    "anthropic": [
+      "anthropic.",
+      ".anthropic."
+    ],
+    "openai": [
+      "openai."
+    ]
+  },
+  "familyMatchers": {
+    "claude": [
+      "anthropic.claude-",
+      ".anthropic.claude-"
+    ],
+    "gpt": [
+      "openai.gpt-"
+    ]
+  },
+  "models": {
+    "claude.opus.latest": {
+      "id": "us.anthropic.claude-opus-5",
+      "provider": "anthropic",
+      "family": "claude",
+      "transport": "bedrock",
+      "maxInputTokens": 1000000,
+      "rejectsTemperature": true
+    },
+    "claude.sonnet.latest": {
+      "id": "us.anthropic.claude-sonnet-5",
+      "provider": "anthropic",
+      "family": "claude",
+      "transport": "bedrock",
+      "maxInputTokens": 1000000,
+      "rejectsTemperature": true
+    },
+    "claude.haiku.latest": {
+      "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "provider": "anthropic",
+      "family": "claude",
+      "transport": "bedrock",
+      "maxInputTokens": 200000,
+      "rejectsTemperature": false
+    },
+    "gpt.sol.latest": {
+      "id": "openai.gpt-5.6-sol",
+      "provider": "openai",
+      "family": "gpt",
+      "transport": "mantle_responses",
+      "region": "us-east-1",
+      "maxInputTokens": 1050000,
+      "rejectsTemperature": true
+    },
+    "gpt.terra.latest": {
+      "id": "openai.gpt-5.6-terra",
+      "provider": "openai",
+      "family": "gpt",
+      "transport": "mantle_responses",
+      "region": "us-east-1",
+      "maxInputTokens": 1050000,
+      "rejectsTemperature": true
+    },
+    "gpt.luna.latest": {
+      "id": "openai.gpt-5.6-luna",
+      "provider": "openai",
+      "family": "gpt",
+      "transport": "mantle_responses",
+      "region": "us-east-1",
+      "maxInputTokens": 1050000,
+      "rejectsTemperature": true
+    },
+    "gpt.oss.120b": {
+      "id": "openai.gpt-oss-120b-1:0",
+      "provider": "openai",
+      "family": "gpt-oss",
+      "transport": "bedrock",
+      "maxInputTokens": 131072,
+      "rejectsTemperature": false
+    },
+    "grok.latest": {
+      "id": "xai.grok-4.3",
+      "provider": "xai",
+      "family": "grok",
+      "transport": "mantle_responses",
+      "region": "us-west-2",
+      "maxInputTokens": 1048576,
+      "rejectsTemperature": false
+    },
+    "gemma.31b.latest": {
+      "id": "google.gemma-4-31b",
+      "provider": "google",
+      "family": "gemma",
+      "transport": "mantle_responses",
+      "region": "us-east-2",
+      "maxInputTokens": 262144,
+      "rejectsTemperature": false
+    },
+    "gemma.26b.latest": {
+      "id": "google.gemma-4-26b-a4b",
+      "provider": "google",
+      "family": "gemma",
+      "transport": "mantle_responses",
+      "region": "us-east-2",
+      "maxInputTokens": 262144,
+      "rejectsTemperature": false
+    },
+    "gemma.e2b.latest": {
+      "id": "google.gemma-4-e2b",
+      "provider": "google",
+      "family": "gemma",
+      "transport": "mantle_responses",
+      "region": "us-east-2",
+      "maxInputTokens": 131072,
+      "rejectsTemperature": false
+    },
+    "deepseek.v3.latest": {
+      "id": "deepseek.v3.2",
+      "provider": "deepseek",
+      "family": "deepseek",
+      "transport": "bedrock",
+      "maxInputTokens": 163840,
+      "rejectsTemperature": false
+    },
+    "glm.5.latest": {
+      "id": "zai.glm-5",
+      "provider": "zai",
+      "family": "glm",
+      "transport": "bedrock",
+      "maxInputTokens": 202752,
+      "rejectsTemperature": false
+    },
+    "glm.4.7": {
+      "id": "zai.glm-4.7",
+      "provider": "zai",
+      "family": "glm",
+      "transport": "bedrock",
+      "maxInputTokens": 202752,
+      "rejectsTemperature": false
+    },
+    "kimi.k2.5": {
+      "id": "moonshotai.kimi-k2.5",
+      "provider": "moonshotai",
+      "family": "kimi",
+      "transport": "bedrock",
+      "maxInputTokens": 262144,
+      "rejectsTemperature": false
+    },
+    "minimax.m2.5": {
+      "id": "minimax.minimax-m2.5",
+      "provider": "minimax",
+      "family": "minimax",
+      "transport": "bedrock",
+      "maxInputTokens": 196608,
+      "rejectsTemperature": false
+    },
+    "qwen.235b": {
+      "id": "qwen.qwen3-235b-a22b-2507-v1:0",
+      "provider": "qwen",
+      "family": "qwen",
+      "transport": "bedrock",
+      "region": "us-west-2",
+      "maxInputTokens": 262144,
+      "rejectsTemperature": false
+    },
+    "mistral.large.latest": {
+      "id": "mistral.mistral-large-3-675b-instruct",
+      "provider": "mistral",
+      "family": "mistral-large",
+      "transport": "bedrock",
+      "maxInputTokens": 262144,
+      "rejectsTemperature": false
+    }
+  },
+  "selectionPolicies": {
+    "general_subagent": {
+      "claude": {
+        "low": "claude.haiku.latest",
+        "medium": "claude.sonnet.latest",
+        "high": "claude.opus.latest"
+      },
+      "gpt": {
+        "low": "gpt.luna.latest",
+        "medium": "gpt.terra.latest",
+        "high": "gpt.sol.latest"
+      }
+    },
+    "code_agent": {
+      "claude": {
+        "low": "claude.haiku.latest",
+        "medium": "claude.sonnet.latest",
+        "high": "claude.opus.latest"
+      }
+    }
+  }
+}

--- a/chatbot-app/agentcore/skills/code-agent/SKILL.md
+++ b/chatbot-app/agentcore/skills/code-agent/SKILL.md
@@ -81,18 +81,20 @@ The goal is to deliver the best possible result with minimal friction. The key i
 
 ### Simple tasks — delegate directly in one call:
 
-    code_agent(task="Fix the typo in src/config.ts line 42: 'recieve' → 'receive'")
+    code_agent(task="Fix the typo in src/config.ts line 42: 'recieve' → 'receive'",
+      task_complexity="low")
 
 ### Medium tasks — delegate with clear scope, let the agent plan internally:
 
     code_agent(task="Add input validation to the /api/users endpoint.
-      Validate email format and required fields. Add tests.")
+      Validate email format and required fields. Add tests.",
+      task_complexity="medium")
 
 ### Complex tasks — break into phases, steer between turns:
 
     # Turn 1: Explore & plan
     code_agent(task="Explore how auth works and propose a plan for adding JWT.
-      Do NOT modify files yet.")
+      Do NOT modify files yet.", task_complexity="high")
 
     # Review the plan the agent returns — does the approach make sense?
 

--- a/chatbot-app/agentcore/skills/delegate-work/SKILL.md
+++ b/chatbot-app/agentcore/skills/delegate-work/SKILL.md
@@ -26,6 +26,14 @@ Do not delegate requests such as "investigate everything", "fix all issues", or
 - Use `reviewer` for an independent read-only review. It cannot execute code or
   modify source files.
 
+## Select task complexity
+
+- Use `low` for narrow extraction, classification, or simple checks.
+- Use `medium` for normal analysis and review work.
+- Use `high` only for genuinely difficult reasoning or broad synthesis.
+- Omit `task_complexity` when the delegated agent should inherit the parent
+  model unchanged.
+
 ## Execute
 
 Call `delegate_task` once. It returns an acceptance receipt immediately.

--- a/chatbot-app/agentcore/src/a2a_tools.py
+++ b/chatbot-app/agentcore/src/a2a_tools.py
@@ -10,7 +10,7 @@ Based on: amazon-bedrock-agentcore-samples orchestrator pattern
 import logging
 import os
 import asyncio
-from typing import Optional, Dict, Any, AsyncGenerator
+from typing import Optional, Dict, Any, AsyncGenerator, Literal
 from uuid import uuid4
 from strands.tools import tool
 from strands.types.tools import ToolContext
@@ -19,6 +19,7 @@ import httpx
 from a2a.client import ClientConfig, ClientFactory
 from a2a.types import Message, Part, Role, TextPart, AgentCard
 
+from agent.config.model_catalog import resolve_code_agent_model
 from agent.mcp.client import BearerAuth
 from a2a_response import A2ATextAccumulator
 
@@ -418,7 +419,13 @@ def create_a2a_tool(agent_id: str):
     # Create different tool implementations based on agent type
     if "code" in agent_id:
         # Code Agent - task parameter, streams code_step events
-        async def tool_impl(task: str, reset_session: bool = False, compact_session: bool = False, tool_context: ToolContext = None) -> AsyncGenerator[Dict[str, Any], None]:
+        async def tool_impl(
+            task: str,
+            task_complexity: Literal["low", "medium", "high"] = "medium",
+            reset_session: bool = False,
+            compact_session: bool = False,
+            tool_context: ToolContext = None,
+        ) -> AsyncGenerator[Dict[str, Any], None]:
             """
             task: The coding task to delegate.
             reset_session: Set True to clear conversation history and start fresh
@@ -427,16 +434,20 @@ def create_a2a_tool(agent_id: str):
             compact_session: Set True to summarise conversation history before
                              running the task (equivalent to /compact in Claude Code).
                              Useful when prior context is long but still relevant.
+            task_complexity: Claude model tier: low, medium, or high.
             """
             session_id, user_id, model_id, _auth_token = extract_context(tool_context)
+            model_selection = resolve_code_agent_model(task_complexity)
 
             metadata = {
                 "session_id": session_id,
                 "user_id": user_id,
                 "source": "main_agent",
                 # Claude Agent SDK has its own provider-specific model setting.
-                # Keep the orchestrator model only for diagnostics.
+                "model_id": model_selection.effective_model_id,
                 "orchestrator_model_id": model_id,
+                "task_complexity": model_selection.task_complexity,
+                "model_selection": model_selection.as_record(),
                 "reset_session": reset_session,
                 "compact_session": compact_session,
             }
@@ -473,7 +484,14 @@ def create_a2a_tool(agent_id: str):
                 tool_context.invocation_state.pop("_a2a_partial_progress", None)
 
         tool_impl.__name__ = correct_name
-        tool_impl.__doc__ = agent_description
+        tool_impl.__doc__ = f"""{agent_description}
+
+        Args:
+            task: The coding task to delegate.
+            task_complexity: Claude model tier: low, medium, or high.
+            reset_session: Clear conversation history while preserving files.
+            compact_session: Compact prior conversation before the task.
+        """
         agent_tool = tool(context=True)(tool_impl)
         agent_tool._skill_name = skill_name
 

--- a/chatbot-app/agentcore/src/agent/config/model_catalog.py
+++ b/chatbot-app/agentcore/src/agent/config/model_catalog.py
@@ -1,0 +1,259 @@
+"""Declarative model catalog and tier-based model selection."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Optional
+
+TASK_COMPLEXITIES = frozenset({"low", "medium", "high"})
+DEFAULT_MAX_INPUT_TOKENS = 131_072
+_ALLOWED_TRANSPORTS = frozenset({"bedrock", "mantle_responses"})
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    key: str
+    model_id: str
+    provider: str
+    family: str
+    transport: str
+    region: Optional[str]
+    max_input_tokens: int
+    rejects_temperature: bool
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    policy: str
+    task_complexity: Optional[str]
+    provider: Optional[str]
+    family: Optional[str]
+    source_model_id: str
+    effective_model_id: str
+    catalog_revision: str
+    applied: bool
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "policy": self.policy,
+            "taskComplexity": self.task_complexity or "",
+            "provider": self.provider or "",
+            "family": self.family or "",
+            "sourceModelId": self.source_model_id,
+            "effectiveModelId": self.effective_model_id,
+            "catalogRevision": self.catalog_revision,
+            "applied": self.applied,
+        }
+
+
+class ModelCatalog:
+    def __init__(self, payload: dict[str, Any]):
+        self.schema_version = int(payload.get("schemaVersion") or 0)
+        if self.schema_version != 1:
+            raise ValueError(
+                f"Unsupported model catalog schemaVersion: {self.schema_version}"
+            )
+        self.revision = str(payload.get("revision") or "").strip()
+        if not self.revision:
+            raise ValueError("Model catalog revision is required")
+
+        raw_matchers = payload.get("providerMatchers") or {}
+        self.provider_matchers = {
+            str(provider): tuple(str(value).lower() for value in values)
+            for provider, values in raw_matchers.items()
+        }
+        raw_family_matchers = payload.get("familyMatchers") or {}
+        self.family_matchers = {
+            str(family): tuple(str(value).lower() for value in values)
+            for family, values in raw_family_matchers.items()
+        }
+
+        self.models: dict[str, ModelSpec] = {}
+        self.models_by_id: dict[str, ModelSpec] = {}
+        for key, raw in (payload.get("models") or {}).items():
+            if "maxInputTokens" not in raw:
+                raise ValueError(
+                    f"Model catalog entry {key} requires maxInputTokens"
+                )
+            spec = ModelSpec(
+                key=str(key),
+                model_id=str(raw.get("id") or ""),
+                provider=str(raw.get("provider") or ""),
+                family=str(raw.get("family") or ""),
+                transport=str(raw.get("transport") or ""),
+                region=str(raw["region"]) if raw.get("region") else None,
+                max_input_tokens=int(raw["maxInputTokens"]),
+                rejects_temperature=bool(raw.get("rejectsTemperature", False)),
+            )
+            self._validate_spec(spec)
+            if spec.model_id in self.models_by_id:
+                raise ValueError(f"Duplicate model ID in catalog: {spec.model_id}")
+            self.models[spec.key] = spec
+            self.models_by_id[spec.model_id] = spec
+
+        self.selection_policies = payload.get("selectionPolicies") or {}
+        self._validate_policies()
+
+    @staticmethod
+    def _validate_spec(spec: ModelSpec) -> None:
+        if not spec.key or not spec.model_id or not spec.provider or not spec.family:
+            raise ValueError(f"Incomplete model catalog entry: {spec.key}")
+        if spec.transport not in _ALLOWED_TRANSPORTS:
+            raise ValueError(
+                f"Unsupported transport for {spec.key}: {spec.transport}"
+            )
+        if spec.transport == "mantle_responses" and not spec.region:
+            raise ValueError(f"Mantle model {spec.key} requires a region")
+        if spec.max_input_tokens <= 0:
+            raise ValueError(f"Invalid maxInputTokens for {spec.key}")
+
+    def _validate_policies(self) -> None:
+        for policy_name, families in self.selection_policies.items():
+            for family, tiers in families.items():
+                missing = TASK_COMPLEXITIES - set(tiers)
+                if missing:
+                    raise ValueError(
+                        f"Policy {policy_name}/{family} is missing tiers: "
+                        f"{sorted(missing)}"
+                    )
+                for complexity, model_key in tiers.items():
+                    if complexity not in TASK_COMPLEXITIES:
+                        raise ValueError(
+                            f"Policy {policy_name}/{family} has invalid tier: "
+                            f"{complexity}"
+                        )
+                    spec = self.models.get(str(model_key))
+                    if spec is None:
+                        raise ValueError(
+                            f"Policy {policy_name}/{family}/{complexity} "
+                            f"references unknown model: {model_key}"
+                        )
+                    if spec.family != family:
+                        raise ValueError(
+                            f"Policy {policy_name}/{family}/{complexity} "
+                            f"references family {spec.family}"
+                        )
+
+    def provider_for(self, model_id: str) -> Optional[str]:
+        spec = self.models_by_id.get(model_id)
+        if spec is not None:
+            return spec.provider
+
+        normalized = model_id.lower()
+        for provider, matchers in self.provider_matchers.items():
+            if any(matcher in normalized for matcher in matchers):
+                return provider
+        return None
+
+    def family_for(self, model_id: str) -> Optional[str]:
+        spec = self.models_by_id.get(model_id)
+        if spec is not None:
+            return spec.family
+
+        normalized = model_id.lower()
+        for family, matchers in self.family_matchers.items():
+            if any(matcher in normalized for matcher in matchers):
+                return family
+        return None
+
+    def resolve(
+        self,
+        policy: str,
+        family: str,
+        task_complexity: str,
+    ) -> Optional[ModelSpec]:
+        complexity = normalize_task_complexity(task_complexity)
+        model_key = (
+            self.selection_policies.get(policy, {})
+            .get(family, {})
+            .get(complexity)
+        )
+        return self.models.get(str(model_key)) if model_key else None
+
+
+def normalize_task_complexity(
+    value: Optional[str],
+    *,
+    default: Optional[str] = None,
+) -> Optional[str]:
+    normalized = str(value or default or "").strip().lower()
+    if not normalized:
+        return None
+    if normalized not in TASK_COMPLEXITIES:
+        raise ValueError("task_complexity must be low, medium, or high")
+    return normalized
+
+
+def _default_catalog_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "config" / "model-catalog.json"
+
+
+@lru_cache(maxsize=4)
+def _load_catalog(path: str) -> ModelCatalog:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return ModelCatalog(json.load(handle))
+
+
+def get_model_catalog() -> ModelCatalog:
+    path = Path(
+        os.environ.get("MODEL_CATALOG_PATH") or _default_catalog_path()
+    ).resolve()
+    return _load_catalog(str(path))
+
+
+def resolve_general_subagent_model(
+    parent_model_id: str,
+    task_complexity: Optional[str],
+) -> ModelSelection:
+    catalog = get_model_catalog()
+    complexity = normalize_task_complexity(task_complexity)
+    provider = catalog.provider_for(parent_model_id)
+    family = catalog.family_for(parent_model_id)
+    if complexity is None or family is None:
+        return ModelSelection(
+            policy="general_subagent",
+            task_complexity=complexity,
+            provider=provider,
+            family=family,
+            source_model_id=parent_model_id,
+            effective_model_id=parent_model_id,
+            catalog_revision=catalog.revision,
+            applied=False,
+        )
+
+    spec = catalog.resolve("general_subagent", family, complexity)
+    effective_model_id = spec.model_id if spec is not None else parent_model_id
+    return ModelSelection(
+        policy="general_subagent",
+        task_complexity=complexity,
+        provider=provider,
+        family=family,
+        source_model_id=parent_model_id,
+        effective_model_id=effective_model_id,
+        catalog_revision=catalog.revision,
+        applied=spec is not None,
+    )
+
+
+def resolve_code_agent_model(task_complexity: Optional[str]) -> ModelSelection:
+    catalog = get_model_catalog()
+    complexity = normalize_task_complexity(task_complexity, default="medium")
+    spec = catalog.resolve("code_agent", "claude", complexity)
+    if spec is None:
+        raise ValueError(
+            f"Model catalog has no code_agent/claude/{complexity} selection"
+        )
+    return ModelSelection(
+        policy="code_agent",
+        task_complexity=complexity,
+        provider="anthropic",
+        family="claude",
+        source_model_id="",
+        effective_model_id=spec.model_id,
+        catalog_revision=catalog.revision,
+        applied=True,
+    )

--- a/chatbot-app/agentcore/src/agent/config/model_context_windows.py
+++ b/chatbot-app/agentcore/src/agent/config/model_context_windows.py
@@ -9,13 +9,18 @@ optional native dependencies; the session manager must not depend on those.
 import logging
 from typing import Optional
 
+from agent.config.model_catalog import (
+    DEFAULT_MAX_INPUT_TOKENS,
+    get_model_catalog,
+)
+
 logger = logging.getLogger(__name__)
 
 
 # Maximum input tokens per model, used to size context compaction relative to the
 # model actually in use rather than a single hard-coded number.
 #
-# Every value below was measured against the deployed endpoints by sending an
+# Catalog values were measured against the deployed endpoints by sending an
 # oversized prompt and reading the limit back out of the rejection, e.g.
 #   prompt tokens (1600007) exceed model maximum (1050000) for openai.gpt-5.6-luna
 #   prompt is too long: 1600056 tokens > 1000000 maximum   (claude-opus-5)
@@ -25,39 +30,13 @@ logger = logging.getLogger(__name__)
 # Note the spread — 131k to 1.05M, an 8x range. Sizing compaction off one
 # constant either wastes most of a 1M window or overflows a 131k one.
 #
-# Re-measure when adding a model to the picker; do not guess. A value that is too
-# high is worse than one that is too low: compaction fires too late and the model
-# call fails outright, instead of merely trimming sooner than necessary.
+# Re-measure when adding a model to the catalog; do not guess. A value that is
+# too high is worse than one that is too low: compaction fires too late and the
+# model call fails outright, instead of merely trimming sooner than necessary.
 MODEL_MAX_INPUT_TOKENS: dict[str, int] = {
-    # Anthropic — 1M is the default and the maximum; there is no separate
-    # long-context model ID and no beta header is required.
-    "us.anthropic.claude-opus-5": 1_000_000,
-    "us.anthropic.claude-sonnet-5": 1_000_000,
-    "us.anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,
-    # OpenAI GPT-5.6 via Mantle — 1.05M on the base model IDs (Bedrock, Aug 2026).
-    "openai.gpt-5.6-sol": 1_050_000,
-    "openai.gpt-5.6-terra": 1_050_000,
-    "openai.gpt-5.6-luna": 1_050_000,
-    # gpt-oss is the smallest window in the picker.
-    "openai.gpt-oss-120b-1:0": 131_072,
-    "xai.grok-4.3": 1_048_576,
-    "google.gemma-4-31b": 262_144,
-    "google.gemma-4-26b-a4b": 262_144,
-    # Registered as a Mantle model but not currently offered in the picker.
-    "google.gemma-4-e2b": 131_072,
-    "deepseek.v3.2": 163_840,
-    "zai.glm-5": 202_752,
-    "zai.glm-4.7": 202_752,
-    "moonshotai.kimi-k2.5": 262_144,
-    "minimax.minimax-m2.5": 196_608,
-    "qwen.qwen3-235b-a22b-2507-v1:0": 262_144,
-    "mistral.mistral-large-3-675b-instruct": 262_144,
+    spec.model_id: spec.max_input_tokens
+    for spec in get_model_catalog().models.values()
 }
-
-# Applied to models missing from the table above. Deliberately pessimistic: an
-# unknown model is more likely to be small than to be a 1M frontier model, and
-# under-estimating only compacts earlier than needed.
-DEFAULT_MAX_INPUT_TOKENS = 131_072
 
 
 def get_max_input_tokens(model_id: Optional[str]) -> int:
@@ -73,5 +52,3 @@ def get_max_input_tokens(model_id: Optional[str]) -> int:
         )
         return DEFAULT_MAX_INPUT_TOKENS
     return limit
-
-

--- a/chatbot-app/agentcore/src/agent/delegation_jobs.py
+++ b/chatbot-app/agentcore/src/agent/delegation_jobs.py
@@ -27,6 +27,7 @@ import boto3
 from boto3.dynamodb.conditions import Key
 
 from agent import async_tasks
+from agent.config.model_catalog import resolve_general_subagent_model
 from agent.factory.session_manager_factory import get_sessions_dir
 
 logger = logging.getLogger(__name__)
@@ -606,6 +607,7 @@ def _event_factory(record: dict[str, Any]) -> EventFactory:
         "session_id": record["sessionId"],
         "user_id": record["userId"],
         "model_id": record.get("modelId", ""),
+        "task_complexity": request.get("taskComplexity", ""),
         "workspace_paths": request.get("workspacePaths", []),
         "output_path": f"outputs/delegations/{record['jobId']}",
         "max_seconds": int(
@@ -820,6 +822,10 @@ def start_job(
     if profile not in _ALLOWED_PROFILES:
         raise ValueError(f"Unsupported delegation profile: {profile}")
 
+    model_selection = resolve_general_subagent_model(
+        model_id,
+        request.get("taskComplexity"),
+    )
     job_id = job_id_for(idempotency_key)
     existing = get_job(user_id, session_id, job_id)
     expected_hash = request_hash(request)
@@ -865,7 +871,9 @@ def start_job(
         "idempotencyKey": idempotency_key,
         "parentRunId": parent_run_id,
         "parentToolUseId": parent_tool_use_id,
-        "modelId": model_id,
+        "parentModelId": model_id,
+        "modelId": model_selection.effective_model_id,
+        "modelSelection": model_selection.as_record(),
         "conversationEpoch": conversation_epoch,
         "executionStatus": "queued",
         "workStatus": "queued",

--- a/chatbot-app/agentcore/src/agents/model_factory.py
+++ b/chatbot-app/agentcore/src/agents/model_factory.py
@@ -21,6 +21,7 @@ from typing import Optional
 import boto3
 from strands.models import BedrockModel, CacheConfig
 
+from agent.config.model_catalog import get_model_catalog
 # Re-exported for callers that already reach for model_factory. The registry
 # itself lives in its own module so the session manager can size compaction
 # without importing the agent stack.
@@ -31,19 +32,17 @@ from agent.config.model_context_windows import (  # noqa: F401
 )
 
 logger = logging.getLogger(__name__)
+_MODEL_CATALOG = get_model_catalog()
 
 
 # Reasoning models that reject the `temperature` inference param. Listed by
 # exact ID rather than substring: a substring like "opus-5" also matches
-# "opus-4-5", which does accept temperature. Add an entry when a model is added
-# to the picker.
-NO_TEMPERATURE_MODELS = frozenset({
-    "us.anthropic.claude-opus-5",
-    "us.anthropic.claude-sonnet-5",
-    "openai.gpt-5.6-sol",
-    "openai.gpt-5.6-terra",
-    "openai.gpt-5.6-luna",
-})
+# "opus-4-5", which does accept temperature. Values come from the model catalog.
+NO_TEMPERATURE_MODELS = frozenset(
+    spec.model_id
+    for spec in _MODEL_CATALOG.models.values()
+    if spec.rejects_temperature
+)
 
 
 @dataclass(frozen=True)
@@ -59,28 +58,24 @@ class MantleSpec:
 
 
 # Mantle-only models (not callable via native Bedrock Converse). Anything not
-# listed here falls back to BedrockModel. The region is pinned per model: a
+# registered there falls back to BedrockModel. The region is pinned per model: a
 # Mantle model is only served in some regions (grok-4.3 in us-west-2, gpt-5.6
 # in us-east-1), so the base_url region is forced independent of where the
 # app is deployed.
 MANTLE_MODELS: dict[str, MantleSpec] = {
-    "openai.gpt-5.6-sol": MantleSpec(api="responses", region="us-east-1"),
-    "openai.gpt-5.6-terra": MantleSpec(api="responses", region="us-east-1"),
-    "openai.gpt-5.6-luna": MantleSpec(api="responses", region="us-east-1"),
-    "xai.grok-4.3": MantleSpec(api="responses", region="us-west-2"),
-    "google.gemma-4-31b": MantleSpec(api="responses", region="us-east-2"),
-    "google.gemma-4-26b-a4b": MantleSpec(api="responses", region="us-east-2"),
-    "google.gemma-4-e2b": MantleSpec(api="responses", region="us-east-2"),
+    spec.model_id: MantleSpec(api="responses", region=str(spec.region))
+    for spec in _MODEL_CATALOG.models.values()
+    if spec.transport == "mantle_responses"
 }
 
 
 # Native Bedrock models that are NOT available in every region. Selecting one of
-# these forces the BedrockModel client to the listed region, overriding the
-# app's deployment region (AWS_REGION). Models available everywhere are omitted
-# and use the default region. Keep in sync with regional Converse availability.
+# catalog entry with a native region forces BedrockModel to that region,
+# overriding the app's deployment region. Models available everywhere omit it.
 NATIVE_MODEL_REGION_OVERRIDES: dict[str, str] = {
-    # qwen3-235b is absent in us-east-1; pin to us-west-2 which serves it.
-    "qwen.qwen3-235b-a22b-2507-v1:0": "us-west-2",
+    spec.model_id: str(spec.region)
+    for spec in _MODEL_CATALOG.models.values()
+    if spec.transport == "bedrock" and spec.region
 }
 
 

--- a/chatbot-app/agentcore/src/local_tools/delegation.py
+++ b/chatbot-app/agentcore/src/local_tools/delegation.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
-from typing import Optional
+from typing import Literal, Optional
 
 from strands import ToolContext, tool
 
+from agent.config.model_catalog import normalize_task_complexity
 from agent.delegation_jobs import (
     cancel_job,
     list_jobs,
@@ -115,6 +116,7 @@ def delegate_task(
     constraints: Optional[list[str]] = None,
     context_summary: str = "",
     max_seconds: int = 600,
+    task_complexity: Optional[Literal["low", "medium", "high"]] = None,
     tool_context: ToolContext = None,
 ) -> str:
     """Delegate one independent, scoped task to an asynchronous specialist.
@@ -131,6 +133,9 @@ def delegate_task(
         constraints: Explicit non-goals or restrictions.
         context_summary: Minimal task-local context, never the full conversation.
         max_seconds: Execution deadline from 30 to 1800 seconds.
+        task_complexity: Optional model tier: low, medium, or high. Anthropic
+            and OpenAI parent models use the matching catalog tier; other
+            providers keep the parent model.
     """
     if profile not in {"analyst", "reviewer"}:
         raise ValueError("profile must be analyst or reviewer")
@@ -140,8 +145,9 @@ def delegate_task(
     session_id, user_id, run_id, tool_use_id, model_id, _auth_token = _context(
         tool_context
     )
+    complexity = normalize_task_complexity(task_complexity)
     request = {
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "goal": _bounded_text(goal, _MAX_GOAL_CHARS, "goal"),
         "deliverable": _bounded_text(
             deliverable,
@@ -159,6 +165,7 @@ def delegate_task(
             if context_summary.strip()
             else ""
         ),
+        "taskComplexity": complexity or "",
         "budget": {
             "maxSeconds": int(max_seconds),
             "maxToolCalls": 20 if profile == "analyst" else 12,

--- a/chatbot-app/agentcore/src/subagent_main.py
+++ b/chatbot-app/agentcore/src/subagent_main.py
@@ -20,6 +20,7 @@ from strands.multiagent.a2a import A2AServer
 from strands.multiagent.a2a.executor import StrandsA2AExecutor
 
 from agent import async_tasks
+from agent.config.model_catalog import get_model_catalog
 from agents.model_factory import build_model
 from builtin_tools.code_interpreter_tool import execute_code, file_operations
 from local_tools.workspace import workspace_list, workspace_read, workspace_write
@@ -31,9 +32,16 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 PORT = int(os.environ.get("PORT", "9000"))
+_DEFAULT_SUBAGENT_SPEC = get_model_catalog().resolve(
+    "general_subagent",
+    "claude",
+    "medium",
+)
+if _DEFAULT_SUBAGENT_SPEC is None:
+    raise RuntimeError("Model catalog is missing general_subagent/claude/medium")
 DEFAULT_MODEL_ID = os.environ.get(
     "MODEL_ID",
-    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    _DEFAULT_SUBAGENT_SPEC.model_id,
 )
 
 

--- a/chatbot-app/agentcore/tests/unit/test_a2a_code_agent_model.py
+++ b/chatbot-app/agentcore/tests/unit/test_a2a_code_agent_model.py
@@ -1,0 +1,112 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def code_tool(monkeypatch):
+    import a2a_tools
+
+    skill = MagicMock()
+    skill.description = "Code agent"
+    registry_client = MagicMock()
+    registry_client.get_a2a_skill.return_value = skill
+    registry_module = MagicMock()
+    registry_module.get_registry_client.return_value = registry_client
+    monkeypatch.setitem(sys.modules, "registry.client", registry_module)
+    monkeypatch.setattr(
+        a2a_tools,
+        "get_cached_agent_url",
+        lambda agent_id: "http://code.test/",
+    )
+
+    sent = []
+
+    async def fake_send(
+        agent_id,
+        message,
+        session_id=None,
+        region=None,
+        metadata=None,
+        auth_token=None,
+    ):
+        sent.append({
+            "agent_id": agent_id,
+            "message": message,
+            "session_id": session_id,
+            "metadata": metadata or {},
+        })
+        yield {"status": "success", "content": [{"text": "done"}]}
+
+    monkeypatch.setattr(a2a_tools, "send_a2a_message", fake_send)
+    tool = a2a_tools.create_a2a_tool("agentcore_code-agent")
+    assert tool is not None
+    return tool, sent
+
+
+def _context():
+    context = MagicMock()
+    context.tool_use = {"toolUseId": "tool-1"}
+    context.invocation_state = {
+        "session_id": "session-1",
+        "user_id": "user-1",
+        "model_id": "openai.gpt-5.6-terra",
+        "auth_token": None,
+    }
+    context.agent = None
+    return context
+
+
+async def _drain(agen):
+    return [event async for event in agen]
+
+
+@pytest.mark.asyncio
+async def test_code_agent_high_uses_latest_opus(code_tool):
+    tool, sent = code_tool
+    tool_impl = tool._tool_func
+    await _drain(
+        tool_impl(
+            task="Implement the feature",
+            task_complexity="high",
+            tool_context=_context(),
+        )
+    )
+
+    metadata = sent[0]["metadata"]
+    assert metadata["model_id"] == "us.anthropic.claude-opus-5"
+    assert metadata["task_complexity"] == "high"
+    assert metadata["orchestrator_model_id"] == "openai.gpt-5.6-terra"
+
+
+@pytest.mark.asyncio
+async def test_code_agent_defaults_to_sonnet(code_tool):
+    tool, sent = code_tool
+    tool_impl = tool._tool_func
+    await _drain(tool_impl(task="Fix a bug", tool_context=_context()))
+    assert sent[0]["metadata"]["model_id"] == "us.anthropic.claude-sonnet-5"
+
+
+@pytest.mark.asyncio
+async def test_code_agent_rejects_invalid_complexity(code_tool):
+    tool, _sent = code_tool
+    tool_impl = tool._tool_func
+    with pytest.raises(ValueError, match="task_complexity"):
+        await _drain(
+            tool_impl(
+                task="Fix a bug",
+                task_complexity="extreme",
+                tool_context=_context(),
+            )
+        )
+
+
+def test_code_agent_schema_exposes_complexity_enum(code_tool):
+    tool, _sent = code_tool
+    schema = tool._metadata.input_model.model_json_schema()
+    assert schema["properties"]["task_complexity"]["enum"] == [
+        "low",
+        "medium",
+        "high",
+    ]

--- a/chatbot-app/agentcore/tests/unit/test_delegation_jobs.py
+++ b/chatbot-app/agentcore/tests/unit/test_delegation_jobs.py
@@ -205,6 +205,33 @@ def test_unknown_profile_is_rejected():
         )
 
 
+def test_start_job_resolves_and_persists_model_selection(monkeypatch):
+    async def run_stub(_record, _factory):
+        return None
+
+    monkeypatch.setattr(delegation_jobs, "_run", run_stub)
+    request = {
+        **_request(),
+        "schemaVersion": 2,
+        "taskComplexity": "high",
+    }
+    receipt = delegation_jobs.start_job(
+        user_id="u1",
+        session_id="s1",
+        idempotency_key="s1:r1:t1",
+        profile="analyst",
+        request=request,
+        model_id="openai.gpt-5.6-terra",
+    )
+
+    record = delegation_jobs.get_job("u1", "s1", receipt.job_id)
+    assert record["parentModelId"] == "openai.gpt-5.6-terra"
+    assert record["modelId"] == "openai.gpt-5.6-sol"
+    assert record["modelSelection"]["taskComplexity"] == "high"
+    assert record["modelSelection"]["catalogRevision"] == "2026-08-11.1"
+    assert record["modelSelection"]["applied"] is True
+
+
 def test_local_storage_rejects_path_traversal():
     with pytest.raises(ValueError, match="Invalid local delegation session ID"):
         delegation_jobs.get_job("u1", "../outside", "job1")

--- a/chatbot-app/agentcore/tests/unit/test_delegation_tools.py
+++ b/chatbot-app/agentcore/tests/unit/test_delegation_tools.py
@@ -44,6 +44,7 @@ def test_delegate_task_builds_deterministic_scoped_request(monkeypatch):
         acceptance_criteria=["List invalid lines"],
         workspace_paths=["uploads/events.jsonl"],
         constraints=["Do not modify source"],
+        task_complexity="high",
         tool_context=_context(),
     )
 
@@ -55,6 +56,8 @@ def test_delegate_task_builds_deterministic_scoped_request(monkeypatch):
     assert captured["idempotency_key"] == "session-1:run-1:tool-1"
     assert captured["request"]["workspacePaths"] == ["uploads/events.jsonl"]
     assert captured["request"]["constraints"] == ["Do not modify source"]
+    assert captured["request"]["schemaVersion"] == 2
+    assert captured["request"]["taskComplexity"] == "high"
 
 
 def test_delegate_task_rejects_broad_profile():
@@ -74,6 +77,17 @@ def test_delegate_task_limits_budget():
             goal="Review",
             deliverable="Report",
             max_seconds=10,
+            tool_context=_context(),
+        )
+
+
+def test_delegate_task_rejects_invalid_complexity():
+    with pytest.raises(ValueError, match="task_complexity"):
+        delegation.delegate_task(
+            profile="reviewer",
+            goal="Review",
+            deliverable="Report",
+            task_complexity="extreme",
             tool_context=_context(),
         )
 

--- a/chatbot-app/agentcore/tests/unit/test_model_catalog.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_catalog.py
@@ -1,0 +1,118 @@
+import pytest
+
+from agent.config.model_catalog import (
+    get_model_catalog,
+    normalize_task_complexity,
+    resolve_code_agent_model,
+    resolve_general_subagent_model,
+)
+
+
+class TestGeneralSubagentSelection:
+    @pytest.mark.parametrize(
+        ("parent_model_id", "complexity", "expected_model_id"),
+        [
+            (
+                "us.anthropic.claude-sonnet-5",
+                "low",
+                "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            ),
+            (
+                "us.anthropic.claude-sonnet-5",
+                "medium",
+                "us.anthropic.claude-sonnet-5",
+            ),
+            (
+                "us.anthropic.claude-sonnet-5",
+                "high",
+                "us.anthropic.claude-opus-5",
+            ),
+            (
+                "openai.gpt-5.6-terra",
+                "low",
+                "openai.gpt-5.6-luna",
+            ),
+            (
+                "openai.gpt-5.6-terra",
+                "medium",
+                "openai.gpt-5.6-terra",
+            ),
+            (
+                "openai.gpt-5.6-terra",
+                "high",
+                "openai.gpt-5.6-sol",
+            ),
+        ],
+    )
+    def test_maps_supported_providers_by_complexity(
+        self,
+        parent_model_id,
+        complexity,
+        expected_model_id,
+    ):
+        selection = resolve_general_subagent_model(
+            parent_model_id,
+            complexity,
+        )
+        assert selection.effective_model_id == expected_model_id
+        assert selection.applied is True
+
+    def test_unknown_provider_keeps_parent_model(self):
+        selection = resolve_general_subagent_model("xai.grok-4.3", "high")
+        assert selection.effective_model_id == "xai.grok-4.3"
+        assert selection.applied is False
+
+    def test_other_openai_family_keeps_parent_model(self):
+        selection = resolve_general_subagent_model(
+            "openai.gpt-oss-120b-1:0",
+            "high",
+        )
+        assert selection.effective_model_id == "openai.gpt-oss-120b-1:0"
+        assert selection.applied is False
+
+    def test_omitted_complexity_keeps_parent_model(self):
+        selection = resolve_general_subagent_model(
+            "us.anthropic.claude-sonnet-5",
+            None,
+        )
+        assert selection.effective_model_id == "us.anthropic.claude-sonnet-5"
+        assert selection.applied is False
+
+    def test_provider_matcher_supports_other_bedrock_claude_ids(self):
+        selection = resolve_general_subagent_model(
+            "eu.anthropic.claude-custom-v1:0",
+            "high",
+        )
+        assert selection.effective_model_id == "us.anthropic.claude-opus-5"
+
+
+class TestCodeAgentSelection:
+    @pytest.mark.parametrize(
+        ("complexity", "expected_model_id"),
+        [
+            ("low", "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+            ("medium", "us.anthropic.claude-sonnet-5"),
+            ("high", "us.anthropic.claude-opus-5"),
+        ],
+    )
+    def test_always_selects_claude_tier(self, complexity, expected_model_id):
+        selection = resolve_code_agent_model(complexity)
+        assert selection.provider == "anthropic"
+        assert selection.family == "claude"
+        assert selection.effective_model_id == expected_model_id
+
+    def test_defaults_to_medium(self):
+        assert (
+            resolve_code_agent_model(None).effective_model_id
+            == "us.anthropic.claude-sonnet-5"
+        )
+
+
+def test_catalog_has_unique_model_ids():
+    catalog = get_model_catalog()
+    assert len(catalog.models) == len(catalog.models_by_id)
+
+
+def test_invalid_complexity_is_rejected():
+    with pytest.raises(ValueError, match="low, medium, or high"):
+        normalize_task_complexity("extreme")

--- a/docs/architecture/async-delegation.md
+++ b/docs/architecture/async-delegation.md
@@ -35,6 +35,21 @@ explicit constraints, a bounded context summary, and selected workspace paths.
 The server limits a session to two active delegations and three execution
 attempts per job.
 
+## Model Selection
+
+Delegation accepts an optional `task_complexity` value: `low`, `medium`, or
+`high`. The backend model catalog maps Claude tasks to Haiku, Sonnet, or Opus
+and GPT tasks to Luna, Terra, or Sol. Other model families keep the parent
+model, and omitting complexity preserves the existing inherit behavior.
+
+The effective model is resolved once when the durable job is created. The job
+stores the parent model, effective model, complexity, family, and catalog
+version so retries cannot change models if catalog configuration changes.
+
+The Code Agent uses the same catalog but always resolves within the Claude
+family. Its default complexity is `medium`; the runtime applies the selected
+model to the session's Claude SDK client before executing the task.
+
 ## Interrupt And Cancellation
 
 Foreground response interruption does not cancel accepted background work.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,8 +1,25 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
-  root_dir   = abspath("${path.module}/../../..")
+  account_id    = data.aws_caller_identity.current.account_id
+  root_dir      = abspath("${path.module}/../../..")
+  model_catalog = jsondecode(file("${local.root_dir}/chatbot-app/agentcore/config/model-catalog.json"))
+  code_agent_default_model_key = (
+    local.model_catalog.selectionPolicies.code_agent.claude.medium
+  )
+  code_agent_default_model_id = (
+    var.code_agent_model_id != ""
+    ? var.code_agent_model_id
+    : local.model_catalog.models[local.code_agent_default_model_key].id
+  )
+  general_subagent_default_model_key = (
+    local.model_catalog.selectionPolicies.general_subagent.claude.medium
+  )
+  general_subagent_default_model_id = (
+    var.general_subagent_default_model_id != ""
+    ? var.general_subagent_default_model_id
+    : local.model_catalog.models[local.general_subagent_default_model_key].id
+  )
 }
 
 module "auth" {
@@ -267,8 +284,8 @@ module "runtime_code_agent" {
 
   extra_env_vars = {
     CLAUDE_CODE_USE_BEDROCK = "1"
-    ANTHROPIC_MODEL         = var.code_agent_model_id
-    CODE_AGENT_MODEL_ID     = var.code_agent_model_id
+    ANTHROPIC_MODEL         = local.code_agent_default_model_id
+    CODE_AGENT_MODEL_ID     = local.code_agent_default_model_id
   }
 
   depends_on = [module.auth, aws_s3_bucket.artifacts, module.agentcore_shared]
@@ -353,7 +370,7 @@ module "runtime_general_subagent" {
   extra_env_vars = merge(
     {
       CODE_INTERPRETER_ID      = module.agentcore_shared.code_interpreter_id
-      MODEL_ID                 = var.general_subagent_default_model_id
+      MODEL_ID                 = local.general_subagent_default_model_id
       S3_FILES_FILE_SYSTEM_ID  = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_id : ""
       S3_FILES_FILE_SYSTEM_ARN = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_arn : ""
       S3_FILES_MOUNT_PATH      = "/mnt/workspace"

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -56,9 +56,17 @@ variable "code_interpreter_private_subnets" {
 }
 
 variable "code_agent_model_id" {
-  description = "Claude model used by the Claude Agent SDK based Code Agent."
+  description = "Optional Code Agent fallback model override. Empty uses the catalog's code_agent/claude/medium model."
   type        = string
-  default     = "us.anthropic.claude-sonnet-5"
+  default     = ""
+
+  validation {
+    condition = (
+      var.code_agent_model_id == ""
+      || can(regex("(^|\\.)anthropic\\.claude-", var.code_agent_model_id))
+    )
+    error_message = "code_agent_model_id must be empty or a Claude model ID."
+  }
 }
 
 variable "research_agent_default_model_id" {
@@ -68,9 +76,9 @@ variable "research_agent_default_model_id" {
 }
 
 variable "general_subagent_default_model_id" {
-  description = "Fallback model for isolated analyst and reviewer delegations."
+  description = "Optional isolated subagent fallback override. Empty uses the catalog's general_subagent/claude/medium model."
   type        = string
-  default     = "us.anthropic.claude-sonnet-5"
+  default     = ""
 }
 
 variable "google_oauth_client_id" {

--- a/infra/scripts/model-smoke.py
+++ b/infra/scripts/model-smoke.py
@@ -87,13 +87,32 @@ def _tool_names(events: list[dict]) -> set[str]:
     }
 
 
-def _interrupts(events: list[dict]) -> list[dict]:
-    result = []
+def _tool_receipt(events: list[dict], tool_name: str) -> dict:
+    tool_call_ids = {
+        event.get("toolCallId")
+        for event in events
+        if event.get("type") == "TOOL_CALL_START"
+        and event.get("toolCallName") == tool_name
+    }
     for event in events:
-        if event.get("type") != "CUSTOM" or event.get("name") != "interrupt":
+        if (
+            event.get("type") != "TOOL_CALL_RESULT"
+            or event.get("toolCallId") not in tool_call_ids
+        ):
             continue
-        result.extend((event.get("value") or {}).get("interrupts") or [])
-    return result
+        content = event.get("content")
+        if not isinstance(content, str):
+            continue
+        try:
+            wrapper = json.loads(content)
+            receipt = wrapper.get("result", wrapper)
+            if isinstance(receipt, str):
+                receipt = json.loads(receipt)
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if isinstance(receipt, dict):
+            return receipt
+    return {}
 
 
 def main() -> int:
@@ -108,47 +127,24 @@ def main() -> int:
     print(f"  Code Agent -> completed with {MODEL_ID} as orchestrator model")
 
     research_thread = _thread_id("research_smoke")
-    approval_events = _invoke(
+    research_events = _invoke(
         "Use the research agent for a concise multi-source comparison of HTTP/2 "
         "and HTTP/3 with three technical differences and sources.",
         research_thread,
     )
-    interrupts = _interrupts(approval_events)
-    if not interrupts:
-        raise RuntimeError("Research Agent approval interrupt was not emitted")
-    interrupt_id = interrupts[0].get("id") or interrupts[0].get("interruptId")
-    if not interrupt_id:
-        raise RuntimeError(f"Research interrupt has no ID: {interrupts[0]}")
-
-    approval = json.dumps([{
-        "interruptResponse": {
-            "interruptId": interrupt_id,
-            "response": "approved",
-        }
-    }])
-    research_events = _invoke(approval, research_thread)
     _assert_finished(research_events, "Research Agent")
-    progress = [
-        event for event in research_events
-        if event.get("type") == "CUSTOM"
-        and event.get("name") == "research_progress"
-    ]
-    research_results = [
-        str(event.get("content", ""))
-        for event in research_events
-        if event.get("type") == "TOOL_CALL_RESULT"
-        and "<research>" in str(event.get("content", ""))
-    ]
-    if not progress:
-        raise RuntimeError("Research Agent emitted no research_progress events")
-    if not research_results:
-        raise RuntimeError("Research Agent returned no research artifact")
-    if (
-        research_results[0].count("<research>") != 1
-        or research_results[0].count("</research>") != 1
-    ):
-        raise RuntimeError("Research Agent returned a duplicated research artifact")
-    print(f"  Research Agent -> approved and completed with {MODEL_ID}")
+    if "research_agent" not in _tool_names(research_events):
+        raise RuntimeError(
+            f"Research Agent tool was not called: {_tool_names(research_events)}"
+        )
+    receipt = _tool_receipt(research_events, "research_agent")
+    if receipt.get("status") != "started":
+        raise RuntimeError(
+            f"Research Agent returned no durable start receipt: {receipt}"
+        )
+    if not receipt.get("job_id") or not receipt.get("artifact_id"):
+        raise RuntimeError(f"Research Agent receipt is incomplete: {receipt}")
+    print(f"  Research Agent -> durable background job started with {MODEL_ID}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- add a shared model catalog for provider/family metadata and delegation tiers
- expose low/medium/high task complexity on general delegation and the Claude-only code agent
- resolve and persist effective models for deterministic retries, and update deployment defaults
- align deployment smoke coverage with durable research jobs

## Verification
- backend/A2A tests: 111 passed
- code-agent tests: 37 passed
- Ruff and compileall passed
- Terraform fmt/validate passed
- deployed runtime smoke passed: Cognito, MCP Gateway, orchestrator warmup, Code Agent, Research Agent
- high Code Agent routed to Claude Opus 5
- high GPT delegation routed from Terra to Sol and completed