### PR TITLE
feat(chat): surface unseen session activity

### DIFF
--- a/chatbot-app/agentcore/src/agent/mailbox.py
+++ b/chatbot-app/agentcore/src/agent/mailbox.py
@@ -577,7 +577,8 @@ class DynamoDBMailboxRepository(MailboxRepository):
                 "SET conversationEpoch = if_not_exists(conversationEpoch, :zero) + :one, "
                 "leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, "
                 "truncatedAt = :updated, updatedAt = :updated "
-                "REMOVE leaseOwner, leaseUntil"
+                "REMOVE leaseOwner, leaseUntil, latestAttentionCursor, "
+                "latestAttentionAt, lastSeenAttentionCursor, lastSeenAttentionAt"
             ),
             ConditionExpression="attribute_not_exists(deletedAt)",
             ExpressionAttributeValues=self._serialize({
@@ -931,8 +932,20 @@ class DynamoDBMailboxRepository(MailboxRepository):
     ) -> bool:
         current = now or utc_now()
         now_epoch = int(current.timestamp())
+        attention_events = [
+            item
+            for item in session_events
+            if item.event_type == "assistant.turn.completed"
+        ]
+        latest_attention = max(
+            attention_events,
+            key=lambda item: _session_event_key(item.created_at, item.event_id),
+            default=None,
+        )
         if len(session_events) > 98:
-            raise ValueError("A mailbox acknowledgement supports at most 98 session events")
+            raise ValueError(
+                "A mailbox acknowledgement supports at most 98 session events"
+            )
         projection_ttl = int(
             (current + timedelta(days=SESSION_EVENT_TTL_DAYS)).timestamp()
         )
@@ -945,10 +958,49 @@ class DynamoDBMailboxRepository(MailboxRepository):
             }
             for item in session_events
         ]
