### PR TITLE
fix(chat): harden session durability and job recovery

### DIFF
--- a/chatbot-app/agentcore/src/a2a_tools.py
+++ b/chatbot-app/agentcore/src/a2a_tools.py
@@ -544,6 +544,11 @@ def create_a2a_tool(agent_id: str):
                 artifact_id=artifact_id,
                 event_factory=event_factory,
                 model_id=model_id,
+                agent_id=agent_id,
+                research_session_id=research_session_id,
+                region=region,
+                metadata=metadata,
+                auth_token=_auth_token or "",
             )
             return __import__("json").dumps(receipt)
 

--- a/chatbot-app/agentcore/src/agent/mailbox.py
+++ b/chatbot-app/agentcore/src/agent/mailbox.py
@@ -412,9 +412,29 @@ class DynamoDBMailboxRepository(MailboxRepository):
         self._deserializer = TypeDeserializer()
 
     def _serialize(self, value: Dict[str, Any]) -> Dict[str, Any]:
-        # DynamoDB rejects Python floats. A JSON round trip converts them to
-        # Decimal while also proving the envelope is JSON-compatible.
-        normalized = json.loads(json.dumps(value), parse_float=Decimal)
+        # DynamoDB rejects Python floats, while records read through the boto3
+        # resource API already contain Decimal values. Normalize both without
+        # sending existing Decimals through json.dumps(), which cannot encode
+        # them and previously broke research completion delivery.
+        def normalize(item: Any) -> Any:
+            if isinstance(item, Decimal):
+                return item
+            if isinstance(item, float):
+                return Decimal(str(item))
+            if isinstance(item, dict):
+                return {
+                    str(key): normalize(child)
+                    for key, child in item.items()
+                }
+            if isinstance(item, (list, tuple)):
+                return [normalize(child) for child in item]
+            if item is None or isinstance(item, (str, int, bool)):
+                return item
+            raise TypeError(
+                f"Mailbox records must be JSON-compatible; got {type(item).__name__}"
+            )
+
+        normalized = normalize(value)
         return {key: self._serializer.serialize(item) for key, item in normalized.items()}
 
     def _deserialize(self, value: Dict[str, Any]) -> Dict[str, Any]:

--- a/chatbot-app/agentcore/src/agent/research_jobs.py
+++ b/chatbot-app/agentcore/src/agent/research_jobs.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 import threading
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
@@ -35,6 +35,10 @@ DeliveryHandler = Callable[[Dict[str, Any], Dict[str, Any]], Awaitable[None]]
 _delivery_loop: Optional[asyncio.AbstractEventLoop] = None
 _delivery_handler: Optional[DeliveryHandler] = None
 _delivery_lock = threading.Lock()
+_STALE_HEARTBEAT_SECONDS = 180
+_MAX_ATTEMPTS = 3
+_TERMINAL_TTL_DAYS = 30
+_TERMINAL_STATUSES = frozenset({"delivered", "error", "cancelled"})
 
 
 class CompletionPublishStatus(str, Enum):
@@ -53,6 +57,12 @@ class CompletionPublishResult:
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _terminal_ttl() -> int:
+    return int(
+        (datetime.now(timezone.utc) + timedelta(days=_TERMINAL_TTL_DAYS)).timestamp()
+    )
 
 
 def _safe_component(value: str) -> str:
@@ -96,6 +106,24 @@ def _is_cloud_storage() -> bool:
     return bool(os.environ.get("DYNAMODB_USERS_TABLE"))
 
 
