### PR TITLE
fix(frontend): prevent duplicate stream replay across sessions

### DIFF
--- a/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat-queue.test.ts
@@ -21,11 +21,12 @@ const streamState: { interrupt: unknown; pendingOAuth: unknown } = {
   interrupt: null,
   pendingOAuth: null,
 }
+const resetStreamingState = vi.fn()
 
 vi.mock('@/hooks/useStreamEvents', () => ({
   useStreamEvents: vi.fn(({ setSessionState }: any) => ({
     handleStreamEvent: vi.fn(),
-    resetStreamingState: vi.fn(),
+    resetStreamingState,
     // Test seam: apply whatever the "backend" reported for this turn.
     __applyStreamState: () => setSessionState((prev: any) => ({ ...prev, ...streamState })),
   })),
@@ -52,6 +53,7 @@ const apiSendMessage = vi.fn(async (...args: SendArgs) => {
 
 const sendStopSignal = vi.fn().mockResolvedValue(true)
 const apiReplayExecution = vi.fn().mockResolvedValue(true)
+const detachStream = vi.fn()
 
 vi.mock('@/hooks/useChatAPI', () => ({
   useChatAPI: vi.fn(() => ({
@@ -62,6 +64,7 @@ vi.mock('@/hooks/useChatAPI', () => ({
     listSessionEvents: vi.fn(),
     sendMessage: apiSendMessage,
     replayExecution: apiReplayExecution,
+    detachStream,
     cleanup: vi.fn(),
     sendStopSignal,
     loadSession: vi.fn().mockResolvedValue({ preferences: null, messages: [] }),
@@ -300,6 +303,23 @@ describe('useChat message queue wiring', () => {
 
     await expect(interruptPromise!).resolves.toBe(false)
     expect(sentTexts()).toEqual([])
+  })
+
+  it('detaches and resets streaming consumers on every session transition', async () => {
+    const { result } = await mount()
+    const originalSessionId = result.current.sessionId
+    detachStream.mockClear()
+    resetStreamingState.mockClear()
+
+    await act(async () => {
+      await result.current.loadSession('different-session')
+    })
+    await act(async () => {
+      await result.current.loadSession(originalSessionId)
+    })
+
+    expect(detachStream).toHaveBeenCalledTimes(2)
+    expect(resetStreamingState).toHaveBeenCalledTimes(2)
   })
 
   it('sends the held message once the user confirms', async () => {

--- a/chatbot-app/frontend/__tests__/hooks/useChat.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChat.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { useChat } from '@/hooks/useChat'
 
+const detachStream = vi.fn()
+const resetStreamingState = vi.fn()
+
 // Mock dependencies
 vi.mock('@/utils/chat', () => ({
   detectBackendUrl: vi.fn().mockResolvedValue({ url: 'http://localhost:8000', connected: true }),
@@ -12,7 +15,7 @@ vi.mock('@/utils/chat', () => ({
 vi.mock('@/hooks/useStreamEvents', () => ({
   useStreamEvents: vi.fn(() => ({
     handleStreamEvent: vi.fn(),
-    resetStreamingState: vi.fn()
+    resetStreamingState
   }))
 }))
 
@@ -21,6 +24,7 @@ vi.mock('@/hooks/useChatAPI', () => ({
     newChat: vi.fn().mockResolvedValue(true),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     replayExecution: vi.fn().mockResolvedValue(true),
+    detachStream,
     cleanup: vi.fn(),
     sendStopSignal: vi.fn(),
     loadSession: vi.fn().mockResolvedValue(null)

--- a/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
@@ -14,7 +14,9 @@ import { useChatAPI } from '@/hooks/useChatAPI'
 vi.mock('@/hooks/useSSEReconnect', () => ({
   useSSEReconnect: () => ({
     reset: vi.fn(),
+    detach: vi.fn(),
     onStreamStart: vi.fn(),
+    restoreFromSession: vi.fn().mockReturnValue(false),
     attemptReconnect: vi.fn(),
     isReconnecting: false,
     reconnectAttempt: 0,

--- a/chatbot-app/frontend/__tests__/hooks/useSSEReconnect.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSSEReconnect.test.ts
@@ -1,0 +1,155 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSSEReconnect } from '@/hooks/useSSEReconnect'
+
+vi.mock('@/config/environment', () => ({
+  getApiUrl: (path: string) => `http://localhost:3000/api/${path}`,
+}))
+
+function statusResponse(status = 'running') {
+  return {
+    ok: true,
+    json: async () => ({ status }),
+  } as Response
+}
+
+function streamResponse(payload: string) {
+  let sent = false
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (sent) return { done: true, value: undefined }
+          sent = true
+          return {
+            done: false,
+            value: new TextEncoder().encode(payload),
+          }
+        },
+        cancel: vi.fn().mockResolvedValue(undefined),
+        releaseLock: vi.fn(),
+      }),
+    },
+  } as unknown as Response
+}
+
+describe('useSSEReconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves SSE event and execution identities during replay', async () => {
+    const executionId = 'session-a:run-1'
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(statusResponse())
+      .mockResolvedValueOnce(streamResponse([
+        'id: 7',
+        'data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"message-1","delta":"Hello"}',
+        '',
+        'id: 8',
+        'data: {"type":"RUN_FINISHED","threadId":"session-a","runId":"run-1"}',
+        '',
+      ].join('\n')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const onEvent = vi.fn()
+    const onComplete = vi.fn()
+    const hook = renderHook(() => useSSEReconnect())
+
+    act(() => hook.result.current.onStreamStart(executionId))
+    await act(async () => {
+      await hook.result.current.attemptReconnect(
+        onEvent,
+        onComplete,
+        vi.fn(),
+        async () => ({ Authorization: 'Bearer test' }),
+      )
+    })
+
+    expect(onEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      type: 'TEXT_MESSAGE_CONTENT',
+      _eventId: 7,
+      _executionId: executionId,
+    }))
+    expect(onEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      type: 'RUN_FINISHED',
+      _eventId: 8,
+      _executionId: executionId,
+    }))
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('does not dispatch replay events after the consumer is detached', async () => {
+    const executionId = 'session-a:run-2'
+    let resolveRead: ((value: ReadableStreamReadResult<Uint8Array>) => void) | undefined
+    const cancel = vi.fn().mockResolvedValue(undefined)
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(statusResponse())
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: () => new Promise<ReadableStreamReadResult<Uint8Array>>(resolve => {
+              resolveRead = resolve
+            }),
+            cancel,
+            releaseLock: vi.fn(),
+          }),
+        },
+      } as unknown as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const onEvent = vi.fn()
+    const onComplete = vi.fn()
+    const onFail = vi.fn()
+    const hook = renderHook(() => useSSEReconnect())
+
+    act(() => hook.result.current.onStreamStart(executionId))
+    let reconnectPromise: Promise<void>
+    act(() => {
+      reconnectPromise = hook.result.current.attemptReconnect(
+        onEvent,
+        onComplete,
+        onFail,
+        async () => ({}),
+      )
+    })
+    await waitFor(() => expect(resolveRead).toBeDefined())
+
+    act(() => hook.result.current.detach())
+    await act(async () => {
+      resolveRead?.({
+        done: false,
+        value: new TextEncoder().encode(
+          'id: 1\ndata: {"type":"RUN_STARTED","threadId":"session-a","runId":"run-2"}\n\n',
+        ),
+      })
+      await reconnectPromise!
+    })
+
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(onEvent).not.toHaveBeenCalled()
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onFail).not.toHaveBeenCalled()
+    expect(sessionStorage.removeItem).not.toHaveBeenCalled()
+  })
+
+  it('does not let an idle session clear another session replay ID', () => {
+    const hook = renderHook(() => useSSEReconnect())
+
+    act(() => {
+      hook.result.current.onStreamStart('session-a:run-3')
+      hook.result.current.detach()
+    })
+    expect(hook.result.current.restoreFromSession('session-b')).toBe(false)
+
+    act(() => hook.result.current.reset())
+
+    expect(sessionStorage.removeItem).not.toHaveBeenCalledWith(
+      'sse_exec_session-a:run-3',
+    )
+  })
+})

--- a/chatbot-app/frontend/__tests__/hooks/useStreamEvents-tool-input.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useStreamEvents-tool-input.test.ts
@@ -134,3 +134,55 @@ describe('useStreamEvents tool input streaming', () => {
     })
   })
 })
+
+describe('useStreamEvents replay deduplication', () => {
+  it('consumes each buffered text event once for the same execution', () => {
+    const hook = setup()
+    const executionId = 'session-1:run-1'
+    const events = [
+      {
+        type: 'RUN_STARTED',
+        threadId: 'session-1',
+        runId: 'run-1',
+        _eventId: 1,
+        _executionId: executionId,
+      },
+      {
+        type: 'TEXT_MESSAGE_START',
+        messageId: 'message-1',
+        role: 'assistant',
+        _eventId: 2,
+        _executionId: executionId,
+      },
+      {
+        type: 'TEXT_MESSAGE_CONTENT',
+        messageId: 'message-1',
+        delta: 'Hello',
+        _eventId: 3,
+        _executionId: executionId,
+      },
+      {
+        type: 'TEXT_MESSAGE_END',
+        messageId: 'message-1',
+        _eventId: 4,
+        _executionId: executionId,
+      },
+    ]
+
+    act(() => {
+      for (const event of events) {
+        hook.result.current.handleStreamEvent(event as any)
+      }
+      for (const replayedEvent of events) {
+        hook.result.current.handleStreamEvent(replayedEvent as any)
+      }
+    })
+
+    expect(hook.result.current.messages).toHaveLength(1)
+    expect(hook.result.current.messages[0]).toMatchObject({
+      id: 'message-1',
+      text: 'Hello',
+      isStreaming: false,
+    })
+  })
+})

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -283,6 +283,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     listSessionEvents: apiListSessionEvents,
     sendMessage: apiSendMessage,
     replayExecution: apiReplayExecution,
+    detachStream,
     cleanup,
     sendStopSignal,
     hasStoppableRun,
@@ -376,6 +377,15 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
   // ==================== SESSION LOADING ====================
   const loadSessionWithPreferences = useCallback(async (newSessionId: string) => {
+    const previousSessionId = currentSessionIdRef.current
+    if (previousSessionId && previousSessionId !== newSessionId) {
+      // Detach the local consumers only. The backend execution remains alive
+      // and its persisted execution ID is used for a single replay on return.
+      detachStream()
+      resetStreamingState()
+      currentToolExecutionsRef.current = []
+    }
+
     // Immediately update session ref to prevent race conditions
     currentSessionIdRef.current = newSessionId
 
@@ -450,7 +460,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     } finally {
       setIsLoadingMessages(false)
     }
-  }, [apiLoadSession, setUIState, setSessionState, stopPolling, checkAndStartPollingForA2ATools])
+  }, [apiLoadSession, setUIState, setSessionState, stopPolling, checkAndStartPollingForA2ATools, detachStream, resetStreamingState])
 
   // ==================== INITIALIZATION EFFECTS ====================
   // Restore last session on page load
@@ -482,6 +492,8 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     // Invalidate current session
     currentSessionIdRef.current = `temp_${Date.now()}`
     stopPolling()
+    detachStream()
+    resetStreamingState()
 
     const success = await apiNewChat()
     if (success) {
@@ -501,7 +513,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
       // Queued turns were composed against the conversation being discarded.
       clearQueuedMessagesRef.current()
     }
-  }, [apiNewChat, stopPolling])
+  }, [apiNewChat, stopPolling, detachStream, resetStreamingState])
 
   // Answering an approval resumes the same turn, so the queue must keep waiting
   // for that turn to finish rather than treating the hold as resolved: the hold

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -198,6 +198,7 @@ interface UseChatAPIReturn {
     executionId: string,
     messageIdentity?: ReplayMessageIdentity,
   ) => Promise<boolean>
+  detachStream: () => void
   cleanup: () => void
   sendStopSignal: () => Promise<boolean>
   hasStoppableRun: boolean
@@ -219,14 +220,27 @@ export const useChatAPI = ({
 }: UseChatAPIProps) => {
 
   const abortRef = useRef<{ unsubscribe: () => void } | null>(null)
+  const streamGenerationRef = useRef(0)
   const sessionIdRef = useRef<string | null>(null)
   const activeRunIdRef = useRef<string | null>(null)
+  const activeRunSessionIdRef = useRef<string | null>(null)
   const [hasStoppableRun, setHasStoppableRun] = useState(false)
   // Read through a ref: adding conciseMode to sendMessage's deps would rebuild
   // it whenever the toggle flips, and useChat's queue flush closes over it.
   const conciseModeRef = useRef(conciseMode)
   conciseModeRef.current = conciseMode
   const reconnect = useSSEReconnect()
+
+  const detachStream = useCallback(() => {
+    streamGenerationRef.current += 1
+    const activeStream = abortRef.current
+    abortRef.current = null
+    activeStream?.unsubscribe()
+    reconnect.detach()
+    activeRunIdRef.current = null
+    activeRunSessionIdRef.current = null
+    setHasStoppableRun(false)
+  }, [reconnect.detach])
 
   // Restore last session on page load (with timeout check) and trigger warmup
   useEffect(() => {
@@ -484,9 +498,9 @@ export const useChatAPI = ({
     // Update last activity timestamp (for session timeout tracking)
     updateLastActivity()
 
-    abortRef.current?.unsubscribe()
-    abortRef.current = null
+    detachStream()
     reconnect.reset()
+    const streamGeneration = streamGenerationRef.current
 
     let requestRunId: string | null = null
     try {
@@ -536,6 +550,7 @@ export const useChatAPI = ({
         const threadId = sessionIdRef.current ?? crypto.randomUUID()
         requestRunId = crypto.randomUUID()
         activeRunIdRef.current = requestRunId
+        activeRunSessionIdRef.current = threadId
         setHasStoppableRun(true)
         const aguiBody = JSON.stringify({
           threadId,
@@ -617,6 +632,9 @@ export const useChatAPI = ({
         if (responseSessionId && responseSessionId !== currentSessionId) {
           setSessionId(responseSessionId)
           sessionIdRef.current = responseSessionId
+          if (activeRunIdRef.current === requestRunId) {
+            activeRunSessionIdRef.current = responseSessionId
+          }
           sessionStorage.setItem('chat-session-id', responseSessionId)
           logger.info('Session updated:', responseSessionId)
         }
@@ -628,6 +646,7 @@ export const useChatAPI = ({
         // normally, so completion below must not treat it as finished: the run is
         // parked mid-turn and the user still needs to be able to stop it.
         let endedAtInterrupt = false
+        let streamExecutionId: string | null = null
 
         if (!reader) {
           throw new Error('No response body reader available')
@@ -640,6 +659,7 @@ export const useChatAPI = ({
         const streamSessionId = sessionIdRef.current
 
         let buffer = ''
+        let currentEventId: number | null = null
 
         while (true) {
           let readResult: ReadableStreamReadResult<Uint8Array>
@@ -659,13 +679,15 @@ export const useChatAPI = ({
           const lines = buffer.split('\n')
           buffer = lines.pop() || ''
 
-          // Session guard: if user switched sessions, consume the stream
-          // without dispatching events so the backend can finish normally.
-          if (sessionIdRef.current !== streamSessionId) {
+          // A detached consumer is permanently stale even if the user later
+          // returns to this session. Replay owns delivery after a session switch.
+          if (
+            streamGenerationRef.current !== streamGeneration
+            || sessionIdRef.current !== streamSessionId
+          ) {
             continue
           }
 
-          let currentEventId: number | null = null
           for (const line of lines) {
             if (line.startsWith('event: ')) {
               continue
@@ -690,6 +712,7 @@ export const useChatAPI = ({
                 if (eventData.type === 'CUSTOM' && eventData.name === 'execution_meta') {
                   const execId = eventData.value?.executionId
                   if (execId) {
+                    streamExecutionId = execId
                     reconnect.onStreamStart(execId)
                     logger.info(`[useChatAPI] Execution started: ${execId}`)
                   }
@@ -699,6 +722,9 @@ export const useChatAPI = ({
                 // Inject eventId for deduplication
                 if (currentEventId !== null && currentEventId > 0) {
                   eventData._eventId = currentEventId
+                }
+                if (streamExecutionId) {
+                  eventData._executionId = streamExecutionId
                 }
                 currentEventId = null
 
@@ -724,10 +750,14 @@ export const useChatAPI = ({
         setUIState(prev => ({ ...prev, isConnected: true }))
 
         // Skip post-stream callbacks if user switched sessions during streaming
-        if (sessionIdRef.current !== streamSessionId) {
+        if (
+          streamGenerationRef.current !== streamGeneration
+          || sessionIdRef.current !== streamSessionId
+        ) {
           logger.info(`[useChatAPI] Stream finished for stale session ${streamSessionId}, skipping callbacks`)
           return
         }
+        abortRef.current = null
 
         // Session metadata is automatically updated by backend (/api/stream/chat)
         // Just check if it's a new session and refresh the list
@@ -745,6 +775,7 @@ export const useChatAPI = ({
         // no run to target and only logged "No active run available to stop".
         if (activeRunIdRef.current === requestRunId && !endedAtInterrupt) {
           activeRunIdRef.current = null
+          activeRunSessionIdRef.current = null
           setHasStoppableRun(false)
         }
         onSuccess?.()
@@ -845,10 +876,11 @@ export const useChatAPI = ({
       onError?.(errorMessage)
       if (activeRunIdRef.current === requestRunId) {
         activeRunIdRef.current = null
+        activeRunSessionIdRef.current = null
         setHasStoppableRun(false)
       }
     }
-  }, [handleStreamEvent, setUIState, setMessages, onSessionCreated, currentModelId, currentTemperature, reconnect])
+  }, [detachStream, handleStreamEvent, setUIState, setMessages, onSessionCreated, currentModelId, currentTemperature, reconnect])
   // sessionId removed from dependency array - using sessionIdRef.current instead
 
   /**
@@ -1422,6 +1454,7 @@ export const useChatAPI = ({
               if (currentEventId !== null && currentEventId > 0) {
                 eventData._eventId = currentEventId
               }
+              eventData._executionId = executionId
               currentEventId = null
               if (
                 eventData.type &&
@@ -1476,14 +1509,17 @@ export const useChatAPI = ({
     }
   }, [getAuthHeaders, handleStreamEvent, setMessages, setUIState])
 
-  const cleanup = useCallback(() => {
-    abortRef.current?.unsubscribe()
-  }, [])
+  const cleanup = detachStream
 
   const sendStopSignal = useCallback(async () => {
     const currentSessionId = sessionIdRef.current
     const currentRunId = activeRunIdRef.current
-    if (!currentSessionId || !currentRunId) {
+    const activeRunSessionId = activeRunSessionIdRef.current
+    if (
+      !currentSessionId
+      || !currentRunId
+      || activeRunSessionId !== currentSessionId
+    ) {
       logger.warn('No active run available to stop')
       return false
     }
@@ -1512,6 +1548,7 @@ export const useChatAPI = ({
       abortRef.current = null
       if (activeRunIdRef.current === currentRunId) {
         activeRunIdRef.current = null
+        activeRunSessionIdRef.current = null
         setHasStoppableRun(false)
       }
       logger.debug('Stop signal sent to backend')
@@ -1530,6 +1567,7 @@ export const useChatAPI = ({
     listSessionEvents,
     sendMessage,
     replayExecution,
+    detachStream,
     cleanup,
     sendStopSignal,
     hasStoppableRun,

--- a/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
+++ b/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
@@ -60,6 +60,8 @@ export function useSSEReconnect() {
     isReconnecting: false,
     reconnectAttempt: 0,
   })
+  const reconnectGenerationRef = useRef(0)
+  const activeControllerRef = useRef<AbortController | null>(null)
   const [isReconnecting, setIsReconnecting] = useState(false)
   const [reconnectAttempt, setReconnectAttempt] = useState(0)
 
@@ -74,7 +76,21 @@ export function useSSEReconnect() {
     setReconnectAttempt(0)
   }, [])
 
+  const detach = useCallback(() => {
+    reconnectGenerationRef.current += 1
+    activeControllerRef.current?.abort()
+    activeControllerRef.current = null
+    stateRef.current = {
+      ...stateRef.current,
+      isReconnecting: false,
+      reconnectAttempt: 0,
+    }
+    setIsReconnecting(false)
+    setReconnectAttempt(0)
+  }, [])
+
   const reset = useCallback(() => {
+    detach()
     if (stateRef.current.executionId) {
       clearPersistedExecutionId(stateRef.current.executionId)
     }
@@ -85,19 +101,19 @@ export function useSSEReconnect() {
     }
     setIsReconnecting(false)
     setReconnectAttempt(0)
-  }, [])
+  }, [detach])
 
   /** Restore execution state from sessionStorage (for page refresh). */
   const restoreFromSession = useCallback((sessionId: string): boolean => {
+    detach()
     const executionId = loadPersistedExecutionId(sessionId)
-    if (!executionId) return false
     stateRef.current = {
       executionId,
-      isReconnecting: stateRef.current.isReconnecting,
-      reconnectAttempt: stateRef.current.reconnectAttempt,
+      isReconnecting: false,
+      reconnectAttempt: 0,
     }
-    return true
-  }, [])
+    return executionId !== null
+  }, [detach])
 
   const attemptReconnect = useCallback(async (
     onEvent: (event: AGUIStreamEvent) => void,
@@ -121,9 +137,17 @@ export function useSSEReconnect() {
     stateRef.current.isReconnecting = true
     setIsReconnecting(true)
 
+    const reconnectGeneration = reconnectGenerationRef.current + 1
+    reconnectGenerationRef.current = reconnectGeneration
     let connectedFired = false
 
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      if (
+        reconnectGenerationRef.current !== reconnectGeneration
+        || stateRef.current.executionId !== executionId
+      ) {
+        return
+      }
       stateRef.current.reconnectAttempt = attempt + 1
       stateRef.current.isReconnecting = true
       setReconnectAttempt(attempt + 1)
@@ -134,12 +158,25 @@ export function useSSEReconnect() {
         const baseDelay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
         const delay = Math.floor(baseDelay * (0.5 + crypto.getRandomValues(new Uint32Array(1))[0] / 0x100000000 * 0.5)) // lgtm[js/biased-cryptographic-random]
         await new Promise(resolve => setTimeout(resolve, delay))
+        if (
+          reconnectGenerationRef.current !== reconnectGeneration
+          || stateRef.current.executionId !== executionId
+        ) {
+          return
+        }
       }
 
       try {
         // 1. Check execution status via BFF buffer
         const headers = await getAuthHeaders()
+        if (
+          reconnectGenerationRef.current !== reconnectGeneration
+          || stateRef.current.executionId !== executionId
+        ) {
+          return
+        }
         const statusController = new AbortController()
+        activeControllerRef.current = statusController
         const statusTimeout = setTimeout(() => statusController.abort(), FETCH_TIMEOUT_MS)
         let statusData: { status: string }
         try {
@@ -151,6 +188,15 @@ export function useSSEReconnect() {
           statusData = await statusRes.json()
         } finally {
           clearTimeout(statusTimeout)
+          if (activeControllerRef.current === statusController) {
+            activeControllerRef.current = null
+          }
+        }
+        if (
+          reconnectGenerationRef.current !== reconnectGeneration
+          || stateRef.current.executionId !== executionId
+        ) {
+          return
         }
 
         if (statusData.status === 'not_found') {
@@ -160,6 +206,7 @@ export function useSSEReconnect() {
 
         // 2. Resume SSE stream from cursor=0 (full replay from BFF buffer)
         const resumeController = new AbortController()
+        activeControllerRef.current = resumeController
         const resumeTimeout = setTimeout(() => resumeController.abort(), FETCH_TIMEOUT_MS)
         const resumeUrl = `${getApiUrl('stream/resume')}?executionId=${encodeURIComponent(executionId)}&cursor=0`
         let response: Response
@@ -173,11 +220,17 @@ export function useSSEReconnect() {
         }
 
         if (!response.ok) {
+          if (activeControllerRef.current === resumeController) {
+            activeControllerRef.current = null
+          }
           console.warn(`[SSEReconnect] Resume failed with ${response.status}, attempt ${attempt + 1}`)
           continue
         }
 
         if (!response.body) {
+          if (activeControllerRef.current === resumeController) {
+            activeControllerRef.current = null
+          }
           console.warn('[SSEReconnect] No body in resume response')
           continue
         }
@@ -187,32 +240,54 @@ export function useSSEReconnect() {
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
         let buffer = ''
+        let currentEventId: number | null = null
 
         try {
           while (true) {
             const { done, value } = await reader.read()
             if (done) break
+            if (
+              reconnectGenerationRef.current !== reconnectGeneration
+              || stateRef.current.executionId !== executionId
+            ) {
+              await reader.cancel()
+              return
+            }
 
             buffer += decoder.decode(value, { stream: true })
             const lines = buffer.split('\n')
             buffer = lines.pop() || ''
 
             for (const line of lines) {
+              if (line.startsWith('id: ')) {
+                currentEventId = parseInt(line.substring(4), 10)
+                continue
+              }
               if (line.startsWith('data: ')) {
                 try {
                   const eventData = JSON.parse(line.substring(6))
                   // Skip internal metadata events
                   if (eventData.type === 'CUSTOM' && eventData.name === 'execution_meta') {
+                    currentEventId = null
                     continue
                   }
+                  const embeddedEventId = Number(eventData.eventId)
+                  const eventId = currentEventId && currentEventId > 0
+                    ? currentEventId
+                    : embeddedEventId > 0
+                      ? embeddedEventId
+                      : null
+                  if (eventId !== null) {
+                    eventData._eventId = eventId
+                  }
+                  eventData._executionId = executionId
+                  currentEventId = null
                   // Dispatch event
                   if (eventData.type && AGUI_EVENT_TYPES.includes(eventData.type)) {
                     onEvent(eventData as AGUIStreamEvent)
                     // Clear reconnecting badge on first real event
                     if (!connectedFired) {
                       connectedFired = true
-                      stateRef.current.isReconnecting = false
-                      stateRef.current.reconnectAttempt = 0
                       setIsReconnecting(false)
                       setReconnectAttempt(0)
                       onConnected?.()
@@ -226,8 +301,17 @@ export function useSSEReconnect() {
           }
         } finally {
           reader.releaseLock()
+          if (activeControllerRef.current === resumeController) {
+            activeControllerRef.current = null
+          }
         }
 
+        if (
+          reconnectGenerationRef.current !== reconnectGeneration
+          || stateRef.current.executionId !== executionId
+        ) {
+          return
+        }
         // Success — clear persisted executionId
         clearPersistedExecutionId(executionId)
         stateRef.current.isReconnecting = false
@@ -237,6 +321,12 @@ export function useSSEReconnect() {
         onComplete()
         return
       } catch (error) {
+        if (
+          reconnectGenerationRef.current !== reconnectGeneration
+          || stateRef.current.executionId !== executionId
+        ) {
+          return
+        }
         console.warn(`[SSEReconnect] Attempt ${attempt + 1} failed:`, error)
         continue
       }
@@ -255,6 +345,7 @@ export function useSSEReconnect() {
     attemptReconnect,
     restoreFromSession,
     reset,
+    detach,
     isReconnecting,
     reconnectAttempt,
   }

--- a/chatbot-app/frontend/src/hooks/useStreamEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useStreamEvents.ts
@@ -75,6 +75,7 @@ export const useStreamEvents = ({
 
   // Event deduplication for SSE reconnection (tracks processed "eventId:type" keys)
   const processedEventIdsRef = useRef(new Set<string>())
+  const processedExecutionIdRef = useRef<string | null>(null)
 
   // Swarm mode state
   const swarmModeRef = useRef<{
@@ -980,9 +981,6 @@ export const useStreamEvents = ({
   }, [setSessionState, setMessages, setUIState, streamingStartedRef, streamingIdRef, completeProcessedRef, metadataTracking, currentToolExecutionsRef, textBuffer, stopPollingRef])
 
   const handleInitEvent = useCallback(() => {
-    // Clear dedup set at the start of each new run so that events from the new
-    // execution (which restart eventId from 1) are not mistakenly dropped.
-    processedEventIdsRef.current.clear()
     pendingAssistantTurnBoundaryRef.current = true
 
     setUIState(prev => {
@@ -1578,11 +1576,24 @@ export const useStreamEvents = ({
 
   const handleStreamEvent = useCallback((event: AGUIStreamEvent) => {
     try {
+      const executionId = (event as any)._executionId as string | undefined
+      if (executionId) {
+        if (processedExecutionIdRef.current !== executionId) {
+          processedEventIdsRef.current.clear()
+          processedExecutionIdRef.current = executionId
+        }
+      } else if (event.type === EventType.RUN_STARTED) {
+        // Legacy/non-buffered streams do not carry an execution identity.
+        processedEventIdsRef.current.clear()
+        processedExecutionIdRef.current = null
+      }
+
       // Event deduplication for SSE reconnection
-      // Use "eventId:type" as key because multiple event types can share the same SSE event id
-      const eventId = (event as any)._eventId as number | undefined
+      const eventId = Number(
+        (event as any)._eventId ?? (event as any).eventId,
+      )
       if (eventId && eventId > 0) {
-        const dedupKey = `${eventId}:${event.type}`
+        const dedupKey = `${executionId || 'legacy'}:${eventId}:${event.type}`
         if (processedEventIdsRef.current.has(dedupKey)) {
           return  // Skip duplicate
         }
@@ -1765,6 +1776,7 @@ export const useStreamEvents = ({
     tokenUsageRef.current = null
     pendingAssistantTurnBoundaryRef.current = false
     processedEventIdsRef.current.clear()
+    processedExecutionIdRef.current = null
     metadataTracking.reset()
 
     // Reset swarm mode state if active


### PR DESCRIPTION
## Summary
- detach live and reconnect consumers when switching chat sessions
- make replay events execution-aware and deduplicate by execution/event identity
- reset stream buffers and prevent stale run stop requests across sessions
- preserve per-session replay IDs without allowing another session to clear them

## Verification
- frontend test suite: 719 passed
- TypeScript type-check passed
- Next.js production build passed
- deployed frontend revision 69 is stable on ECS
- CloudFront health and authenticated Gateway/orchestrator smoke passed
- deployed stream disconnect -> completion -> cursor-0 replay smoke passed with unique SSE IDs and expected text