+        state_operation = self._lease_condition(
+            event.user_id,
+            event.session_id,
+            lease,
+            now_epoch,
+        )
+        if latest_attention:
+            state_operation = {
+                "Update": {
+                    "TableName": self.table_name,
+                    "Key": self._key(
+                        event.user_id,
+                        event.session_id,
+                        "STATE",
+                    ),
+                    "UpdateExpression": (
+                        "SET latestAttentionCursor = :cursor, "
+                        "latestAttentionAt = :created_at"
+                    ),
+                    "ConditionExpression": (
+                        "leaseOwner = :owner AND leaseEpoch = :epoch "
+                        "AND leaseUntil >= :now "
+                        "AND conversationEpoch = :conversation_epoch"
+                    ),
+                    "ExpressionAttributeValues": self._serialize({
+                        ":cursor": _session_event_key(
+                            latest_attention.created_at,
+                            latest_attention.event_id,
+                        ),
+                        ":created_at": latest_attention.created_at,
+                        ":owner": lease.owner,
+                        ":epoch": lease.epoch,
+                        ":now": now_epoch,
+                        ":conversation_epoch": int(
+                            getattr(lease, "conversation_epoch", 0)
+                        ),
+                    }),
+                }
+            }
         try:
             self.client.transact_write_items(
                 TransactItems=[
-                    self._lease_condition(event.user_id, event.session_id, lease, now_epoch),
+                    state_operation,
                     {
                         "Update": {
                             "TableName": self.table_name,
@@ -1208,6 +1260,10 @@ class FileMailboxRepository(MailboxRepository):
             state["updatedAt"] = _iso(current)
             state.pop("leaseOwner", None)
             state.pop("leaseUntil", None)
+            state.pop("latestAttentionCursor", None)
+            state.pop("latestAttentionAt", None)
+            state.pop("lastSeenAttentionCursor", None)
+            state.pop("lastSeenAttentionAt", None)
             for record in data["events"].values():
                 if (
                     int(record.get("conversationEpoch", 0))
@@ -1430,6 +1486,24 @@ class FileMailboxRepository(MailboxRepository):
                 data["sessionEvents"][item.event_id] = item.to_record(
                     ttl=projection_ttl
                 )
+            attention_events = [
+                item
+                for item in session_events
+                if item.event_type == "assistant.turn.completed"
+            ]
+            if attention_events:
+                latest_attention = max(
+                    attention_events,
+                    key=lambda item: _session_event_key(
+                        item.created_at,
+                        item.event_id,
+                    ),
+                )
+                data["state"]["latestAttentionCursor"] = _session_event_key(
+                    latest_attention.created_at,
+                    latest_attention.event_id,
+                )
+                data["state"]["latestAttentionAt"] = latest_attention.created_at
             self._save(event.user_id, event.session_id, data)
             return True
 

--- a/chatbot-app/agentcore/tests/unit/test_mailbox.py
+++ b/chatbot-app/agentcore/tests/unit/test_mailbox.py
@@ -295,6 +295,87 @@ def test_acknowledge_atomically_publishes_session_events(tmp_path):
 
     stored = repository.list_session_events("user-1", "session-1")
     assert stored == [projection]
+    state = repository._load("user-1", "session-1")["state"]
+    assert state["latestAttentionCursor"] == (
+        "OUTBOX_V2#2026-08-06T12:00:00+00:00#event-1:assistant"
+    )
+    assert state["latestAttentionAt"] == "2026-08-06T12:00:00+00:00"
+
+
+def test_non_assistant_projection_does_not_create_attention(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+    lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=30, now=NOW
+    )
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW,
+    )
+    projection = SessionEvent.create(
+        event_id="event-1:artifact",
+        event_type="artifact.upserted",
+        session_id="session-1",
+        user_id="user-1",
+        origin_event_id="event-1",
+        now=NOW,
+    )
+
+    assert repository.acknowledge(
+        claimed,
+        lease,
+        session_events=[projection],
+        now=NOW,
+    )
+    state = repository._load("user-1", "session-1")["state"]
+    assert "latestAttentionCursor" not in state
+
+
+def test_truncate_clears_attention_state(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    repository.enqueue(event("event-1"))
+    lease = repository.acquire_lease(
+        "user-1", "session-1", "worker-1", lease_seconds=30, now=NOW
+    )
+    claimed = repository.claim_next(
+        "user-1",
+        "session-1",
+        lease,
+        event_lease_seconds=30,
+        now=NOW,
+    )
+    projection = SessionEvent.create(
+        event_id="event-1:assistant",
+        event_type="assistant.turn.completed",
+        session_id="session-1",
+        user_id="user-1",
+        origin_event_id="event-1",
+        now=NOW,
+    )
+    assert repository.acknowledge(
+        claimed,
+        lease,
+        session_events=[projection],
+        now=NOW,
+    )
+    data = repository._load("user-1", "session-1")
+    data["state"]["lastSeenAttentionCursor"] = data["state"][
+        "latestAttentionCursor"
+    ]
+    repository._save("user-1", "session-1", data)
+
+    repository.advance_conversation_epoch(
+        "user-1",
+        "session-1",
+        now=NOW + timedelta(seconds=1),
+    )
+
+    state = repository._load("user-1", "session-1")["state"]
+    assert "latestAttentionCursor" not in state
+    assert "lastSeenAttentionCursor" not in state
 
 
 def test_retry_then_dead_letter(tmp_path):
@@ -501,6 +582,17 @@ def test_dynamodb_ack_writes_projections_in_fenced_transaction():
 
     transaction = client.transact_write_items.call_args.kwargs["TransactItems"]
     assert len(transaction) == 3
+    state_update = transaction[0]["Update"]
+    assert state_update["Key"] == repository._key(
+        "user-1", "session-1", "STATE"
+    )
+    assert "leaseEpoch = :epoch" in state_update["ConditionExpression"]
+    attention_values = repository._deserialize(
+        state_update["ExpressionAttributeValues"]
+    )
+    assert attention_values[":cursor"] == (
+        "OUTBOX_V2#2026-08-06T12:00:00+00:00#event-1:assistant"
+    )
     stored = repository._deserialize(transaction[2]["Put"]["Item"])
     assert stored["recordKey"] == (
         "OUTBOX_V2#2026-08-06T12:00:00+00:00#event-1:assistant"

--- a/chatbot-app/frontend/__tests__/api/session-attention.test.ts
+++ b/chatbot-app/frontend/__tests__/api/session-attention.test.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  extractUserFromRequest: vi.fn(),
+  getUserSessions: vi.fn(),
+  getSession: vi.fn(),
+  getSessionAttentionStates: vi.fn(),
+  hasUnseenSessionAttention: vi.fn(),
+  markSessionAttentionSeen: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-utils', () => ({
+  extractUserFromRequest: mocks.extractUserFromRequest,
+}))
+
+vi.mock('@/lib/dynamodb-client', () => ({
+  getUserSessions: mocks.getUserSessions,
+  getSession: mocks.getSession,
+}))
+
+vi.mock('@/lib/session-events', () => ({
+  getSessionAttentionStates: mocks.getSessionAttentionStates,
+  hasUnseenSessionAttention: mocks.hasUnseenSessionAttention,
+  markSessionAttentionSeen: mocks.markSessionAttentionSeen,
+}))
+
+describe('session attention API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.extractUserFromRequest.mockResolvedValue({ userId: 'user-1' })
+    mocks.hasUnseenSessionAttention.mockImplementation(
+      state => Boolean(
+        state.latestAttentionCursor &&
+        state.latestAttentionCursor > (state.lastSeenAttentionCursor || ''),
+      ),
+    )
+  })
+
+  it('merges attention state and orders sessions by latest activity', async () => {
+    mocks.getUserSessions.mockResolvedValue([
+      {
+        sessionId: 'session-recent-message',
+        title: 'Recent message',
+        lastMessageAt: '2026-08-11T10:00:00Z',
+        messageCount: 1,
+        status: 'active',
+        createdAt: '2026-08-11T09:00:00Z',
+      },
+      {
+        sessionId: 'session-background',
+        title: 'Background result',
+        lastMessageAt: '2026-08-10T10:00:00Z',
+        messageCount: 1,
+        status: 'active',
+        createdAt: '2026-08-10T09:00:00Z',
+      },
+    ])
+    mocks.getSessionAttentionStates.mockResolvedValue(new Map([
+      ['session-background', {
+        latestAttentionCursor:
+          'OUTBOX_V2#2026-08-11T11:00:00Z#event-1',
+        latestAttentionAt: '2026-08-11T11:00:00Z',
+      }],
+    ]))
+
+    const { GET } = await import('@/app/api/session/list/route')
+    const response = await GET(new NextRequest(
+      'http://localhost/api/session/list?limit=100&status=active',
+    ))
+    const body = await response.json()
+
+    expect(body.sessions.map((session: any) => session.sessionId)).toEqual([
+      'session-background',
+      'session-recent-message',
+    ])
+    expect(body.sessions[0]).toMatchObject({
+      lastActivityAt: '2026-08-11T11:00:00Z',
+      hasUnseenUpdate: true,
+    })
+  })
+
+  it('marks the supplied rendered cursor as seen', async () => {
+    mocks.getSession.mockResolvedValue({
+      sessionId: 'session-1',
+      userId: 'user-1',
+    })
+    const cursor = 'OUTBOX_V2#2026-08-11T11:00:00Z#event-1'
+    const { POST } = await import('@/app/api/session/[sessionId]/seen/route')
+    const request = new NextRequest(
+      'http://localhost/api/session/session-1/seen',
+      {
+        method: 'POST',
+        body: JSON.stringify({ seenThroughCursor: cursor }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )
+
+    const response = await POST(request, {
+      params: Promise.resolve({ sessionId: 'session-1' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.markSessionAttentionSeen).toHaveBeenCalledWith(
+      'user-1',
+      'session-1',
+      cursor,
+    )
+  })
+})

--- a/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatInterface.test.tsx
@@ -4,6 +4,11 @@ import { ChatInterface } from '@/components/ChatInterface'
 import type { Message } from '@/types/chat'
 import type { AgentStatus, TurnPhase } from '@/types/events'
 
+const attentionMocks = vi.hoisted(() => ({
+  events: [] as any[],
+  apiPost: vi.fn(),
+}))
+
 // Type for grouped messages
 interface GroupedMessage {
   type: 'user' | 'assistant_turn'
@@ -46,6 +51,7 @@ const mockUseChat: {
   toggleConciseMode: ReturnType<typeof vi.fn>
   newChat: ReturnType<typeof vi.fn>
   sessionId: string | null
+  isLoadingMessages: boolean
   loadSession: ReturnType<typeof vi.fn>
   browserSession: { sessionId: string | null; browserId: string | null } | null
   browserProgress: any
@@ -86,6 +92,7 @@ const mockUseChat: {
   toggleConciseMode: vi.fn(),
   newChat: vi.fn().mockResolvedValue(undefined),
   sessionId: null,
+  isLoadingMessages: false,
   loadSession: vi.fn().mockResolvedValue(undefined),
   browserSession: null,
   browserProgress: undefined,
@@ -96,6 +103,13 @@ const mockUseChat: {
 
 vi.mock('@/hooks/useChat', () => ({
   useChat: () => mockUseChat
+}))
+
+vi.mock('@/hooks/useSessionEvents', () => ({
+  useSessionEvents: () => ({
+    events: attentionMocks.events,
+    refresh: vi.fn(),
+  }),
 }))
 
 // Mock useIframeAuth
@@ -133,7 +147,12 @@ vi.mock('next-themes', () => ({
 
 // Mock api-client
 vi.mock('@/lib/api-client', () => ({
-  apiGet: vi.fn().mockResolvedValue({ success: true, config: {}, models: [] })
+  apiGet: vi.fn().mockResolvedValue({ success: true, config: {}, models: [] }),
+  apiPost: attentionMocks.apiPost,
+  apiFetch: vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ jobs: [] }),
+  }),
 }))
 
 // Mock child components
@@ -205,6 +224,11 @@ describe('ChatInterface', () => {
     mockUseChat.pendingOAuth = null
     mockUseChat.queuedMessages = []
     mockUseChat.queueHoldReason = null
+    mockUseChat.sessionId = null
+    mockUseChat.isLoadingMessages = false
+    attentionMocks.events = []
+    attentionMocks.apiPost.mockResolvedValue({ success: true })
+    delete (window as any).__refreshSessionList
   })
 
   afterEach(() => {
@@ -287,6 +311,50 @@ describe('ChatInterface', () => {
 
       expect(screen.getByTestId('assistant-turn')).toBeInTheDocument()
       expect(screen.getByText('Hi there!')).toBeInTheDocument()
+    })
+
+    it('marks a durable completion seen only after it is represented', async () => {
+      mockUseChat.sessionId = 'session-1'
+      mockUseChat.groupedMessages = [
+        {
+          type: 'assistant_turn',
+          id: 'turn_1',
+          messages: [{
+            id: '2',
+            text: 'Research completed',
+            sender: 'bot',
+            timestamp: '12:01',
+            originEventId: 'research-result:job-1',
+          }]
+        }
+      ]
+      attentionMocks.events = [{
+        eventId: 'research-result:job-1:assistant',
+        eventType: 'assistant.turn.completed',
+        sessionId: 'session-1',
+        userId: 'user-1',
+        createdAt: '2026-08-11T12:01:00Z',
+        originEventId: 'research-result:job-1',
+        correlation: {},
+        payload: {},
+      }]
+      const refreshSessions = vi.fn()
+      ;(window as any).__refreshSessionList = refreshSessions
+
+      render(<ChatInterface />)
+
+      await waitFor(() => {
+        expect(attentionMocks.apiPost).toHaveBeenCalledWith(
+          'session/session-1/seen',
+          {
+            seenThroughCursor:
+              'OUTBOX_V2#2026-08-11T12:01:00Z#research-result:job-1:assistant',
+          },
+        )
+      })
+      await waitFor(() => {
+        expect(refreshSessions).toHaveBeenCalled()
+      })
     })
   })
 

--- a/chatbot-app/frontend/__tests__/components/ChatSessionList.test.tsx
+++ b/chatbot-app/frontend/__tests__/components/ChatSessionList.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ChatSessionList } from '@/components/sidebar/ChatSessionList'
+import type { ChatSession } from '@/hooks/useChatSessions'
+
+const sessions: ChatSession[] = [
+  {
+    sessionId: 'session-current',
+    title: 'Current session',
+    lastMessageAt: '2099-08-11T10:00:00Z',
+    lastActivityAt: '2099-08-11T10:05:00Z',
+    hasUnseenUpdate: true,
+    messageCount: 2,
+    status: 'active',
+    createdAt: '2099-08-11T09:00:00Z',
+  },
+  {
+    sessionId: 'session-background',
+    title: 'Background session',
+    lastMessageAt: '2099-08-11T09:00:00Z',
+    lastActivityAt: '2099-08-11T10:10:00Z',
+    hasUnseenUpdate: true,
+    messageCount: 3,
+    status: 'active',
+    createdAt: '2099-08-11T08:00:00Z',
+  },
+]
+
+describe('ChatSessionList attention badge', () => {
+  it('shows one minimal marker only for an inactive unseen session', () => {
+    render(
+      <ChatSessionList
+        sessions={sessions}
+        currentSessionId="session-current"
+        isLoading={false}
+        onLoadSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+      />,
+    )
+
+    expect(screen.getAllByRole('status', { name: 'New activity' })).toHaveLength(1)
+  })
+
+  it('loads the session when its row is clicked', () => {
+    const onLoadSession = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ChatSessionList
+        sessions={sessions}
+        currentSessionId="session-current"
+        isLoading={false}
+        onLoadSession={onLoadSession}
+        onDeleteSession={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Background session'))
+
+    expect(onLoadSession).toHaveBeenCalledWith('session-background')
+  })
+})

--- a/chatbot-app/frontend/__tests__/hooks/useChatSessions.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChatSessions.test.ts
@@ -213,6 +213,31 @@ describe('useChatSessions', () => {
       expect(mockApiGet).toHaveBeenCalled()
       expect(result.current.chatSessions[0].title).toBe('Updated Title')
     })
+
+    it('should poll the session list while the page is visible', async () => {
+      vi.useFakeTimers()
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: 'visible',
+      })
+      const { unmount } = renderHook(() => useChatSessions(defaultProps))
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(mockApiGet).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        vi.advanceTimersByTime(10_000)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(mockApiGet).toHaveBeenCalledTimes(2)
+      unmount()
+      vi.useRealTimers()
+    })
   })
 
   describe('Deleting Sessions', () => {

--- a/chatbot-app/frontend/__tests__/lib/session-attention.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/session-attention.test.ts
@@ -1,0 +1,90 @@
+import {
+  BatchGetItemCommand,
+  DynamoDBClient,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('session attention state', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('detects only cursors newer than the last seen cursor', async () => {
+    const { hasUnseenSessionAttention } = await import('@/lib/session-events')
+
+    expect(hasUnseenSessionAttention({})).toBe(false)
+    expect(hasUnseenSessionAttention({
+      latestAttentionCursor: 'OUTBOX_V2#2026-08-11T10:00:00Z#event-1',
+    })).toBe(true)
+    expect(hasUnseenSessionAttention({
+      latestAttentionCursor: 'OUTBOX_V2#2026-08-11T10:00:00Z#event-1',
+      lastSeenAttentionCursor: 'OUTBOX_V2#2026-08-11T10:00:00Z#event-1',
+    })).toBe(false)
+  })
+
+  it('batch loads attention state for the requested sessions', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
+    vi.stubEnv('SESSION_ORCHESTRATION_TABLE', 'orchestration-table')
+    const send = vi
+      .spyOn(DynamoDBClient.prototype, 'send')
+      .mockImplementation(async command => {
+        expect(command).toBeInstanceOf(BatchGetItemCommand)
+        return {
+          Responses: {
+            'orchestration-table': [
+              marshall({
+                sessionKey: 'USER#user-1#SESSION#session-1',
+                latestAttentionCursor:
+                  'OUTBOX_V2#2026-08-11T10:00:00Z#event-1',
+                latestAttentionAt: '2026-08-11T10:00:00Z',
+              }),
+            ],
+          },
+        }
+      })
+
+    const { getSessionAttentionStates } = await import('@/lib/session-events')
+    const states = await getSessionAttentionStates(
+      'user-1',
+      ['session-1', 'session-2'],
+    )
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(states.get('session-1')).toEqual({
+      latestAttentionCursor: 'OUTBOX_V2#2026-08-11T10:00:00Z#event-1',
+      latestAttentionAt: '2026-08-11T10:00:00Z',
+      lastSeenAttentionCursor: undefined,
+      lastSeenAttentionAt: undefined,
+    })
+    expect(states.get('session-2')).toEqual({})
+  })
+
+  it('marks only the represented attention cursor as seen', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
+    vi.stubEnv('SESSION_ORCHESTRATION_TABLE', 'orchestration-table')
+    const send = vi
+      .spyOn(DynamoDBClient.prototype, 'send')
+      .mockImplementation(async () => ({} as any))
+
+    const { markSessionAttentionSeen } = await import('@/lib/session-events')
+    await markSessionAttentionSeen(
+      'user-1',
+      'session-1',
+      'OUTBOX_V2#2026-08-11T10:00:00Z#event-1',
+    )
+
+    const command = send.mock.calls[0][0]
+    expect(command).toBeInstanceOf(UpdateItemCommand)
+    const input = (command as UpdateItemCommand).input
+    expect(input.ConditionExpression).toContain(
+      'latestAttentionCursor >= :cursor',
+    )
+    expect(input.ConditionExpression).toContain(
+      'lastSeenAttentionCursor < :cursor',
+    )
+  })
+})

--- a/chatbot-app/frontend/src/app/api/session/[sessionId]/seen/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/[sessionId]/seen/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { extractUserFromRequest } from '@/lib/auth-utils'
+import { markSessionAttentionSeen } from '@/lib/session-events'
+
+const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
+
+export const runtime = 'nodejs'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    const { sessionId } = await params
+    const user = await extractUserFromRequest(request)
+    const body = await request.json()
+    const seenThroughCursor = body?.seenThroughCursor
+
+    if (
+      !sessionId ||
+      typeof seenThroughCursor !== 'string' ||
+      !seenThroughCursor.startsWith('OUTBOX_V2#')
+    ) {
+      return NextResponse.json(
+        { success: false, error: 'A valid seenThroughCursor is required' },
+        { status: 400 },
+      )
+    }
+
+    let session = null
+    if (IS_LOCAL) {
+      const { getSession } = await import('@/lib/local-session-store')
+      session = getSession(user.userId, sessionId)
+    } else if (user.userId !== 'anonymous') {
+      const { getSession } = await import('@/lib/dynamodb-client')
+      session = await getSession(user.userId, sessionId)
+    }
+    if (!session) {
+      return NextResponse.json(
+        { success: false, error: 'Session not found' },
+        { status: 404 },
+      )
+    }
+
+    await markSessionAttentionSeen(
+      user.userId,
+      sessionId,
+      seenThroughCursor,
+    )
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('[SessionAttention] Failed to mark session seen:', error)
+    return NextResponse.json(
+      { success: false, error: 'Failed to update session attention' },
+      { status: 500 },
+    )
+  }
+}

--- a/chatbot-app/frontend/src/app/api/session/list/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/list/route.ts
@@ -4,6 +4,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { extractUserFromRequest } from '@/lib/auth-utils'
 import { getUserSessions } from '@/lib/dynamodb-client'
+import {
+  getSessionAttentionStates,
+  hasUnseenSessionAttention,
+} from '@/lib/session-events'
 
 // Check if running in local development mode
 const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
@@ -18,7 +22,10 @@ export async function GET(request: NextRequest) {
 
     // Get query parameters
     const searchParams = request.nextUrl.searchParams
-    const limit = parseInt(searchParams.get('limit') || '20')
+    const requestedLimit = parseInt(searchParams.get('limit') || '20')
+    const limit = Number.isFinite(requestedLimit)
+      ? Math.min(Math.max(requestedLimit, 1), 100)
+      : 20
     const status = searchParams.get('status') as 'active' | 'archived' | 'deleted' | undefined
 
     console.log(`[API] Loading sessions for user ${userId}, limit: ${limit}, status: ${status || 'all'}`)
@@ -29,7 +36,7 @@ export async function GET(request: NextRequest) {
       // Anonymous user - load from local file storage
       if (IS_LOCAL) {
         const { getUserSessions: getLocalSessions } = await import('@/lib/local-session-store')
-        sessions = getLocalSessions(userId, limit, status)
+        sessions = getLocalSessions(userId, 100, status)
         console.log(`[API] Loaded ${sessions.length} sessions from local file for anonymous user`)
       } else {
         // AWS: Anonymous users don't persist sessions
@@ -40,27 +47,53 @@ export async function GET(request: NextRequest) {
       // Authenticated user - load from DynamoDB (AWS) or local file (local)
       if (IS_LOCAL) {
         const { getUserSessions: getLocalSessions } = await import('@/lib/local-session-store')
-        sessions = getLocalSessions(userId, limit, status)
+        sessions = getLocalSessions(userId, 100, status)
         console.log(`[API] Loaded ${sessions.length} sessions from local file for user ${userId}`)
       } else {
         // AWS: Load from DynamoDB
-        sessions = await getUserSessions(userId, limit, status)
+        sessions = await getUserSessions(userId, 100, status)
         console.log(`[API] Loaded ${sessions.length} sessions from DynamoDB for user ${userId}`)
       }
     }
 
+    let attentionStates = new Map()
+    try {
+      attentionStates = await getSessionAttentionStates(
+        userId,
+        sessions.map(session => session.sessionId),
+      )
+    } catch (error) {
+      console.warn('[API] Failed to load session attention state:', error)
+    }
+    const projectedSessions = sessions.map((session) => {
+      const attention = attentionStates.get(session.sessionId) || {}
+      const lastActivityAt =
+        attention.latestAttentionAt &&
+        Date.parse(attention.latestAttentionAt) > Date.parse(session.lastMessageAt)
+          ? attention.latestAttentionAt
+          : session.lastMessageAt
+      return {
+        sessionId: session.sessionId,
+        title: session.title,
+        lastMessageAt: session.lastMessageAt,
+        lastActivityAt,
+        latestAttentionCursor: attention.latestAttentionCursor,
+        lastSeenAttentionCursor: attention.lastSeenAttentionCursor,
+        hasUnseenUpdate: hasUnseenSessionAttention(attention),
+        messageCount: session.messageCount,
+        starred: session.starred || false,
+        status: session.status,
+        createdAt: session.createdAt,
+        tags: session.tags || [],
+      }
+    })
+    projectedSessions.sort((left, right) =>
+      Date.parse(right.lastActivityAt) - Date.parse(left.lastActivityAt),
+    )
+
     return NextResponse.json({
       success: true,
-      sessions: sessions.map((s) => ({
-        sessionId: s.sessionId,
-        title: s.title,
-        lastMessageAt: s.lastMessageAt,
-        messageCount: s.messageCount,
-        starred: s.starred || false,
-        status: s.status,
-        createdAt: s.createdAt,
-        tags: s.tags || [],
-      })),
+      sessions: projectedSessions.slice(0, limit),
     })
   } catch (error) {
     console.error('[API] Error loading sessions:', error)

--- a/chatbot-app/frontend/src/components/ChatInterface.tsx
+++ b/chatbot-app/frontend/src/components/ChatInterface.tsx
@@ -33,6 +33,8 @@ import type { WorkspaceAttachment } from "@/types/chat"
 import { useTheme } from "next-themes"
 import { useVoiceIntegration } from "@/hooks/useVoiceIntegration"
 import { TurnActivityIndicator } from "@/components/chat/TurnActivityIndicator"
+import { apiPost } from "@/lib/api-client"
+import { sessionEventCursor } from "@/lib/session-event-cursor"
 
 
 // Custom throttle hook
@@ -68,10 +70,22 @@ export function ChatInterface() {
   const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
   const [isMobileView, setIsMobileView] = useState(false)
+  const [isPageVisible, setIsPageVisible] = useState(true)
 
   // Prevent hydration mismatch by only rendering theme-dependent UI after mount
   useEffect(() => {
     setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    const updateVisibility = () => {
+      setIsPageVisible(document.visibilityState === 'visible')
+    }
+    updateVisibility()
+    document.addEventListener('visibilitychange', updateVisibility)
+    return () => {
+      document.removeEventListener('visibilitychange', updateVisibility)
+    }
   }, [])
 
   // Detect mobile viewport
@@ -292,10 +306,16 @@ export function ChatInterface() {
   }, [groupedMessages])
   const reloadedDeliveriesRef = useRef<Set<string>>(new Set())
   const researchArtifactVersionsRef = useRef<Map<string, string>>(new Map())
+  const acknowledgedAttentionRef = useRef<string | null>(null)
+  const attentionRequestRef = useRef<string | null>(null)
+  const activeSessionIdRef = useRef(sessionId)
+  activeSessionIdRef.current = sessionId
 
   useEffect(() => {
     reloadedDeliveriesRef.current.clear()
     researchArtifactVersionsRef.current.clear()
+    acknowledgedAttentionRef.current = null
+    attentionRequestRef.current = null
   }, [sessionId])
 
   // A completed report is readable from the durable job store even before the
@@ -370,6 +390,60 @@ export function ChatInterface() {
     representedOriginEventIds,
     replayExecution,
     sessionEvents,
+  ])
+
+  const renderedAttentionCursor = useMemo(() => {
+    let latest: string | null = null
+    for (const event of sessionEvents) {
+      if (
+        event.eventType !== 'assistant.turn.completed' ||
+        !representedOriginEventIds.has(event.originEventId)
+      ) {
+        continue
+      }
+      const cursor = sessionEventCursor(event)
+      if (!latest || cursor > latest) latest = cursor
+    }
+    return latest
+  }, [representedOriginEventIds, sessionEvents])
+
+  useEffect(() => {
+    if (
+      !sessionId ||
+      !renderedAttentionCursor ||
+      isLoadingMessages ||
+      !isPageVisible ||
+      (acknowledgedAttentionRef.current &&
+        acknowledgedAttentionRef.current >= renderedAttentionCursor) ||
+      attentionRequestRef.current === renderedAttentionCursor
+    ) {
+      return
+    }
+
+    const requestedSessionId = sessionId
+    const requestedCursor = renderedAttentionCursor
+    attentionRequestRef.current = requestedCursor
+    void apiPost(
+      `session/${encodeURIComponent(requestedSessionId)}/seen`,
+      { seenThroughCursor: requestedCursor },
+    ).then(() => {
+      if (activeSessionIdRef.current !== requestedSessionId) return
+      acknowledgedAttentionRef.current = requestedCursor
+      if (typeof (window as any).__refreshSessionList === 'function') {
+        void (window as any).__refreshSessionList()
+      }
+    }).catch((error) => {
+      console.warn('[ChatInterface] Failed to mark session activity seen:', error)
+    }).finally(() => {
+      if (attentionRequestRef.current === requestedCursor) {
+        attentionRequestRef.current = null
+      }
+    })
+  }, [
+    isLoadingMessages,
+    isPageVisible,
+    renderedAttentionCursor,
+    sessionId,
   ])
 
   // Keep reloadFromStorage ref in sync for the onSessionLoaded callback

--- a/chatbot-app/frontend/src/components/sidebar/ChatSessionList.tsx
+++ b/chatbot-app/frontend/src/components/sidebar/ChatSessionList.tsx
@@ -42,7 +42,9 @@ function groupSessionsByDate(sessions: ChatSession[]): DateGroup[] {
   };
 
   for (const session of sessions) {
-    const date = new Date(session.lastMessageAt || session.createdAt);
+    const date = new Date(
+      session.lastActivityAt || session.lastMessageAt || session.createdAt,
+    );
     if (date >= today) {
       groups['Today'].push(session);
     } else if (date >= yesterday) {
@@ -119,6 +121,8 @@ export function ChatSessionList({
             <div className="space-y-1">
               {group.sessions.map((session) => {
                 const isCurrentSession = session.sessionId === currentSessionId;
+                const showUnseen =
+                  session.hasUnseenUpdate === true && !isCurrentSession;
                 const { display, isTruncated } = truncateTitle(session.title);
 
                 const row = (
@@ -135,13 +139,26 @@ export function ChatSessionList({
                     <span className="text-[13px] text-sidebar-foreground leading-snug flex-1 min-w-0">
                       {display}
                     </span>
-                    <button
-                      onClick={(e) => handleDeleteSession(session.sessionId, e)}
-                      className="opacity-0 group-hover/session:opacity-100 transition-opacity p-1 rounded-sm hover:bg-destructive/10 text-sidebar-foreground/40 hover:text-destructive flex-shrink-0"
-                      title="Delete"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
+                    <span className="relative h-5 w-5 flex-shrink-0">
+                      {showUnseen && (
+                        <span
+                          className="absolute inset-0 flex items-center justify-center opacity-100 group-hover/session:opacity-0 transition-opacity"
+                          role="status"
+                          aria-label="New activity"
+                          title="New activity"
+                        >
+                          <span className="h-1.5 w-1.5 rounded-full bg-sky-500 dark:bg-sky-400" />
+                        </span>
+                      )}
+                      <button
+                        onClick={(e) => handleDeleteSession(session.sessionId, e)}
+                        className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/session:opacity-100 transition-opacity rounded-sm hover:bg-destructive/10 text-sidebar-foreground/40 hover:text-destructive"
+                        title="Delete"
+                        aria-label={`Delete ${session.title}`}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </span>
                   </div>
                 );
 

--- a/chatbot-app/frontend/src/hooks/useChatSessions.ts
+++ b/chatbot-app/frontend/src/hooks/useChatSessions.ts
@@ -1,10 +1,16 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { apiGet, apiDelete } from '@/lib/api-client';
+
+const SESSION_POLL_INTERVAL_MS = 10_000;
 
 export interface ChatSession {
   sessionId: string;
   title: string;
   lastMessageAt: string;
+  lastActivityAt?: string;
+  latestAttentionCursor?: string;
+  lastSeenAttentionCursor?: string;
+  hasUnseenUpdate?: boolean;
   messageCount: number;
   starred?: boolean;
   status: string;
@@ -20,10 +26,15 @@ interface UseChatSessionsProps {
 export function useChatSessions({ sessionId, onNewChat }: UseChatSessionsProps) {
   const [chatSessions, setChatSessions] = useState<ChatSession[]>([]);
   const [isLoadingSessions, setIsLoadingSessions] = useState(false);
+  const hasLoadedRef = useRef(false);
+  const isRefreshingRef = useRef(false);
 
   // Load chat sessions
   const loadSessions = useCallback(async () => {
-    setIsLoadingSessions(true);
+    if (isRefreshingRef.current) return;
+    isRefreshingRef.current = true;
+    const showLoading = !hasLoadedRef.current;
+    if (showLoading) setIsLoadingSessions(true);
     try {
       const data = await apiGet<{ success: boolean; sessions: ChatSession[] }>(
         'session/list?limit=100&status=active'
@@ -35,9 +46,11 @@ export function useChatSessions({ sessionId, onNewChat }: UseChatSessionsProps) 
     } catch (error) {
       console.error('Failed to load chat sessions:', error);
     } finally {
-      setIsLoadingSessions(false);
+      hasLoadedRef.current = true;
+      isRefreshingRef.current = false;
+      if (showLoading) setIsLoadingSessions(false);
     }
-  }, [sessionId]);
+  }, []);
 
   // Delete a session
   const deleteSession = useCallback(async (sessionIdToDelete: string) => {
@@ -111,7 +124,26 @@ export function useChatSessions({ sessionId, onNewChat }: UseChatSessionsProps) 
 
   // Load sessions on mount and when sessionId changes
   useEffect(() => {
-    loadSessions();
+    void loadSessions();
+  }, [loadSessions, sessionId]);
+
+  useEffect(() => {
+    const refreshIfVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void loadSessions();
+      }
+    };
+    const interval = window.setInterval(
+      refreshIfVisible,
+      SESSION_POLL_INTERVAL_MS,
+    );
+    document.addEventListener('visibilitychange', refreshIfVisible);
+    window.addEventListener('focus', refreshIfVisible);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', refreshIfVisible);
+      window.removeEventListener('focus', refreshIfVisible);
+    };
   }, [loadSessions]);
 
   // Expose loadSessions globally for external refresh

--- a/chatbot-app/frontend/src/lib/session-event-cursor.ts
+++ b/chatbot-app/frontend/src/lib/session-event-cursor.ts
@@ -1,0 +1,8 @@
+export const SESSION_EVENT_CURSOR_PREFIX = 'OUTBOX_V2#'
+
+export function sessionEventCursor(event: {
+  createdAt: string
+  eventId: string
+}): string {
+  return `${SESSION_EVENT_CURSOR_PREFIX}${event.createdAt}#${event.eventId}`
+}

--- a/chatbot-app/frontend/src/lib/session-events.ts
+++ b/chatbot-app/frontend/src/lib/session-events.ts
@@ -1,18 +1,24 @@
 import fs from 'fs'
 import path from 'path'
-import { createHash } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import {
+  BatchGetItemCommand,
   DynamoDBClient,
   GetItemCommand,
   QueryCommand,
+  UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
-import { unmarshall } from '@aws-sdk/util-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import {
+  SESSION_EVENT_CURSOR_PREFIX,
+  sessionEventCursor,
+} from '@/lib/session-event-cursor'
 
 const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 const AWS_REGION =
   process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
 const TABLE_NAME = process.env.SESSION_ORCHESTRATION_TABLE || ''
-const STREAM_PREFIX = 'OUTBOX_V2#'
+const STREAM_PREFIX = SESSION_EVENT_CURSOR_PREFIX
 const LEGACY_PREFIX = 'OUTBOX#'
 const PAGE_SIZE = 100
 
@@ -36,6 +42,13 @@ export interface SessionEventPage {
   hasMore: boolean
 }
 
+export interface SessionAttentionState {
+  latestAttentionCursor?: string
+  latestAttentionAt?: string
+  lastSeenAttentionCursor?: string
+  lastSeenAttentionAt?: string
+}
+
 function sessionKey(userId: string, sessionId: string): string {
   return `USER#${userId}#SESSION#${sessionId}`
 }
@@ -52,10 +65,6 @@ function localMailboxPath(userId: string, sessionId: string): string {
     'mailbox',
     `${digest}.json`,
   )
-}
-
-function projectionCursor(event: SessionEventProjection): string {
-  return `${STREAM_PREFIX}${event.createdAt}#${event.eventId}`
 }
 
 function readLocalPage(
@@ -90,21 +99,21 @@ function readLocalPage(
     )
     const page = sorted
       .filter(event =>
-        !effectiveCursor || projectionCursor(event) > effectiveCursor,
+        !effectiveCursor || sessionEventCursor(event) > effectiveCursor,
       )
       .slice(0, PAGE_SIZE)
     return {
       events: page,
       cursor:
         page.length > 0
-          ? projectionCursor(page[page.length - 1])
+          ? sessionEventCursor(page[page.length - 1])
           : effectiveCursor || STREAM_PREFIX,
       conversationEpoch,
       hasMore:
         sorted.some(event =>
-          projectionCursor(event) >
+          sessionEventCursor(event) >
           (page.length > 0
-            ? projectionCursor(page[page.length - 1])
+            ? sessionEventCursor(page[page.length - 1])
             : effectiveCursor || STREAM_PREFIX),
         ),
     }
@@ -249,7 +258,7 @@ async function readCloudPage(
     events,
     cursor:
       lastStreamEvent
-        ? projectionCursor(lastStreamEvent)
+        ? sessionEventCursor(lastStreamEvent)
         : effectiveCursor || STREAM_PREFIX,
     conversationEpoch,
     hasMore: Boolean(streamPage.lastKey),
@@ -277,4 +286,161 @@ export async function listSessionEvents(
         options.cursor,
         options.knownEpoch,
       )
+}
+
+function attentionStateFromRecord(
+  record: Record<string, any> | undefined,
+): SessionAttentionState {
+  if (!record) return {}
+  return {
+    latestAttentionCursor:
+      typeof record.latestAttentionCursor === 'string'
+        ? record.latestAttentionCursor
+        : undefined,
+    latestAttentionAt:
+      typeof record.latestAttentionAt === 'string'
+        ? record.latestAttentionAt
+        : undefined,
+    lastSeenAttentionCursor:
+      typeof record.lastSeenAttentionCursor === 'string'
+        ? record.lastSeenAttentionCursor
+        : undefined,
+    lastSeenAttentionAt:
+      typeof record.lastSeenAttentionAt === 'string'
+        ? record.lastSeenAttentionAt
+        : undefined,
+  }
+}
+
+export function hasUnseenSessionAttention(
+  state: SessionAttentionState,
+): boolean {
+  return Boolean(
+    state.latestAttentionCursor &&
+    state.latestAttentionCursor >
+      (state.lastSeenAttentionCursor || STREAM_PREFIX),
+  )
+}
+
+export async function getSessionAttentionStates(
+  userId: string,
+  sessionIds: string[],
+): Promise<Map<string, SessionAttentionState>> {
+  const result = new Map<string, SessionAttentionState>()
+  if (sessionIds.length === 0) return result
+
+  if (IS_LOCAL || userId === 'anonymous') {
+    for (const sessionId of sessionIds) {
+      const targetPath = localMailboxPath(userId, sessionId)
+      if (!fs.existsSync(targetPath)) {
+        result.set(sessionId, {})
+        continue
+      }
+      try {
+        const data = JSON.parse(fs.readFileSync(targetPath, 'utf-8'))
+        result.set(sessionId, attentionStateFromRecord(data.state))
+      } catch {
+        result.set(sessionId, {})
+      }
+    }
+    return result
+  }
+
+  if (!TABLE_NAME) {
+    sessionIds.forEach(sessionId => result.set(sessionId, {}))
+    return result
+  }
+
+  const client = new DynamoDBClient({ region: AWS_REGION })
+  let pendingKeys = sessionIds.map(sessionId => marshall({
+    sessionKey: sessionKey(userId, sessionId),
+    recordKey: 'STATE',
+  }))
+  let attempts = 0
+  while (pendingKeys.length > 0 && attempts < 3) {
+    attempts += 1
+    const response = await client.send(new BatchGetItemCommand({
+      RequestItems: {
+        [TABLE_NAME]: {
+          Keys: pendingKeys,
+          ConsistentRead: true,
+          ProjectionExpression:
+            'sessionKey, latestAttentionCursor, latestAttentionAt, ' +
+            'lastSeenAttentionCursor, lastSeenAttentionAt',
+        },
+      },
+    }))
+    for (const raw of response.Responses?.[TABLE_NAME] || []) {
+      const record = unmarshall(raw)
+      const prefix = `USER#${userId}#SESSION#`
+      const id = String(record.sessionKey || '').startsWith(prefix)
+        ? String(record.sessionKey).slice(prefix.length)
+        : ''
+      if (id) result.set(id, attentionStateFromRecord(record))
+    }
+    pendingKeys = response.UnprocessedKeys?.[TABLE_NAME]?.Keys || []
+  }
+  sessionIds.forEach(sessionId => {
+    if (!result.has(sessionId)) result.set(sessionId, {})
+  })
+  return result
+}
+
+export async function markSessionAttentionSeen(
+  userId: string,
+  sessionId: string,
+  seenThroughCursor: string,
+): Promise<void> {
+  if (!seenThroughCursor.startsWith(STREAM_PREFIX)) {
+    throw new Error('Invalid session attention cursor')
+  }
+  const seenAt = new Date().toISOString()
+
+  if (IS_LOCAL || userId === 'anonymous') {
+    const targetPath = localMailboxPath(userId, sessionId)
+    if (!fs.existsSync(targetPath)) return
+    const data = JSON.parse(fs.readFileSync(targetPath, 'utf-8'))
+    const state = data.state || {}
+    const latest = state.latestAttentionCursor
+    const previous = state.lastSeenAttentionCursor || STREAM_PREFIX
+    if (
+      typeof latest !== 'string' ||
+      latest < seenThroughCursor ||
+      previous >= seenThroughCursor ||
+      state.deletedAt
+    ) {
+      return
+    }
+    state.lastSeenAttentionCursor = seenThroughCursor
+    state.lastSeenAttentionAt = seenAt
+    data.state = state
+    const temporaryPath = `${targetPath}.${randomUUID()}.tmp`
+    fs.writeFileSync(temporaryPath, JSON.stringify(data, null, 2))
+    fs.renameSync(temporaryPath, targetPath)
+    return
+  }
+
+  if (!TABLE_NAME) return
+  const client = new DynamoDBClient({ region: AWS_REGION })
+  try {
+    await client.send(new UpdateItemCommand({
+      TableName: TABLE_NAME,
+      Key: marshall({
+        sessionKey: sessionKey(userId, sessionId),
+        recordKey: 'STATE',
+      }),
+      UpdateExpression:
+        'SET lastSeenAttentionCursor = :cursor, lastSeenAttentionAt = :seenAt',
+      ConditionExpression:
+        'attribute_not_exists(deletedAt) AND latestAttentionCursor >= :cursor ' +
+        'AND (attribute_not_exists(lastSeenAttentionCursor) ' +
+        'OR lastSeenAttentionCursor < :cursor)',
+      ExpressionAttributeValues: marshall({
+        ':cursor': seenThroughCursor,
+        ':seenAt': seenAt,
+      }),
+    }))
+  } catch (error: any) {
+    if (error?.name !== 'ConditionalCheckFailedException') throw error
+  }
 }

--- a/chatbot-app/frontend/src/lib/session-lifecycle.ts
+++ b/chatbot-app/frontend/src/lib/session-lifecycle.ts
@@ -87,6 +87,10 @@ function advanceLocalConversationEpoch(
   }
   delete data.state.leaseOwner
   delete data.state.leaseUntil
+  delete data.state.latestAttentionCursor
+  delete data.state.latestAttentionAt
+  delete data.state.lastSeenAttentionCursor
+  delete data.state.lastSeenAttentionAt
 
   const terminalTtl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
   for (const event of Object.values(data.events || {}) as Record<string, any>[]) {
@@ -300,7 +304,8 @@ export async function advanceSessionConversationEpoch(
       'SET conversationEpoch = if_not_exists(conversationEpoch, :zero) + :one, ' +
       'leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, ' +
       'truncatedAt = :updated, updatedAt = :updated ' +
-      'REMOVE leaseOwner, leaseUntil',
+      'REMOVE leaseOwner, leaseUntil, latestAttentionCursor, ' +
+      'latestAttentionAt, lastSeenAttentionCursor, lastSeenAttentionAt',
     ConditionExpression: 'attribute_not_exists(deletedAt)',
     ExpressionAttributeValues: marshall({
       ':zero': 0,


### PR DESCRIPTION
## Summary
- persist durable attention cursors when asynchronous assistant completions are committed
- expose unseen activity in the session list, poll it in the sidebar, and mark it seen only after the result is rendered
- show a minimal activity dot for inactive sessions and reset attention state on truncate

## Validation
- `npm test` (59 files, 731 tests)
- `npm run type-check`
- `pytest tests/unit/test_mailbox.py -q` (21 passed)
- dev deployment: frontend ECS revision 72, orchestrator v52, general subagent v11
- dev E2E: real research job reached `delivered`, session became `hasUnseenUpdate: true`, then cleared after the seen API call