+def _is_orchestration_storage() -> bool:
+    return bool(os.environ.get("SESSION_ORCHESTRATION_TABLE"))
+
+
+def _orchestration_table():
+    return boto3.resource(
+        "dynamodb",
+        region_name=os.environ.get("AWS_REGION", "us-west-2"),
+    ).Table(os.environ["SESSION_ORCHESTRATION_TABLE"])
+
+
+def _condition_failed(error: Exception) -> bool:
+    return (
+        getattr(error, "response", {}).get("Error", {}).get("Code")
+        == "ConditionalCheckFailedException"
+    )
+
+
 def _legacy_job_reads_enabled() -> bool:
     return (
         not os.environ.get("SESSION_ORCHESTRATION_TABLE")
@@ -107,13 +135,18 @@ def _legacy_job_reads_enabled() -> bool:
 
 
 def _save_job(record: Dict[str, Any]) -> None:
+    stored_record = {
+        key: value
+        for key, value in record.items()
+        if not key.startswith("_")
+    }
     if _is_cloud_storage():
         region = os.environ.get("AWS_REGION", "us-west-2")
         orchestration_table = os.environ.get("SESSION_ORCHESTRATION_TABLE")
         if orchestration_table:
             table_name = orchestration_table
             item = {
-                **record,
+                **stored_record,
                 "sessionKey": _orchestration_session_key(
                     record["userId"],
                     record["sessionId"],
@@ -124,7 +157,7 @@ def _save_job(record: Dict[str, Any]) -> None:
         else:
             table_name = os.environ["DYNAMODB_USERS_TABLE"]
             item = {
-                **record,
+                **stored_record,
                 "userId": record["userId"],
                 "sk": _job_sk(record["sessionId"], record["jobId"]),
                 "recordType": "RESEARCH_JOB",
@@ -133,7 +166,269 @@ def _save_job(record: Dict[str, Any]) -> None:
         return
 
     path = _local_job_dir(record["sessionId"]) / f"{_safe_component(record['jobId'])}.json"
-    _atomic_write(path, json.dumps(record, ensure_ascii=False, indent=2))
+    _atomic_write(path, json.dumps(stored_record, ensure_ascii=False, indent=2))
+
+
+def _create_job(record: Dict[str, Any]) -> None:
+    if _is_orchestration_storage():
+        item = {
+            **record,
+            "sessionKey": _orchestration_session_key(
+                record["userId"],
+                record["sessionId"],
+            ),
+            "recordKey": _orchestration_job_key(record["jobId"]),
+            "recordType": "RESEARCH_JOB",
+        }
+        _orchestration_table().put_item(
+            Item=item,
+            ConditionExpression=(
+                "attribute_not_exists(sessionKey) "
+                "AND attribute_not_exists(recordKey)"
+            ),
+        )
+        record.update(item)
+        return
+    _save_job(record)
+
+
+def _update_owned(record: Dict[str, Any], updates: Dict[str, Any]) -> bool:
+    """Update a running worker only while its fencing token owns the job."""
+    if record.get("_inlineOwner"):
+        record.update(updates)
+        _save_job(record)
+        return True
+    if _is_orchestration_storage():
+        names: Dict[str, str] = {}
+        values: Dict[str, Any] = {
+            ":token": record["executionToken"],
+            ":running": "running",
+        }
+        assignments = []
+        for index, (key, value) in enumerate(updates.items()):
+            name_token = f"#field{index}"
+            value_token = f":value{index}"
+            names[name_token] = key
+            values[value_token] = value
+            assignments.append(f"{name_token} = {value_token}")
+        try:
+            response = _orchestration_table().update_item(
+                Key={
+                    "sessionKey": _orchestration_session_key(
+                        record["userId"],
+                        record["sessionId"],
+                    ),
+                    "recordKey": _orchestration_job_key(record["jobId"]),
+                },
+                UpdateExpression="SET " + ", ".join(assignments),
+                ConditionExpression=(
+                    "executionToken = :token "
+                    "AND desiredState = :running AND workStatus = :running"
+                ),
+                ExpressionAttributeNames=names,
+                ExpressionAttributeValues=values,
+                ReturnValues="ALL_NEW",
+            )
+        except Exception as error:
+            if _condition_failed(error):
+                return False
+            raise
+        record.update(response.get("Attributes") or updates)
+        return True
+
+    latest = _get_job(record["userId"], record["sessionId"], record["jobId"])
+    if (
+        latest is not None
+        and latest.get("executionToken") == record.get("executionToken")
+        and latest.get("desiredState") == "running"
+        and latest.get("workStatus") == "running"
+    ):
+        latest.update(updates)
+        _save_job(latest)
+        record.update(latest)
+        return True
+    return False
+
+
+def _update_existing(
+    record: Dict[str, Any],
+    updates: Dict[str, Any],
+    *,
+    allowed_statuses: tuple[str, ...],
+) -> bool:
+    """Project delivery state without recreating cancelled or deleted rows."""
+    if record.get("_inlineOwner"):
+        if record.get("status") not in allowed_statuses:
+            return False
+        record.update(updates)
+        _save_job(record)
+        return True
+    if _is_orchestration_storage():
+        names: Dict[str, str] = {"#status": "status"}
+        values: Dict[str, Any] = {}
+        assignments = []
+        for index, (key, value) in enumerate(updates.items()):
+            name_token = f"#field{index}"
+            value_token = f":value{index}"
+            names[name_token] = key
+            values[value_token] = value
+            assignments.append(f"{name_token} = {value_token}")
+        status_conditions = []
+        for index, status in enumerate(allowed_statuses):
+            token = f":status{index}"
+            values[token] = status
+            status_conditions.append(f"#status = {token}")
+        try:
+            response = _orchestration_table().update_item(
+                Key={
+                    "sessionKey": _orchestration_session_key(
+                        record["userId"],
+                        record["sessionId"],
+                    ),
+                    "recordKey": _orchestration_job_key(record["jobId"]),
+                },
+                UpdateExpression="SET " + ", ".join(assignments),
+                ConditionExpression=(
+                    "attribute_exists(recordKey) AND ("
+                    + " OR ".join(status_conditions)
+                    + ")"
+                ),
+                ExpressionAttributeNames=names,
+                ExpressionAttributeValues=values,
+                ReturnValues="ALL_NEW",
+            )
+        except Exception as error:
+            if _condition_failed(error):
+                return False
+            raise
+        record.update(response.get("Attributes") or updates)
+        return True
+
+    latest = _get_job(record["userId"], record["sessionId"], record["jobId"])
+    if latest is None or latest.get("status") not in allowed_statuses:
+        return False
+    latest.update(updates)
+    _save_job(latest)
+    record.update(latest)
+    return True
+
+
+def _claim_job(
+    user_id: str,
+    session_id: str,
+    job_id: str,
+) -> Optional[Dict[str, Any]]:
+    current = _get_job(user_id, session_id, job_id)
+    if current is None:
+        return None
+    if (
+        current.get("desiredState") == "cancelled"
+        or current.get("status") in _TERMINAL_STATUSES
+    ):
+        return None
+    attempts = int(current.get("attempts", 0))
+    if attempts >= _MAX_ATTEMPTS:
+        _update_existing(
+            current,
+            {
+                "status": "error",
+                "workStatus": "terminal",
+                "desiredState": "cancelled",
+                "error": "Research retry limit exceeded",
+                "updatedAt": _now(),
+                "ttl": _terminal_ttl(),
+            },
+            allowed_statuses=("queued", "running"),
+        )
+        return None
+
+    now = _now()
+    stale_before = (
+        datetime.now(timezone.utc)
+        - timedelta(seconds=_STALE_HEARTBEAT_SECONDS)
+    ).isoformat()
+    execution_token = uuid4().hex
+    if _is_orchestration_storage():
+        try:
+            response = _orchestration_table().update_item(
+                Key={
+                    "sessionKey": _orchestration_session_key(user_id, session_id),
+                    "recordKey": _orchestration_job_key(job_id),
+                },
+                UpdateExpression=(
+                    "SET #status = :running, workStatus = :running, "
+                    "heartbeatAt = :now, updatedAt = :now, "
+                    "startedAt = if_not_exists(startedAt, :now), "
+                    "attempts = if_not_exists(attempts, :zero) + :one, "
+                    "executionToken = :token"
+                ),
+                ConditionExpression=(
+                    "desiredState = :desired AND attempts < :maxAttempts AND ("
+                    "workStatus = :queued OR "
+                    "(workStatus = :running AND heartbeatAt < :stale))"
+                ),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":running": "running",
+                    ":queued": "queued",
+                    ":now": now,
+                    ":stale": stale_before,
+                    ":zero": 0,
+                    ":one": 1,
+                    ":maxAttempts": _MAX_ATTEMPTS,
+                    ":token": execution_token,
+                    ":desired": "running",
+                },
+                ReturnValues="ALL_NEW",
+            )
+            return response.get("Attributes")
+        except Exception as error:
+            if _condition_failed(error):
+                return None
+            raise
+
+    heartbeat = str(current.get("heartbeatAt") or "")
+    if current.get("workStatus", "queued") == "running" and heartbeat >= stale_before:
+        return None
+    current.update(
+        status="running",
+        workStatus="running",
+        heartbeatAt=now,
+        updatedAt=now,
+        startedAt=current.get("startedAt") or now,
+        attempts=attempts + 1,
+        executionToken=execution_token,
+    )
+    _save_job(current)
+    return current
+
+
+def _heartbeat(record: Dict[str, Any]) -> bool:
+    heartbeat_at = _now()
+    return _update_owned(
+        record,
+        {"heartbeatAt": heartbeat_at, "updatedAt": heartbeat_at},
+    )
+
+
+def _event_factory_for_record(
+    record: Dict[str, Any],
+    *,
+    auth_token: str = "",
+) -> EventFactory:
+    def factory():
+        from a2a_tools import send_a2a_message
+
+        return send_a2a_message(
+            str(record["agentId"]),
+            str(record["plan"]),
+            str(record["researchSessionId"]),
+            str(record.get("region") or "us-west-2"),
+            metadata=dict(record.get("metadata") or {}),
+            auth_token=auth_token or None,
+        )
+
+    return factory
 
 
 def _get_job(
@@ -495,9 +790,16 @@ def recover_pending_mailbox_events(user_id: str, session_id: str) -> list[str]:
         # before the INBOX transaction became durable.
         event_id = _enqueue_completion_event(record)
         if event_id:
-            record["mailboxEventId"] = event_id
-            record.pop("mailboxWriteError", None)
-            _save_job(record)
+            _update_existing(
+                record,
+                {
+                    "status": "delivering",
+                    "workStatus": "terminal",
+                    "mailboxEventId": event_id,
+                    "updatedAt": _now(),
+                },
+                allowed_statuses=("completed", "delivering"),
+            )
         if event_id:
             recovered.append(event_id)
     return recovered
@@ -534,7 +836,7 @@ def reconcile_processed_deliveries(
         records = _list_jobs(user_id, session_id)
 
     for record in records:
-        if record.get("status") != "delivering":
+        if record.get("status") not in ("completed", "delivering"):
             continue
         event = repository.get_event(
             user_id,
@@ -549,9 +851,18 @@ def reconcile_processed_deliveries(
 
 
 def mark_delivered(record: Dict[str, Any]) -> None:
-    record.update(status="delivered", deliveredAt=_now(), updatedAt=_now())
-    record.pop("deliveryError", None)
-    _save_job(record)
+    delivered_at = _now()
+    _update_existing(
+        record,
+        {
+            "status": "delivered",
+            "workStatus": "terminal",
+            "deliveredAt": delivered_at,
+            "updatedAt": delivered_at,
+            "ttl": _terminal_ttl(),
+        },
+        allowed_statuses=("completed", "delivering"),
+    )
 
 
 def register_delivery_handler(
@@ -612,63 +923,126 @@ async def _run_job(record: Dict[str, Any], event_factory: EventFactory) -> None:
         {"job_id": record["jobId"], "session_id": record["sessionId"]},
     )
     try:
-        record.update(status="running", startedAt=_now(), updatedAt=_now())
-        _save_job(record)
+        # Compatibility for direct/local callers. Production workers enter via
+        # start_job_execution and already hold a durable fencing token.
+        if not record.get("executionToken"):
+            record.update(
+                executionToken=uuid4().hex,
+                desiredState="running",
+                workStatus="running",
+                status="running",
+                startedAt=_now(),
+                heartbeatAt=_now(),
+                updatedAt=_now(),
+                _inlineOwner=True,
+            )
+            _save_job(record)
 
         report = ""
         error = ""
-        async for event in event_factory():
+        queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+
+        async def produce() -> None:
+            try:
+                async for streamed_event in event_factory():
+                    await queue.put(("event", streamed_event))
+            except BaseException as producer_error:
+                await queue.put(("error", producer_error))
+            finally:
+                await queue.put(("done", None))
+
+        producer = asyncio.create_task(produce())
+        while True:
+            try:
+                kind, value = await asyncio.wait_for(queue.get(), timeout=15)
+            except asyncio.TimeoutError:
+                if not _heartbeat(record):
+                    raise asyncio.CancelledError
+                continue
+            if kind == "done":
+                break
+            if kind == "error":
+                raise value
+            event = value
+            if not _heartbeat(record):
+                raise asyncio.CancelledError
             if not isinstance(event, dict):
                 continue
             if event.get("type") in ("research_step", "research_progress"):
-                record["progress"] = {
-                    "stepNumber": event.get("stepNumber", 0),
-                    "content": event.get("content", ""),
-                }
-                record["updatedAt"] = _now()
-                _save_job(record)
+                updated_at = _now()
+                if not _update_owned(record, {
+                    "progress": {
+                        "stepNumber": event.get("stepNumber", 0),
+                        "content": event.get("content", ""),
+                    },
+                    "heartbeatAt": updated_at,
+                    "updatedAt": updated_at,
+                }):
+                    raise asyncio.CancelledError
                 _publish_progress(record, event)
 
             status = event.get("status")
             if status in ("success", "error"):
                 content = event.get("content") or []
-                text = content[0].get("text", "") if content and isinstance(content[0], dict) else ""
+                text = (
+                    content[0].get("text", "")
+                    if content and isinstance(content[0], dict)
+                    else ""
+                )
                 if status == "success":
                     report = text
                 else:
                     error = text or "Research agent failed"
 
+        if not producer.done():
+            producer.cancel()
+        await asyncio.gather(producer, return_exceptions=True)
+
         if error or not report:
             raise RuntimeError(error or "Research agent returned an empty report")
 
         completed_at = _now()
-        record.update(
-            status="completed",
-            completedAt=completed_at,
-            updatedAt=completed_at,
-        )
-        record.update(_save_report(record, report))
-        artifact = _build_artifact(record, report)
-        record["artifact"] = {key: value for key, value in artifact.items() if key != "content"}
+        artifact_location = _save_report(record, report)
+        artifact_record = {
+            **record,
+            **artifact_location,
+            "completedAt": completed_at,
+        }
+        artifact = _build_artifact(artifact_record, report)
+        completion_updates: Dict[str, Any] = {
+            **artifact_location,
+            "artifact": {
+                key: value
+                for key, value in artifact.items()
+                if key != "content"
+            },
+            "status": "delivering",
+            "workStatus": "terminal",
+            "completedAt": completed_at,
+            "heartbeatAt": completed_at,
+            "updatedAt": completed_at,
+            "ttl": _terminal_ttl(),
+        }
         if _mailbox_write_enabled():
-            record["mailboxEventId"] = _completion_event_id(record)
+            completion_updates["mailboxEventId"] = _completion_event_id(record)
+        if not _update_owned(record, completion_updates):
+            raise asyncio.CancelledError
 
-        # Persist every field needed by a mailbox consumer before publishing
-        # the INBOX record. Once enqueue succeeds, the dispatcher may deliver
-        # and mark this job delivered immediately; the worker must not write a
-        # stale "completed" or "delivering" snapshot afterward.
-        record.update(status="delivering", updatedAt=_now())
-        _save_job(record)
         from agent.mailbox_runtime import mailbox_delivery_enabled
 
         publish = _publish_completion(record)
         if publish.status == CompletionPublishStatus.CANCELLED:
-            record.update(
-                status="cancelled",
-                updatedAt=_now(),
-                deliveryError=publish.error,
+            _update_existing(
+                record,
+                {
+                    "status": "cancelled",
+                    "workStatus": "terminal",
+                    "updatedAt": _now(),
+                    "deliveryError": publish.error or "Session fenced",
+                    "ttl": _terminal_ttl(),
+                },
+                allowed_statuses=("delivering",),
             )
-            _save_job(record)
             logger.info(
                 "[ResearchJob] Cancelled delivery to fenced session %s",
                 record["sessionId"],
@@ -676,22 +1050,22 @@ async def _run_job(record: Dict[str, Any], event_factory: EventFactory) -> None:
             return
         if publish.status == CompletionPublishStatus.DURABLE:
             record["mailboxEventId"] = publish.event_id
-            record.pop("mailboxWriteError", None)
         elif publish.status == CompletionPublishStatus.FAILED:
-            record.pop("mailboxEventId", None)
-            record["mailboxWriteError"] = publish.error
             if mailbox_delivery_enabled():
-                record.update(
-                    status="completed",
-                    deliveryError=(
-                        "Mailbox delivery is enabled but completion enqueue failed"
-                    ),
-                    updatedAt=_now(),
+                _update_existing(
+                    record,
+                    {
+                        "status": "completed",
+                        "workStatus": "terminal",
+                        "deliveryError": (
+                            "Mailbox delivery is enabled but completion enqueue failed"
+                        ),
+                        "mailboxWriteError": publish.error or "Mailbox write failed",
+                        "updatedAt": _now(),
+                    },
+                    allowed_statuses=("delivering",),
                 )
-                _save_job(record)
                 return
-        elif publish.status == CompletionPublishStatus.DISABLED:
-            _save_job(record)
 
         try:
             if mailbox_delivery_enabled():
@@ -707,26 +1081,36 @@ async def _run_job(record: Dict[str, Any], event_factory: EventFactory) -> None:
                 return
             await _deliver(record, artifact)
         except Exception as exc:
-            record.update(
-                status="completed",
-                deliveryError=str(exc),
-                updatedAt=_now(),
+            _update_existing(
+                record,
+                {
+                    "status": "completed",
+                    "workStatus": "terminal",
+                    "deliveryError": str(exc),
+                    "updatedAt": _now(),
+                },
+                allowed_statuses=("delivering",),
             )
-            _save_job(record)
             logger.exception("[ResearchJob] Delivery failed for %s", record["jobId"])
             return
 
-        record.update(
-            status="delivered",
-            deliveredAt=_now(),
-            updatedAt=_now(),
-        )
-        record.pop("deliveryError", None)
-        _save_job(record)
+        mark_delivered(record)
+    except asyncio.CancelledError:
+        logger.info("[ResearchJob] Worker lost ownership for %s", record["jobId"])
     except Exception as exc:
-        record.update(status="error", error=str(exc), updatedAt=_now())
+        updated_at = _now()
         try:
-            _save_job(record)
+            _update_owned(
+                record,
+                {
+                    "status": "error",
+                    "workStatus": "terminal",
+                    "error": str(exc),
+                    "heartbeatAt": updated_at,
+                    "updatedAt": updated_at,
+                    "ttl": _terminal_ttl(),
+                },
+            )
         except Exception:
             logger.exception("[ResearchJob] Failed to persist terminal error")
         logger.exception("[ResearchJob] Job %s failed", record["jobId"])
@@ -740,11 +1124,18 @@ def start_research_job(
     user_id: str,
     plan: str,
     artifact_id: str,
-    event_factory: EventFactory,
+    event_factory: Optional[EventFactory] = None,
     model_id: Optional[str] = None,
     request_type: str = "skill",
+    agent_id: str = "",
+    research_session_id: str = "",
+    region: str = "us-west-2",
+    metadata: Optional[Dict[str, Any]] = None,
+    auth_token: str = "",
 ) -> Dict[str, Any]:
     """Persist and start one research job, returning its public start receipt."""
+    if event_factory is None and not agent_id:
+        raise ValueError("agent_id is required when event_factory is not provided")
     job_id = uuid4().hex
     created_at = _now()
     conversation_epoch = 0
@@ -762,22 +1153,59 @@ def start_research_job(
         "artifactId": artifact_id,
         "plan": plan,
         "status": "queued",
+        "workStatus": "queued",
+        "desiredState": "running",
+        "attempts": 0,
+        "heartbeatAt": created_at,
         "createdAt": created_at,
         "updatedAt": created_at,
         "modelId": model_id or "",
         "requestType": request_type,
         "conversationEpoch": conversation_epoch,
+        "agentId": agent_id,
+        "researchSessionId": research_session_id or session_id,
+        "region": region,
+        "metadata": metadata or {},
     }
-    _save_job(record)
-
-    thread = threading.Thread(
-        target=lambda: asyncio.run(_run_job(record, event_factory)),
-        name=f"research-{job_id[:8]}",
-        daemon=True,
+    _create_job(record)
+    start_job_execution(
+        user_id,
+        session_id,
+        job_id,
+        event_factory=event_factory,
+        auth_token=auth_token,
     )
-    thread.start()
     return {
         "status": "started",
         "job_id": job_id,
         "artifact_id": artifact_id,
     }
+
+
+def start_job_execution(
+    user_id: str,
+    session_id: str,
+    job_id: str,
+    *,
+    event_factory: Optional[EventFactory] = None,
+    auth_token: str = "",
+) -> Dict[str, Any]:
+    """Conditionally claim and start one research worker."""
+    record = _claim_job(user_id, session_id, job_id)
+    if record is None:
+        existing = _get_job(user_id, session_id, job_id)
+        return {
+            "status": "ignored",
+            "executionStatus": existing.get("status") if existing else "not_found",
+        }
+    factory = event_factory or _event_factory_for_record(
+        record,
+        auth_token=auth_token,
+    )
+    thread = threading.Thread(
+        target=lambda: asyncio.run(_run_job(record, factory)),
+        name=f"research-{job_id[:8]}",
+        daemon=True,
+    )
+    thread.start()
+    return {"status": "accepted", "executionStatus": "running"}

--- a/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
+++ b/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
@@ -59,6 +59,7 @@ class CompactionState:
 class MailboxPersistenceScope:
     origin_event_id: str
     conversation_epoch: int
+    hide_user_message: bool = True
     message_index: int = 0
 
 
@@ -188,14 +189,17 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
         self,
         origin_event_id: str,
         conversation_epoch: int = 0,
+        *,
+        hide_user_message: bool = True,
     ):
-        """Make message writes idempotent for one durable mailbox event."""
+        """Make message writes idempotent and conversation-epoch aware."""
         with self._mailbox_scope_lock:
             if self._mailbox_scope is not None:
                 raise RuntimeError("Nested mailbox persistence scopes are not supported")
             self._mailbox_scope = MailboxPersistenceScope(
                 origin_event_id,
                 conversation_epoch,
+                hide_user_message,
             )
         try:
             yield
@@ -222,6 +226,7 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
                 scoped_message = (
                     scope.origin_event_id,
                     scope.conversation_epoch,
+                    scope.hide_user_message,
                     message_index,
                 )
 
@@ -233,7 +238,12 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
                 **kwargs,
             )
 
-        origin_event_id, conversation_epoch, message_index = scoped_message
+        (
+            origin_event_id,
+            conversation_epoch,
+            hide_user_message,
+            message_index,
+        ) = scoped_message
         logical_message_id = f"mailbox:{origin_event_id}:{message_index}"
         role = session_message.message.get("role", "")
         metadata = dict(kwargs.pop("metadata", {}) or {})
@@ -242,7 +252,11 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
             "conversationEpoch": {"stringValue": str(conversation_epoch)},
             "logicalMessageId": {"stringValue": logical_message_id},
             "visibility": {
-                "stringValue": "internal" if role == "user" else "conversation"
+                "stringValue": (
+                    "internal"
+                    if role == "user" and hide_user_message
+                    else "conversation"
+                )
             },
         })
 

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -321,6 +321,34 @@ async def invocations(http_request: Request):
             auth_token=auth_token,
         )
 
+    if action == "start_research":
+        if not _is_mailbox_dispatcher_request(http_request):
+            raise HTTPException(
+                status_code=403,
+                detail="Research dispatcher token required",
+            )
+        user_id = str(state.get("user_id") or "")
+        job_id = str(state.get("job_id") or "")
+        if not user_id or not thread_id or not job_id:
+            raise HTTPException(
+                status_code=400,
+                detail="thread_id, state.user_id, and state.job_id are required",
+            )
+        authorization = http_request.headers.get("authorization", "")
+        auth_token = (
+            authorization.split(" ", 1)[1]
+            if authorization.lower().startswith("bearer ")
+            else ""
+        )
+        from agent.research_jobs import start_job_execution
+
+        return start_job_execution(
+            user_id,
+            thread_id,
+            job_id,
+            auth_token=auth_token,
+        )
+
     if action == "drain_mailbox":
         if not _is_mailbox_dispatcher_request(http_request):
             raise HTTPException(status_code=403, detail="Mailbox dispatcher token required")
@@ -585,8 +613,15 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
     from agent.mailbox_runtime import mailbox_delivery_enabled
 
     use_mailbox_delivery = mailbox_delivery_enabled()
+    conversation_epoch = 0
     pending_research = []
     if use_mailbox_delivery:
+        from agent.mailbox import get_mailbox_repository
+
+        conversation_epoch = get_mailbox_repository().get_conversation_epoch(
+            user_id,
+            session_id,
+        )
         # A foreground invocation is also a recovery signal. Recreate any
         # deterministic completion envelopes that predate mailbox delivery;
         # the coordinator will materialize them as separate assistant turns.
@@ -713,16 +748,31 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
             # microVM mid-run.
             task_id = async_tasks.begin("agent_run", {"execution_id": execution.execution_id})
             try:
-                stream = agui_processor.process_stream(
-                    agent.agent,
-                    agui_message,
-                    session_id=session_id,
-                    invocation_state=invocation_state,
-                    elicitation_bridge=getattr(agent, 'elicitation_bridge', None),
+                persistence_scope = getattr(
+                    agent.session_manager,
+                    "mailbox_event_scope",
+                    None,
                 )
-                async for sse_chunk in stream:
-                    event_type = _extract_event_type(sse_chunk)
-                    execution.append_event(sse_chunk, event_type)
+                scope_context = (
+                    persistence_scope(
+                        f"foreground:{run_id}",
+                        conversation_epoch,
+                        hide_user_message=False,
+                    )
+                    if persistence_scope and use_mailbox_delivery
+                    else nullcontext()
+                )
+                with scope_context:
+                    stream = agui_processor.process_stream(
+                        agent.agent,
+                        agui_message,
+                        session_id=session_id,
+                        invocation_state=invocation_state,
+                        elicitation_bridge=getattr(agent, 'elicitation_bridge', None),
+                    )
+                    async for sse_chunk in stream:
+                        event_type = _extract_event_type(sse_chunk)
+                        execution.append_event(sse_chunk, event_type)
 
                 if pending_research:
                     from agent.research_jobs import mark_delivered

--- a/chatbot-app/agentcore/src/streaming/execution_registry.py
+++ b/chatbot-app/agentcore/src/streaming/execution_registry.py
@@ -57,14 +57,18 @@ class Execution:
         if len(self.events) >= self.MAX_EVENTS:
             trim_count = int(self.MAX_EVENTS * self.TRUNCATE_RATIO)
             self.events = self.events[trim_count:]
-            # Insert truncation marker
+            first_retained_id = self.events[0].event_id
+            # The marker represents the gap immediately before the retained
+            # window, so its id must preserve chronological cursor ordering.
             marker = SSEEvent(
-                event_id=self.next_event_id,
-                data='data: {"type":"custom","name":"buffer_truncated"}\n\n',
+                event_id=first_retained_id - 1,
+                data=(
+                    'data: {"type":"CUSTOM","name":"buffer_truncated",'
+                    f'"value":{{"truncatedThroughEventId":{first_retained_id - 1}}}}}\n\n'
+                ),
                 timestamp=time.time(),
                 event_type="buffer_truncated",
             )
-            self.next_event_id += 1
             self.events.insert(0, marker)
 
         event = SSEEvent(

--- a/chatbot-app/agentcore/tests/integration/e2e/test_l4_protocol_paths.py
+++ b/chatbot-app/agentcore/tests/integration/e2e/test_l4_protocol_paths.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import json
 import os
+import time
 
+import httpx
 import pytest
 
 pytestmark = pytest.mark.e2e
@@ -160,51 +162,65 @@ def test_protocol_path(stream, prompt, expected_tool_substrings, call_kwargs):
     _assert_skill_or_tool_invoked(result, expected_tool_substrings)
 
 
-def test_a2a_research_approval_roundtrip(stream):
-    """Approve the HITL interrupt and verify the Research Agent completes."""
-    first = stream(
+def _research_start_receipt(result) -> dict:
+    for content in result.tool_result_contents():
+        try:
+            wrapper = json.loads(content)
+            receipt = wrapper.get("result", wrapper)
+            if isinstance(receipt, str):
+                receipt = json.loads(receipt)
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if isinstance(receipt, dict) and receipt.get("status") == "started":
+            return receipt
+    return {}
+
+
+def test_a2a_research_durable_completion(stream, bff_url, cognito_token):
+    """Verify research reaches durable artifact and mailbox delivery."""
+    started = stream(
         "Use the research agent for a concise multi-source comparison of HTTP/2 "
         "and HTTP/3 with a summary, three technical differences, and sources.",
         timeout=300.0,
     )
-    assert first.interrupted_for_approval(), (
-        f"Research approval interrupt not observed. Errors: {first.raw_error_events}"
+    assert started.run_finished(), (
+        f"Research start turn did not finish. Errors: {started.raw_error_events}"
     )
-    _assert_skill_or_tool_invoked(first, ("research-agent", "research_agent"))
+    _assert_skill_or_tool_invoked(started, ("research-agent", "research_agent"))
+    receipt = _research_start_receipt(started)
+    assert receipt.get("job_id"), f"Research returned no durable receipt: {receipt}"
+    assert receipt.get("artifact_id"), f"Research receipt is incomplete: {receipt}"
 
-    interrupt = first.interrupts()[0]
-    interrupt_id = interrupt.get("id") or interrupt.get("interruptId")
-    assert interrupt_id, f"Interrupt has no ID: {interrupt}"
+    deadline = time.monotonic() + 600
+    job = {}
+    with httpx.Client(
+        base_url=bff_url,
+        headers={"Authorization": f"Bearer {cognito_token}"},
+        timeout=30.0,
+    ) as client:
+        while time.monotonic() < deadline:
+            response = client.get(
+                "/api/research/jobs",
+                params={
+                    "session_id": started.thread_id,
+                    "job_id": receipt["job_id"],
+                    "include_content": "true",
+                },
+            )
+            response.raise_for_status()
+            job = response.json().get("job") or {}
+            if job.get("status") in {"delivered", "error", "cancelled"}:
+                break
+            time.sleep(5)
 
-    approval = json.dumps([{
-        "interruptResponse": {
-            "interruptId": interrupt_id,
-            "response": "approved",
-        }
-    }])
-    completed = stream(
-        approval,
-        thread_id=first.thread_id,
-        timeout=600.0,
+    assert job.get("status") == "delivered", (
+        f"Research did not reach mailbox delivery: {job}"
     )
-
-    assert completed.run_finished(), (
-        f"Research approval continuation did not finish. "
-        f"Errors: {completed.raw_error_events}"
-    )
-    assert not completed.raw_error_events
-    assert completed.custom_events("research_progress"), (
-        "Research Agent completed without emitting research_progress events"
-    )
-    research_results = [
-        content for content in completed.tool_result_contents()
-        if "<research>" in content
-    ]
-    assert research_results, "Research Agent returned no research artifact"
-    assert research_results[0].count("<research>") == 1
-    assert research_results[0].count("</research>") == 1
-    assert completed.assistant_text().strip(), (
-        "Orchestrator returned no completion summary"
+    assert job.get("mailboxEventId") == f"research-result:{receipt['job_id']}"
+    artifact = job.get("artifact") or {}
+    assert artifact.get("id") == receipt["artifact_id"]
+    assert str(artifact.get("content") or "").strip(), (
+        "Delivered research job has no hydrated artifact content"
     )
 
 

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -167,6 +167,27 @@ class TestExecutionRegistry:
         assert events[0].event_id == 3
 
     @pytest.mark.asyncio
+    async def test_overflow_preserves_monotonic_replay_ids(self):
+        from streaming.execution_registry import ExecutionRegistry
+
+        ExecutionRegistry.reset()
+        execution = await ExecutionRegistry().create_execution(
+            "overflow-session",
+            "user1",
+            "run1",
+        )
+        for index in range(execution.MAX_EVENTS + 1):
+            execution.append_event(
+                f'data: {{"type":"CUSTOM","name":"event-{index}"}}\n\n',
+                "custom",
+            )
+
+        event_ids = [event.event_id for event in execution.events]
+        assert event_ids == sorted(event_ids)
+        assert execution.events[0].event_type == "buffer_truncated"
+        assert '"type":"CUSTOM"' in execution.events[0].data
+
+    @pytest.mark.asyncio
     async def test_cleanup_expired(self):
         """Test that completed executions are cleaned up after TTL."""
         import time

--- a/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
+++ b/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
@@ -148,6 +148,29 @@ class TestMailboxPersistenceScope:
         )
         assert calls[0].kwargs["metadata"]["visibility"]["stringValue"] == "conversation"
 
+    @patch(
+        'agent.session.compacting_session_manager.AgentCoreMemorySessionManager.create_message'
+    )
+    def test_foreground_scope_keeps_user_message_visible(self, parent_create, manager):
+        from strands.types.session import SessionMessage
+
+        parent_create.return_value = {"eventId": "stored"}
+        user = SessionMessage.from_message(
+            {"role": "user", "content": [{"text": "hello"}]},
+            0,
+        )
+
+        with manager.mailbox_event_scope(
+            "foreground:run-1",
+            4,
+            hide_user_message=False,
+        ):
+            manager.create_message("session-1", "default", user)
+
+        metadata = parent_create.call_args.kwargs["metadata"]
+        assert metadata["conversationEpoch"]["stringValue"] == "4"
+        assert metadata["visibility"]["stringValue"] == "conversation"
+
     def test_list_messages_filters_stale_mailbox_epochs(self, manager):
         repository = MagicMock()
         repository.get_conversation_epoch.return_value = 3

--- a/chatbot-app/agentcore/tests/unit/test_delegation_jobs.py
+++ b/chatbot-app/agentcore/tests/unit/test_delegation_jobs.py
@@ -244,7 +244,7 @@ def test_local_storage_rejects_session_symlink_escape(tmp_path):
     outside = tmp_path.parent / f"{tmp_path.name}-outside"
     outside.mkdir()
     storage_root = tmp_path / "delegation_jobs"
-    storage_root.mkdir()
+    storage_root.mkdir(exist_ok=True)
     session_key = hashlib.sha256(b"s1").hexdigest()
     (storage_root / session_key).symlink_to(
         outside,

--- a/chatbot-app/agentcore/tests/unit/test_mailbox.py
+++ b/chatbot-app/agentcore/tests/unit/test_mailbox.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -384,6 +385,26 @@ def test_dynamodb_enqueue_uses_event_key_for_idempotency():
     client.transact_write_items.side_effect = transaction_condition_failure()
     client.get_item.return_value = {}
     assert repository.enqueue(item) is False
+
+
+def test_dynamodb_serialize_accepts_nested_decimal_values():
+    repository = DynamoDBMailboxRepository("mailbox-table", client=MagicMock())
+
+    serialized = repository._serialize({
+        "artifact": {
+            "wordCount": Decimal("527"),
+            "confidence": Decimal("0.875"),
+            "scores": [Decimal("1"), 0.5],
+        },
+    })
+
+    assert repository._deserialize(serialized) == {
+        "artifact": {
+            "wordCount": 527,
+            "confidence": 0.875,
+            "scores": [1, 0.5],
+        },
+    }
 
 
 def test_dynamodb_get_event_uses_direct_consistent_read():

--- a/chatbot-app/agentcore/tests/unit/test_research_jobs.py
+++ b/chatbot-app/agentcore/tests/unit/test_research_jobs.py
@@ -1,6 +1,7 @@
 import asyncio
 from copy import deepcopy
 from dataclasses import replace
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -116,17 +117,16 @@ def test_start_returns_without_running_worker_inline(monkeypatch):
     saved = []
     started = []
 
-    class FakeThread:
-        def __init__(self, *, target, name, daemon):
-            self.target = target
-            self.name = name
-            self.daemon = daemon
-
-        def start(self):
-            started.append(self)
-
-    monkeypatch.setattr(research_jobs, "_save_job", lambda record: saved.append(record))
-    monkeypatch.setattr(research_jobs.threading, "Thread", FakeThread)
+    monkeypatch.setattr(
+        research_jobs,
+        "_create_job",
+        lambda record: saved.append(deepcopy(record)),
+    )
+    monkeypatch.setattr(
+        research_jobs,
+        "start_job_execution",
+        lambda *args, **kwargs: started.append((args, kwargs)),
+    )
 
     async def events():
         yield {"status": "success", "content": [{"text": "# Report"}]}
@@ -142,11 +142,12 @@ def test_start_returns_without_running_worker_inline(monkeypatch):
     assert receipt["status"] == "started"
     assert receipt["artifact_id"] == "research-tool-3"
     assert saved[0]["status"] == "queued"
+    assert saved[0]["workStatus"] == "queued"
+    assert saved[0]["desiredState"] == "running"
     assert len(started) == 1
-    assert started[0].daemon is True
 
 
-def test_cloud_job_writes_use_orchestration_table(monkeypatch):
+def test_cloud_job_create_uses_orchestration_table(monkeypatch):
     table = MagicMock()
     resource = MagicMock()
     resource.Table.return_value = table
@@ -160,14 +161,17 @@ def test_cloud_job_writes_use_orchestration_table(monkeypatch):
         "status": "queued",
     }
 
-    research_jobs._save_job(record)
+    research_jobs._create_job(record)
 
     resource.Table.assert_called_once_with("orchestration-table")
     item = table.put_item.call_args.kwargs["Item"]
     assert item["sessionKey"] == "USER#user-1#SESSION#session-1"
     assert item["recordKey"] == "JOB#job-1"
-    assert item["recordType"] == "JOB"
+    assert item["recordType"] == "RESEARCH_JOB"
     assert "sk" not in item
+    assert "attribute_not_exists" in table.put_item.call_args.kwargs[
+        "ConditionExpression"
+    ]
 
 
 def test_cloud_job_reads_merge_orchestration_and_legacy_rows(monkeypatch):
@@ -244,6 +248,12 @@ def test_completion_mailbox_event_is_small_and_idempotent(monkeypatch):
 
     class Repository:
         def enqueue(self, event):
+            from agent.mailbox import DynamoDBMailboxRepository
+
+            DynamoDBMailboxRepository(
+                "mailbox-table",
+                client=MagicMock(),
+            )._serialize(event.to_record())
             observed.append(event)
             return len(observed) == 1
 
@@ -261,6 +271,9 @@ def test_completion_mailbox_event_is_small_and_idempotent(monkeypatch):
             "id": "research-tool-1",
             "title": "Report",
             "type": "research",
+            "metadata": {
+                "word_count": Decimal("527"),
+            },
         },
         "artifactBucket": "bucket",
         "artifactS3Key": "research/report.md",
@@ -304,7 +317,7 @@ def test_artifact_state_reference_excludes_report_body():
 
 
 def test_recover_pending_job_creates_deterministic_mailbox_event(monkeypatch):
-    saved = []
+    updated = []
     record = {
         "jobId": "job-1",
         "sessionId": "session-1",
@@ -323,8 +336,10 @@ def test_recover_pending_job_creates_deterministic_mailbox_event(monkeypatch):
     )
     monkeypatch.setattr(
         research_jobs,
-        "_save_job",
-        lambda item: saved.append(deepcopy(item)),
+        "_update_existing",
+        lambda item, changes, **kwargs: updated.append(
+            (deepcopy(changes), kwargs)
+        ) or True,
     )
 
     recovered = research_jobs.recover_pending_mailbox_events(
@@ -333,12 +348,18 @@ def test_recover_pending_job_creates_deterministic_mailbox_event(monkeypatch):
     )
 
     assert recovered == ["research-result:job-1"]
-    assert saved[0]["mailboxEventId"] == "research-result:job-1"
+    assert updated[0][0]["mailboxEventId"] == "research-result:job-1"
+    assert updated[0][0]["status"] == "delivering"
+    assert updated[0][0]["workStatus"] == "terminal"
+    assert updated[0][1]["allowed_statuses"] == ("completed", "delivering")
 
 
 def test_recover_pending_job_reenqueues_existing_idempotency_key(monkeypatch):
     record = {
         "jobId": "job-1",
+        "userId": "user-1",
+        "sessionId": "session-1",
+        "status": "delivering",
         "mailboxEventId": "research-result:job-1",
     }
     monkeypatch.setattr(
@@ -347,9 +368,9 @@ def test_recover_pending_job_reenqueues_existing_idempotency_key(monkeypatch):
         lambda user_id, session_id: [{"record": record, "artifact": {}}],
     )
     enqueue = MagicMock(return_value="research-result:job-1")
-    save = MagicMock()
+    update = MagicMock(return_value=True)
     monkeypatch.setattr(research_jobs, "_enqueue_completion_event", enqueue)
-    monkeypatch.setattr(research_jobs, "_save_job", save)
+    monkeypatch.setattr(research_jobs, "_update_existing", update)
 
     recovered = research_jobs.recover_pending_mailbox_events(
         "user-1",
@@ -358,17 +379,18 @@ def test_recover_pending_job_reenqueues_existing_idempotency_key(monkeypatch):
 
     assert recovered == ["research-result:job-1"]
     enqueue.assert_called_once_with(record)
-    save.assert_called_once_with(record)
+    update.assert_called_once()
 
 
-def test_reconcile_processed_delivery_marks_job_delivered(monkeypatch):
+@pytest.mark.parametrize("job_status", ["completed", "delivering"])
+def test_reconcile_processed_delivery_marks_job_delivered(monkeypatch, job_status):
     from agent.mailbox import MailboxEvent, PROCESSED
 
     record = {
         "jobId": "job-1",
         "userId": "user-1",
         "sessionId": "session-1",
-        "status": "delivering",
+        "status": job_status,
         "mailboxEventId": "research-result:job-1",
     }
     event = replace(
@@ -579,7 +601,62 @@ async def test_mailbox_write_failure_stays_retryable_without_direct_delivery(
     assert writes[-1]["deliveryError"] == (
         "Mailbox delivery is enabled but completion enqueue failed"
     )
-    assert "mailboxEventId" not in writes[-1]
+    assert writes[-1]["mailboxEventId"] == "research-result:job-1"
+    assert writes[-1]["mailboxWriteError"] == "write failed"
+
+
+def test_cloud_claim_supports_stale_takeover(monkeypatch):
+    table = MagicMock()
+    current = {
+        "jobId": "job-1",
+        "userId": "user-1",
+        "sessionId": "session-1",
+        "status": "running",
+        "workStatus": "running",
+        "desiredState": "running",
+        "heartbeatAt": "2020-01-01T00:00:00+00:00",
+        "attempts": 1,
+    }
+    table.update_item.return_value = {
+        "Attributes": {
+            **current,
+            "executionToken": "new-token",
+            "attempts": 2,
+        }
+    }
+    monkeypatch.setenv("DYNAMODB_USERS_TABLE", "users-table")
+    monkeypatch.setenv("SESSION_ORCHESTRATION_TABLE", "orchestration-table")
+    monkeypatch.setattr(research_jobs, "_orchestration_table", lambda: table)
+    monkeypatch.setattr(research_jobs, "_get_job", lambda *_: current)
+
+    claimed = research_jobs._claim_job("user-1", "session-1", "job-1")
+
+    assert claimed["executionToken"] == "new-token"
+    condition = table.update_item.call_args.kwargs["ConditionExpression"]
+    assert "heartbeatAt < :stale" in condition
+    assert "attempts < :maxAttempts" in condition
+
+
+def test_owned_update_rejects_cancelled_or_taken_over_job(monkeypatch):
+    table = MagicMock()
+    error = RuntimeError("condition failed")
+    error.response = {"Error": {"Code": "ConditionalCheckFailedException"}}
+    table.update_item.side_effect = error
+    monkeypatch.setenv("DYNAMODB_USERS_TABLE", "users-table")
+    monkeypatch.setenv("SESSION_ORCHESTRATION_TABLE", "orchestration-table")
+    monkeypatch.setattr(research_jobs, "_orchestration_table", lambda: table)
+
+    updated = research_jobs._update_owned(
+        {
+            "jobId": "job-1",
+            "userId": "user-1",
+            "sessionId": "session-1",
+            "executionToken": "old-token",
+        },
+        {"status": "delivering"},
+    )
+
+    assert updated is False
 
 
 @pytest.mark.asyncio

--- a/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
@@ -8,16 +8,20 @@
  * never work, logging only "No active run available to stop".
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { useChatAPI } from '@/hooks/useChatAPI'
+
+const reconnectMocks = vi.hoisted(() => ({
+  reset: vi.fn(),
+  detach: vi.fn(),
+  onStreamStart: vi.fn(),
+  restoreFromSession: vi.fn().mockReturnValue(false),
+  attemptReconnect: vi.fn(),
+}))
 
 vi.mock('@/hooks/useSSEReconnect', () => ({
   useSSEReconnect: () => ({
-    reset: vi.fn(),
-    detach: vi.fn(),
-    onStreamStart: vi.fn(),
-    restoreFromSession: vi.fn().mockReturnValue(false),
-    attemptReconnect: vi.fn(),
+    ...reconnectMocks,
     isReconnecting: false,
     reconnectAttempt: 0,
   }),
@@ -70,7 +74,10 @@ const INTERRUPT = {
 
 function setup(handleStreamEvent = vi.fn()) {
   const stopFetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '' })
-  const setMessages = vi.fn()
+  let messageState: any[] = []
+  const setMessages = vi.fn((update: any) => {
+    messageState = typeof update === 'function' ? update(messageState) : update
+  })
   const hook = renderHook(() =>
     useChatAPI({
       backendUrl: 'http://localhost:8000',
@@ -84,7 +91,13 @@ function setup(handleStreamEvent = vi.fn()) {
       currentTemperature: 0.5,
     } as any),
   )
-  return { hook, stopFetch, handleStreamEvent, setMessages }
+  return {
+    hook,
+    stopFetch,
+    handleStreamEvent,
+    setMessages,
+    getMessages: () => messageState,
+  }
 }
 
 /** Runs one turn whose stream ends with the given events. */
@@ -281,5 +294,102 @@ describe('useChatAPI — background execution replay', () => {
         logicalMessageId: 'mailbox:research-result:job-1:1',
       }),
     ])
+  })
+})
+
+describe('useChatAPI — durable session restore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionStorage.clear()
+    reconnectMocks.restoreFromSession.mockReturnValue(false)
+    reconnectMocks.attemptReconnect.mockReset()
+  })
+
+  const history = (text: string) => ({
+    success: true,
+    messages: [
+      { id: `${text}-user`, role: 'user', content: [{ text: 'question' }] },
+      { id: `${text}-assistant`, role: 'assistant', content: [{ text }] },
+    ],
+    artifacts: [],
+    sessionPreferences: null,
+  })
+
+  it('restores canonical history when the persisted execution has expired', async () => {
+    reconnectMocks.restoreFromSession.mockReturnValue(true)
+    reconnectMocks.attemptReconnect.mockImplementation(
+      async (_onEvent, _onComplete, onFail) => onFail(),
+    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => history('durable answer'),
+    }))
+    const { hook, getMessages } = setup()
+
+    await act(async () => {
+      await hook.result.current.loadSession('session-1')
+    })
+
+    expect(getMessages()).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'durable answer-assistant',
+        text: 'durable answer',
+      }),
+    ]))
+  })
+
+  it('does not let an older session response overwrite the active session', async () => {
+    let resolveA: ((response: Response) => void) | undefined
+    let resolveB: ((response: Response) => void) | undefined
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('conversation/history') && url.includes('session-a')) {
+        return new Promise<Response>(resolve => { resolveA = resolve })
+      }
+      if (url.includes('conversation/history') && url.includes('session-b')) {
+        return new Promise<Response>(resolve => { resolveB = resolve })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ status: 'warm' }),
+      } as Response)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { hook, getMessages } = setup()
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    let loadA: Promise<unknown>
+    let loadB: Promise<unknown>
+    act(() => {
+      loadA = hook.result.current.loadSession('session-a')
+    })
+    await waitFor(() => expect(resolveA).toBeDefined())
+    act(() => {
+      loadB = hook.result.current.loadSession('session-b')
+    })
+    await waitFor(() => expect(resolveB).toBeDefined())
+    await act(async () => {
+      resolveB?.({
+        ok: true,
+        json: async () => history('answer B'),
+      } as Response)
+      await loadB!
+    })
+    await act(async () => {
+      resolveA?.({
+        ok: true,
+        json: async () => history('answer A'),
+      } as Response)
+      await loadA!
+    })
+
+    expect(getMessages()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ text: 'answer B' }),
+    ]))
+    expect(getMessages()).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ text: 'answer A' }),
+    ]))
   })
 })

--- a/chatbot-app/frontend/__tests__/hooks/useSSEReconnect.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useSSEReconnect.test.ts
@@ -81,6 +81,45 @@ describe('useSSEReconnect', () => {
     expect(onComplete).toHaveBeenCalledOnce()
   })
 
+  it('serializes asynchronous event cleanup before completing replay', async () => {
+    const executionId = 'session-a:run-serial'
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(statusResponse())
+      .mockResolvedValueOnce(streamResponse([
+        'id: 1',
+        'data: {"type":"RUN_FINISHED","threadId":"session-a","runId":"run-serial"}',
+        '',
+      ].join('\n')))
+    vi.stubGlobal('fetch', fetchMock)
+    let releaseCleanup: (() => void) | undefined
+    const cleanup = new Promise<void>(resolve => {
+      releaseCleanup = resolve
+    })
+    const onEvent = vi.fn().mockReturnValue(cleanup)
+    const onComplete = vi.fn()
+    const hook = renderHook(() => useSSEReconnect())
+
+    act(() => hook.result.current.onStreamStart(executionId))
+    let replay: Promise<void>
+    act(() => {
+      replay = hook.result.current.attemptReconnect(
+        onEvent,
+        onComplete,
+        vi.fn(),
+        async () => ({}),
+      )
+    })
+    await waitFor(() => expect(onEvent).toHaveBeenCalledOnce())
+    expect(onComplete).not.toHaveBeenCalled()
+
+    await act(async () => {
+      releaseCleanup?.()
+      await replay!
+    })
+
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
   it('does not dispatch replay events after the consumer is detached', async () => {
     const executionId = 'session-a:run-2'
     let resolveRead: ((value: ReadableStreamReadResult<Uint8Array>) => void) | undefined

--- a/chatbot-app/frontend/src/app/api/stream/chat/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/chat/route.ts
@@ -448,6 +448,14 @@ export async function POST(request: NextRequest) {
           }
 
         } catch (error) {
+          if (
+            clientDisconnected
+            && error instanceof Error
+            && error.name === 'AbortError'
+          ) {
+            console.log('[BFF] Stream relay detached after client disconnect')
+            return
+          }
           console.error('[BFF] Error:', error)
           const errorEvent = `data: ${JSON.stringify({
             type: 'error',

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -221,6 +221,7 @@ export const useChatAPI = ({
 
   const abortRef = useRef<{ unsubscribe: () => void } | null>(null)
   const streamGenerationRef = useRef(0)
+  const loadGenerationRef = useRef(0)
   const sessionIdRef = useRef<string | null>(null)
   const activeRunIdRef = useRef<string | null>(null)
   const activeRunSessionIdRef = useRef<string | null>(null)
@@ -738,7 +739,7 @@ export const useChatAPI = ({
                 }
 
                 if (eventData.type && (AGUI_EVENT_TYPES as readonly string[]).includes(eventData.type)) {
-                  handleStreamEvent(eventData as AGUIStreamEvent)
+                  await handleStreamEvent(eventData as AGUIStreamEvent)
                 }
               } catch (error) {
                 logger.error('Error processing SSE event:', error)
@@ -1011,6 +1012,11 @@ export const useChatAPI = ({
   }
 
   const loadSession = useCallback(async (newSessionId: string): Promise<{ preferences: SessionPreferences | null; messages: Message[] }> => {
+    const loadGeneration = ++loadGenerationRef.current
+    const isCurrentLoad = () => (
+      loadGenerationRef.current === loadGeneration
+      && sessionIdRef.current === newSessionId
+    )
     try {
       logger.info(`Loading session: ${newSessionId}`)
 
@@ -1025,6 +1031,9 @@ export const useChatAPI = ({
       }
 
       const authHeaders = await getAuthHeaders()
+      if (!isCurrentLoad()) {
+        return { preferences: null, messages: [] }
+      }
 
       // Load conversation history from AgentCore Memory
       const url = getApiUrl(`conversation/history?session_id=${newSessionId}`)
@@ -1042,6 +1051,9 @@ export const useChatAPI = ({
       }
 
       const data = await response.json()
+      if (!isCurrentLoad()) {
+        return { preferences: null, messages: [] }
+      }
 
       if (!data.success) {
         throw new Error(data.error || 'Failed to load conversation history')
@@ -1284,6 +1296,9 @@ export const useChatAPI = ({
         )
         return { ...msg, toolExecutions: updated }
       })
+      if (!isCurrentLoad()) {
+        return { preferences: null, messages: [] }
+      }
 
       // Skip setMessages during polling if content hasn't changed (prevents re-render flicker)
       if (isSameSession) {
@@ -1345,21 +1360,27 @@ export const useChatAPI = ({
         reconnect.attemptReconnect(
           (event) => handleStreamEvent(event),
           () => {
+            if (!isCurrentLoad()) return
             // Resume succeeded
             logger.info('[loadSession] Resume after page refresh succeeded')
             setUIState(prev => ({ ...prev, isReconnecting: false, isTyping: false, isConnected: true, agentStatus: 'idle', turnPhase: 'idle' }))
           },
           () => {
+            if (!isCurrentLoad()) return
             // Resume failed — show history only
             logger.info('[loadSession] Resume after page refresh failed, showing history only')
+            setMessages(finalMessages)
             setUIState(prev => ({ ...prev, isReconnecting: false, isTyping: false, agentStatus: 'idle', turnPhase: 'idle' }))
           },
           getAuthHeaders,
           () => {
+            if (!isCurrentLoad()) return
             // Connected — clear badge, keep isTyping true since stream continues
             setUIState(prev => ({ ...prev, isReconnecting: false, isConnected: true }))
           },
         ).catch(() => {
+          if (!isCurrentLoad()) return
+          setMessages(finalMessages)
           setUIState(prev => ({ ...prev, isReconnecting: false, isTyping: false, agentStatus: 'idle', turnPhase: 'idle' }))
         })
       }

--- a/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
+++ b/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
@@ -116,7 +116,7 @@ export function useSSEReconnect() {
   }, [detach])
 
   const attemptReconnect = useCallback(async (
-    onEvent: (event: AGUIStreamEvent) => void,
+    onEvent: (event: AGUIStreamEvent) => void | Promise<void>,
     onComplete: () => void,
     onFail: () => void,
     getAuthHeaders: () => Promise<Record<string, string>>,
@@ -284,7 +284,7 @@ export function useSSEReconnect() {
                   currentEventId = null
                   // Dispatch event
                   if (eventData.type && AGUI_EVENT_TYPES.includes(eventData.type)) {
-                    onEvent(eventData as AGUIStreamEvent)
+                    await onEvent(eventData as AGUIStreamEvent)
                     // Clear reconnecting badge on first real event
                     if (!connectedFired) {
                       connectedFired = true

--- a/chatbot-app/frontend/src/lib/session-lifecycle.ts
+++ b/chatbot-app/frontend/src/lib/session-lifecycle.ts
@@ -146,6 +146,40 @@ function advanceLocalConversationEpoch(
       }
     }
   }
+
+  const researchJobsDir = path.resolve(
+    process.cwd(),
+    '..',
+    'agentcore',
+    'sessions',
+    `session_${sessionId}`,
+    'research_jobs',
+  )
+  if (researchJobsDir.startsWith(path.resolve(
+    process.cwd(),
+    '..',
+    'agentcore',
+    'sessions',
+  ) + path.sep) && fs.existsSync(researchJobsDir)) {
+    for (const name of fs.readdirSync(researchJobsDir)) {
+      if (!name.endsWith('.json')) continue
+      const jobPath = path.join(researchJobsDir, name)
+      const job = JSON.parse(fs.readFileSync(jobPath, 'utf-8'))
+      if (
+        Number(job.conversationEpoch || 0) < nextEpoch &&
+        ['queued', 'running', 'completed', 'delivering'].includes(job.status)
+      ) {
+        Object.assign(job, {
+          status: 'cancelled',
+          workStatus: 'terminal',
+          desiredState: 'cancelled',
+          updatedAt,
+          deliveryError: 'Conversation truncated',
+        })
+        writeLocalMailbox(jobPath, job)
+      }
+    }
+  }
   return nextEpoch
 }
 
@@ -341,13 +375,15 @@ export async function advanceSessionConversationEpoch(
       TableName: TABLE_NAME,
       Key: key,
       UpdateExpression:
-        'SET #status = :cancelled, updatedAt = :updated, deliveryError = :reason',
+        'SET #status = :cancelled, workStatus = :terminal, ' +
+        'desiredState = :cancelled, updatedAt = :updated, deliveryError = :reason',
       ConditionExpression:
         '#status = :queued OR #status = :running OR #status = :completed ' +
         'OR #status = :delivering',
       ExpressionAttributeNames: { '#status': 'status' },
       ExpressionAttributeValues: marshall({
         ':cancelled': 'cancelled',
+        ':terminal': 'terminal',
         ':updated': updatedAt,
         ':reason': 'Conversation truncated',
         ':queued': 'queued',

--- a/infra/lambda/session-mailbox-dispatcher/lambda_function.py
+++ b/infra/lambda/session-mailbox-dispatcher/lambda_function.py
@@ -131,6 +131,37 @@ def _start_delegation(user_id: str, session_id: str, job_id: str) -> None:
         )
 
 
+def _start_research(user_id: str, session_id: str, job_id: str) -> None:
+    payload = json.dumps({
+        "thread_id": session_id,
+        "run_id": f"research-dispatch-{job_id}",
+        "messages": [],
+        "tools": [],
+        "context": [],
+        "state": {
+            "action": "start_research",
+            "user_id": user_id,
+            "job_id": job_id,
+        },
+    }).encode()
+    request = urllib.request.Request(
+        os.environ["AGENTCORE_RUNTIME_URL"],
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {_access_token()}",
+            "Content-Type": "application/json",
+            "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id,
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        result = json.loads(response.read())
+    if result.get("status") not in {"accepted", "ignored"}:
+        raise RuntimeError(
+            f"Research was not accepted for {user_id}/{session_id}: {result}"
+        )
+
+
 def _mailbox_target(record: dict[str, Any]) -> tuple[str, str, str] | None:
     if record.get("eventName") != "INSERT":
         return None
@@ -152,6 +183,24 @@ def _delegation_target(record: dict[str, Any]) -> tuple[str, str, str] | None:
         return None
     image = record.get("dynamodb", {}).get("NewImage", {})
     if image.get("recordType", {}).get("S") != "DELEGATION_JOB":
+        return None
+    if image.get("workStatus", {}).get("S") != "queued":
+        return None
+    if image.get("desiredState", {}).get("S") != "running":
+        return None
+    user_id = image.get("userId", {}).get("S")
+    session_id = image.get("sessionId", {}).get("S")
+    job_id = image.get("jobId", {}).get("S")
+    if not user_id or not session_id or not job_id:
+        return None
+    return user_id, session_id, job_id
+
+
+def _research_target(record: dict[str, Any]) -> tuple[str, str, str] | None:
+    if record.get("eventName") not in {"INSERT", "MODIFY"}:
+        return None
+    image = record.get("dynamodb", {}).get("NewImage", {})
+    if image.get("recordType", {}).get("S") != "RESEARCH_JOB":
         return None
     if image.get("workStatus", {}).get("S") != "queued":
         return None
@@ -201,6 +250,24 @@ def _enqueue_delegation(user_id: str, session_id: str, job_id: str) -> None:
         MessageGroupId=hashlib.sha256(target).hexdigest(),
         MessageDeduplicationId=hashlib.sha256(
             target + b"\ndelegation\n" + job_id.encode()
+        ).hexdigest(),
+    )
+
+
+def _enqueue_research(user_id: str, session_id: str, job_id: str) -> None:
+    body = json.dumps({
+        "kind": "research",
+        "userId": user_id,
+        "sessionId": session_id,
+        "jobId": job_id,
+    })
+    target = f"{user_id}\n{session_id}".encode()
+    boto3.client("sqs").send_message(
+        QueueUrl=os.environ["WAKE_QUEUE_URL"],
+        MessageBody=body,
+        MessageGroupId=hashlib.sha256(target).hexdigest(),
+        MessageDeduplicationId=hashlib.sha256(
+            target + b"\nresearch\n" + job_id.encode()
         ).hexdigest(),
     )
 
@@ -271,7 +338,7 @@ def _handle_stream(event: dict[str, Any]) -> dict[str, Any]:
         tuple[str, str],
         dict[str, list[str]],
     ] = {}
-    delegation_records: list[tuple[str, str, str, str]] = []
+    job_records: list[tuple[str, str, str, str, str]] = []
     for record in event.get("Records", []):
         target = _mailbox_target(record)
         if target:
@@ -285,8 +352,14 @@ def _handle_stream(event: dict[str, Any]) -> dict[str, Any]:
             continue
         delegation = _delegation_target(record)
         if delegation:
-            delegation_records.append(
-                (*delegation, record.get("eventID", ""))
+            job_records.append(
+                ("delegation", *delegation, record.get("eventID", ""))
+            )
+            continue
+        research = _research_target(record)
+        if research:
+            job_records.append(
+                ("research", *research, record.get("eventID", ""))
             )
 
     failures = []
@@ -308,12 +381,16 @@ def _handle_stream(event: dict[str, Any]) -> dict[str, Any]:
                 for record_id in grouped["stream_record_ids"]
                 if record_id
             )
-    for user_id, session_id, job_id, record_id in delegation_records:
+    for kind, user_id, session_id, job_id, record_id in job_records:
         try:
-            _enqueue_delegation(user_id, session_id, job_id)
+            if kind == "delegation":
+                _enqueue_delegation(user_id, session_id, job_id)
+            else:
+                _enqueue_research(user_id, session_id, job_id)
         except Exception:
             logger.exception(
-                "Failed to enqueue delegation %s for %s/%s",
+                "Failed to enqueue %s %s for %s/%s",
+                kind,
                 job_id,
                 user_id,
                 session_id,
@@ -332,7 +409,7 @@ def _handle_sqs(event: dict[str, Any]) -> dict[str, Any]:
         try:
             body = json.loads(record["body"])
             kind = str(body.get("kind") or "mailbox")
-            if kind not in {"mailbox", "delegation"}:
+            if kind not in {"mailbox", "delegation", "research"}:
                 raise ValueError(f"Unknown wake kind: {kind}")
             target = (kind, body["userId"], body["sessionId"])
             record["_mailboxEventIds"] = [
@@ -341,8 +418,8 @@ def _handle_sqs(event: dict[str, Any]) -> dict[str, Any]:
                 if event_id
             ]
             record["_delegationJobId"] = str(body.get("jobId") or "")
-            if kind == "delegation" and not record["_delegationJobId"]:
-                raise ValueError("Delegation wake requires jobId")
+            if kind in {"delegation", "research"} and not record["_delegationJobId"]:
+                raise ValueError(f"{kind} wake requires jobId")
         except (KeyError, TypeError, ValueError, json.JSONDecodeError):
             logger.exception("Invalid mailbox wake message %s", message_id)
             if message_id:
@@ -361,6 +438,12 @@ def _handle_sqs(event: dict[str, Any]) -> dict[str, Any]:
                     record["_delegationJobId"] for record in records
                 }):
                     _start_delegation(user_id, session_id, job_id)
+                continue
+            if kind == "research":
+                for job_id in sorted({
+                    record["_delegationJobId"] for record in records
+                }):
+                    _start_research(user_id, session_id, job_id)
                 continue
             event_ids = sorted({
                 event_id
@@ -388,7 +471,7 @@ def _handle_sqs(event: dict[str, Any]) -> dict[str, Any]:
 
 
 def _handle_reconcile() -> dict[str, Any]:
-    """Re-enqueue queued and stale-running delegation jobs."""
+    """Re-enqueue queued and stale-running durable jobs."""
     client = boto3.client("dynamodb")
     table_name = os.environ["ORCHESTRATION_TABLE_NAME"]
     now = datetime.now(timezone.utc)
@@ -408,22 +491,29 @@ def _handle_reconcile() -> dict[str, Any]:
                 "KeyConditionExpression": (
                     "workStatus = :workStatus AND heartbeatAt <= :cutoff"
                 ),
-                "FilterExpression": (
-                    "recordType = :recordType AND desiredState = :running"
-                ),
+                "FilterExpression": "desiredState = :running",
                 "ExpressionAttributeValues": {
                     ":workStatus": {"S": work_status},
                     ":cutoff": {"S": cutoff},
-                    ":recordType": {"S": "DELEGATION_JOB"},
                     ":running": {"S": "running"},
                 },
-                "ProjectionExpression": "userId, sessionId, jobId",
+                "ProjectionExpression": "recordType, userId, sessionId, jobId",
             }
             if exclusive_start_key:
                 parameters["ExclusiveStartKey"] = exclusive_start_key
             response = client.query(**parameters)
             for item in response.get("Items", []):
-                _enqueue_delegation(
+                record_type = item.get("recordType", {}).get("S")
+                enqueue = (
+                    _enqueue_delegation
+                    if record_type == "DELEGATION_JOB"
+                    else _enqueue_research
+                    if record_type == "RESEARCH_JOB"
+                    else None
+                )
+                if enqueue is None:
+                    continue
+                enqueue(
                     item["userId"]["S"],
                     item["sessionId"]["S"],
                     item["jobId"]["S"],

--- a/infra/lambda/session-mailbox-dispatcher/test_lambda_function.py
+++ b/infra/lambda/session-mailbox-dispatcher/test_lambda_function.py
@@ -86,6 +86,31 @@ def delegation_sqs_record(
     return item
 
 
+def research_record(
+    event_id: str,
+    *,
+    job_id: str = "research-1",
+):
+    item = delegation_record(event_id, job_id=job_id)
+    item["dynamodb"]["NewImage"]["recordType"] = {"S": "RESEARCH_JOB"}
+    return item
+
+
+def research_sqs_record(
+    message_id: str,
+    *,
+    job_id: str = "research-1",
+):
+    item = sqs_record(message_id)
+    item["body"] = json.dumps({
+        "kind": "research",
+        "userId": "user-1",
+        "sessionId": "session-1",
+        "jobId": job_id,
+    })
+    return item
+
+
 def test_coalesces_multiple_inserts_for_one_session(monkeypatch):
     enqueue = MagicMock()
     monkeypatch.setattr(lambda_function, "_enqueue_wake", enqueue)
@@ -167,10 +192,37 @@ def test_sqs_worker_starts_delegation(monkeypatch):
     start.assert_called_once_with("user-1", "session-1", "job-1")
 
 
+def test_stream_enqueues_research_job(monkeypatch):
+    enqueue = MagicMock()
+    monkeypatch.setattr(lambda_function, "_enqueue_research", enqueue)
+
+    result = lambda_function.lambda_handler(
+        {"Records": [research_record("stream-1")]},
+        None,
+    )
+
+    assert result == {"batchItemFailures": []}
+    enqueue.assert_called_once_with("user-1", "session-1", "research-1")
+
+
+def test_sqs_worker_starts_research(monkeypatch):
+    start = MagicMock()
+    monkeypatch.setattr(lambda_function, "_start_research", start)
+
+    result = lambda_function.lambda_handler(
+        {"Records": [research_sqs_record("message-1")]},
+        None,
+    )
+
+    assert result == {"batchItemFailures": []}
+    start.assert_called_once_with("user-1", "session-1", "research-1")
+
+
 def test_reconcile_enqueues_queued_and_stale_jobs(monkeypatch):
     query = MagicMock(side_effect=[
         {
             "Items": [{
+                "recordType": {"S": "DELEGATION_JOB"},
                 "userId": {"S": "user-1"},
                 "sessionId": {"S": "session-1"},
                 "jobId": {"S": "queued-job"},
@@ -178,6 +230,7 @@ def test_reconcile_enqueues_queued_and_stale_jobs(monkeypatch):
         },
         {
             "Items": [{
+                "recordType": {"S": "RESEARCH_JOB"},
                 "userId": {"S": "user-1"},
                 "sessionId": {"S": "session-1"},
                 "jobId": {"S": "stale-job"},
@@ -189,8 +242,10 @@ def test_reconcile_enqueues_queued_and_stale_jobs(monkeypatch):
         "client",
         lambda service: MagicMock(query=query),
     )
-    enqueue = MagicMock()
-    monkeypatch.setattr(lambda_function, "_enqueue_delegation", enqueue)
+    delegation = MagicMock()
+    research = MagicMock()
+    monkeypatch.setattr(lambda_function, "_enqueue_delegation", delegation)
+    monkeypatch.setattr(lambda_function, "_enqueue_research", research)
     monkeypatch.setenv("ORCHESTRATION_TABLE_NAME", "orchestration")
 
     result = lambda_function.lambda_handler(
@@ -199,8 +254,8 @@ def test_reconcile_enqueues_queued_and_stale_jobs(monkeypatch):
     )
 
     assert result == {"status": "reconciled", "enqueued": 2}
-    assert enqueue.call_args_list[0].args[-1] == "queued-job"
-    assert enqueue.call_args_list[1].args[-1] == "stale-job"
+    delegation.assert_called_once_with("user-1", "session-1", "queued-job")
+    research.assert_called_once_with("user-1", "session-1", "stale-job")
 
 
 def test_sqs_worker_coalesces_wakes_for_one_session(monkeypatch):


### PR DESCRIPTION
## Summary

- add durable claim, heartbeat, stale takeover, retry, cancellation, and fencing to research jobs
- make mailbox payload serialization safe for DynamoDB `Decimal` values and reconcile recovered delivery states
- fence foreground memory writes with conversation epochs and preserve monotonic replay IDs after buffer truncation
- prevent stale session loads, restore canonical history after expired executions, and serialize async stream cleanup
- extend the mailbox dispatcher to start and reconcile research jobs

## Validation

- backend Ruff: passed
- backend unit: 614 passed
- backend integration: 136 passed, 15 deselected
- frontend type check: passed
- frontend tests: 722 passed
- frontend production build: passed
- mailbox dispatcher: 14 passed
- Terraform format and deployment script syntax: passed

## Deployed E2E

- detached a foreground stream at cursor 3, observed `running`, replayed events 4 through 774 monotonically, and received `RUN_FINISHED`
- verified research `started` receipt through artifact storage, mailbox processing, and `delivered` projection
- verified stale research takeover replaces the execution token, increments attempts, refreshes heartbeat, and delivers once
- verified local tool, Gateway arXiv, and same-session memory roundtrip paths

## Remaining limitation

Foreground execution event buffers remain process-local. Runtime process loss cannot resume an exact mid-stream cursor without a durable event journal; the canonical history fallback prevents the completed response from disappearing.
