### PR TITLE
fix(chat): harden AG-UI compatibility and execution security

### DIFF
--- a/chatbot-app/agentcore/src/a2a_tools.py
+++ b/chatbot-app/agentcore/src/a2a_tools.py
@@ -406,11 +406,6 @@ def create_a2a_tool(agent_id: str):
 
             _auth_token = tool_context.invocation_state.get("auth_token")
 
-        if not session_id:
-            session_id = os.environ.get('SESSION_ID')
-        if not user_id:
-            user_id = os.environ.get('USER_ID')
-
         return session_id, user_id, model_id, _auth_token
 
     # Generate correct tool name BEFORE creating function

--- a/chatbot-app/agentcore/src/builtin_tools/nova_act_browser_tools.py
+++ b/chatbot-app/agentcore/src/builtin_tools/nova_act_browser_tools.py
@@ -3,7 +3,6 @@ Browser automation tools using AgentCore Browser + Nova Act.
 Each tool returns a screenshot to show current browser state.
 """
 
-import os
 import logging
 from typing import Dict, Any, Optional, List
 from strands import tool, ToolContext
@@ -588,8 +587,9 @@ def browser_save_screenshot(filename: str, tool_context: ToolContext) -> Dict[st
         else:
             raise ValueError("session_id not found in ToolContext")
 
-        # Get user_id (from environment or agent config)
-        user_id = os.environ.get('USER_ID', 'default_user')
+        user_id = tool_context.invocation_state.get("user_id")
+        if not user_id:
+            raise ValueError("user_id not found in ToolContext")
 
         # Get current browser controller
         controller = get_or_create_controller(session_id)

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -43,6 +43,138 @@ _WORKSPACE_UPLOAD_PATH = re.compile(
 )
 
 router = APIRouter(tags=["chat"])
+MAX_AGUI_REQUEST_BYTES = int(
+    os.environ.get("AGUI_MAX_REQUEST_BYTES", 20 * 1024 * 1024)
+)
+
+
+def _is_local_environment() -> bool:
+    return os.environ.get("ENVIRONMENT", "development").lower() in {
+        "development",
+        "local",
+        "test",
+    }
+
+
+def _decode_runtime_jwt_claims(http_request: Request) -> Optional[dict]:
+    """Decode claims from a JWT already verified by AgentCore Runtime."""
+    authorization = http_request.headers.get("authorization", "")
+    if not authorization.lower().startswith("bearer "):
+        return None
+
+    token = authorization.split(" ", 1)[1]
+    try:
+        encoded_payload = token.split(".")[1]
+        encoded_payload += "=" * (-len(encoded_payload) % 4)
+        claims = json.loads(
+            base64.urlsafe_b64decode(encoded_payload.encode("ascii"))
+        )
+    except (IndexError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        raise HTTPException(status_code=401, detail="Invalid bearer token")
+
+    expires_at = claims.get("exp")
+    if isinstance(expires_at, (int, float)) and expires_at <= time.time():
+        raise HTTPException(status_code=401, detail="Bearer token has expired")
+    return claims
+
+
+def _resolve_user_id(
+    http_request: Request,
+    claimed_user_id: object = None,
+    *,
+    allow_local_unauthenticated: bool = False,
+) -> Optional[str]:
+    """Resolve application identity from the Runtime-verified JWT subject."""
+    claimed = str(claimed_user_id or "").strip()
+    claims = _decode_runtime_jwt_claims(http_request)
+    if claims is None:
+        if not _is_local_environment():
+            raise HTTPException(status_code=401, detail="Authentication required")
+        if allow_local_unauthenticated and not claimed:
+            return None
+        return claimed or "anonymous"
+
+    subject = claims.get("sub")
+    if not isinstance(subject, str) or not subject:
+        expected_m2m_client = os.environ.get("M2M_CLIENT_ID")
+        if (
+            expected_m2m_client
+            and claims.get("client_id") == expected_m2m_client
+            and claimed
+        ):
+            return claimed
+        raise HTTPException(status_code=401, detail="Bearer token subject is required")
+    if claimed and claimed != subject:
+        raise HTTPException(status_code=403, detail="User identity mismatch")
+    return subject
+
+
+def _normalize_agui_input(raw_body: object) -> dict:
+    """Accept standard camelCase AG-UI input during the legacy transition."""
+    if not isinstance(raw_body, dict):
+        raise HTTPException(status_code=400, detail="JSON object required")
+
+    body = dict(raw_body)
+    for camel_case, snake_case in (
+        ("threadId", "thread_id"),
+        ("runId", "run_id"),
+        ("forwardedProps", "forwarded_props"),
+    ):
+        if snake_case not in body and camel_case in body:
+            body[snake_case] = body[camel_case]
+    return body
+
+
+def _validate_agui_input_limits(body: dict) -> None:
+    encoded_size = len(
+        json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    )
+    if encoded_size > MAX_AGUI_REQUEST_BYTES:
+        raise HTTPException(status_code=413, detail="AG-UI request is too large")
+
+    for field_name in ("thread_id", "run_id"):
+        value = body.get(field_name)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{field_name} must be a non-empty string",
+            )
+        max_length = 256 if field_name == "thread_id" else 128
+        if len(value) > max_length or any(ord(char) < 32 for char in value):
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid {field_name}",
+            )
+
+    for field_name, max_items in (
+        ("messages", 500),
+        ("tools", 100),
+        ("context", 100),
+        ("resume", 100),
+    ):
+        value = body.get(field_name)
+        if value is not None and (
+            not isinstance(value, list)
+            or len(value) > max_items
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid {field_name}",
+            )
+
+
+def _execution_belongs_to(
+    execution,
+    user_id: Optional[str],
+    thread_id: Optional[str] = None,
+) -> bool:
+    if user_id is not None and execution.user_id != user_id:
+        return False
+    if thread_id and execution.session_id != thread_id:
+        return False
+    return True
 
 
 def _workspace_attachment_prompt(raw_paths: object) -> Optional[str]:
@@ -204,14 +336,21 @@ def _inject_event_id(data: str, event_id: int) -> str:
 
 def _extract_event_type(sse_chunk: str) -> str:
     """Extract event type from an SSE data chunk for logging/tracking."""
+    event_types = _extract_event_types(sse_chunk)
+    return event_types[0] if event_types else "unknown"
+
+
+def _extract_event_types(sse_chunk: str) -> list[str]:
+    """Extract every AG-UI event type from a possibly batched SSE chunk."""
+    event_types = []
     try:
         for line in sse_chunk.strip().split("\n"):
             if line.startswith("data: "):
                 data = json.loads(line[6:])
-                return data.get("type", "unknown")
+                event_types.append(data.get("type", "unknown"))
     except (json.JSONDecodeError, AttributeError):
-        pass
-    return "unknown"
+        return event_types
+    return event_types
 
 
 async def _create_tail_stream(
@@ -282,10 +421,23 @@ async def invocations(http_request: Request):
     All requests use AG-UI RunAgentInput format (thread_id + run_id).
     Lifecycle actions (warmup, stop, elicitation) are indicated via state.action.
     """
-    body = await http_request.json()
+    content_length = http_request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > MAX_AGUI_REQUEST_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail="AG-UI request is too large",
+                )
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid Content-Length")
 
-    # AG-UI state에서 lifecycle action 확인
+    body = _normalize_agui_input(await http_request.json())
+    _validate_agui_input_limits(body)
+
     state = body.get("state") or {}
+    if not isinstance(state, dict):
+        raise HTTPException(status_code=422, detail="state must be an object")
     action = state.get("action")
     thread_id = body.get("thread_id", "")
 
@@ -413,16 +565,25 @@ async def invocations(http_request: Request):
 
     # Warmup — triggers container cold start, Python modules load (TOOL_REGISTRY, etc.)
     if action == "warmup":
-        user_id = state.get("user_id", "anonymous")
+        user_id = _resolve_user_id(
+            http_request,
+            state.get("user_id") or state.get("userId"),
+        )
         logger.info(f"[Warmup] Container warmed - session={thread_id}, user={user_id}")
         return {"status": "warm"}
 
     # Stop
     if action == "stop":
-        user_id = state.get("user_id", "anonymous")
-        run_id = state.get("run_id")
+        user_id = _resolve_user_id(
+            http_request,
+            state.get("user_id") or state.get("userId"),
+        )
+        run_id = state.get("run_id") or state.get("runId")
         if not run_id:
             raise HTTPException(status_code=400, detail="run_id required for stop")
+        execution = registry.get_execution(f"{thread_id}:{run_id}")
+        if execution and not _execution_belongs_to(execution, user_id, thread_id):
+            raise HTTPException(status_code=404, detail="Execution not found")
         from agent.stop_signal import get_stop_signal_provider
         provider = get_stop_signal_provider()
         if not provider:
@@ -434,22 +595,43 @@ async def invocations(http_request: Request):
 
     # Execution status — check if a buffered execution is still running
     if action == "execution_status":
-        execution_id = state.get("execution_id")
+        user_id = _resolve_user_id(
+            http_request,
+            state.get("user_id") or state.get("userId"),
+        )
+        execution_id = state.get("execution_id") or state.get("executionId")
         if not execution_id:
             return {"status": "not_found"}
         execution = registry.get_execution(execution_id)
-        if not execution:
+        if not execution or not _execution_belongs_to(
+            execution,
+            user_id,
+            thread_id,
+        ):
             return {"status": "not_found"}
         return {"status": execution.status.value}
 
     # Resume — reconnect to a running/completed execution's event buffer
     if action == "resume":
-        execution_id = state.get("execution_id")
-        cursor = int(state.get("cursor", 0))
+        user_id = _resolve_user_id(
+            http_request,
+            state.get("user_id") or state.get("userId"),
+        )
+        execution_id = state.get("execution_id") or state.get("executionId")
+        try:
+            cursor = int(state.get("cursor", 0))
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="Invalid cursor")
+        if cursor < 0:
+            raise HTTPException(status_code=400, detail="Invalid cursor")
         if not execution_id:
             raise HTTPException(status_code=400, detail="execution_id required in state")
         execution = registry.get_execution(execution_id)
-        if not execution:
+        if not execution or not _execution_belongs_to(
+            execution,
+            user_id,
+            thread_id,
+        ):
             raise HTTPException(status_code=404, detail="Execution not found or expired")
         tail_stream = _create_tail_stream(execution, cursor, http_request)
         final_stream = keepalive_stream(tail_stream, execution.session_id)
@@ -464,7 +646,7 @@ async def invocations(http_request: Request):
             }
         )
 
-    # Normal agent execution — requires thread_id + run_id
+    # Normal agent execution — accepts standard camelCase and legacy snake_case.
     if "thread_id" not in body or "run_id" not in body:
         raise HTTPException(status_code=422, detail="AG-UI format required: thread_id and run_id are required")
 
@@ -472,10 +654,14 @@ async def invocations(http_request: Request):
 
 
 @router.get("/execution-status")
-async def get_execution_status(executionId: str):
+async def get_execution_status(executionId: str, request: Request):
     """Check execution status. Local-mode convenience endpoint."""
+    user_id = _resolve_user_id(
+        request,
+        allow_local_unauthenticated=True,
+    )
     execution = registry.get_execution(executionId)
-    if not execution:
+    if not execution or not _execution_belongs_to(execution, user_id):
         return {"status": "not_found"}
     return {"status": execution.status.value}
 
@@ -483,8 +669,12 @@ async def get_execution_status(executionId: str):
 @router.get("/resume")
 async def resume_execution(executionId: str, cursor: int = 0, request: Request = None):
     """Resume an execution stream from cursor. Local-mode convenience endpoint."""
+    user_id = _resolve_user_id(
+        request,
+        allow_local_unauthenticated=True,
+    )
     execution = registry.get_execution(executionId)
-    if not execution:
+    if not execution or not _execution_belongs_to(execution, user_id):
         raise HTTPException(status_code=404, detail="Execution not found or expired")
     tail_stream = _create_tail_stream(execution, cursor, request)
     final_stream = keepalive_stream(tail_stream, execution.session_id)
@@ -523,6 +713,28 @@ def _parse_message(message: str, request_type: str) -> tuple[str, dict]:
     return message, {}
 
 
+def _parse_resume_entries(resume_entries: object) -> Optional[list[dict]]:
+    """Convert standard AG-UI resume entries to Strands interrupt responses."""
+    if not resume_entries:
+        return None
+
+    responses = []
+    for entry in resume_entries:
+        interrupt_id = getattr(entry, "interrupt_id", None)
+        status = getattr(entry, "status", None)
+        payload = getattr(entry, "payload", None)
+        if not interrupt_id:
+            continue
+        response = payload if status == "resolved" else "declined"
+        responses.append({
+            "interruptResponse": {
+                "interruptId": interrupt_id,
+                "response": response,
+            },
+        })
+    return responses or None
+
+
 async def _handle_agui_invocation(body: dict, http_request: Request) -> StreamingResponse:
     """Handle AG-UI protocol RunAgentInput requests."""
     # forwarded_props is required by RunAgentInput but optional in practice; default to None
@@ -535,9 +747,13 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
     run_id = input_data.run_id
 
     session_id = thread_id
-    user_id = "agui"
+    claimed_user_id = None
     if input_data.state and isinstance(input_data.state, dict):
-        user_id = input_data.state.get("user_id", "agui")
+        claimed_user_id = (
+            input_data.state.get("user_id")
+            or input_data.state.get("userId")
+        )
+    user_id = _resolve_user_id(http_request, claimed_user_id)
 
     message = ""
     image_content_parts = []  # Inline base64 images from AG-UI multimodal
@@ -690,9 +906,6 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
 
         agui_processor = AGUIStreamEventProcessor(thread_id=thread_id, run_id=run_id)
 
-        os.environ["SESSION_ID"] = session_id
-        os.environ["USER_ID"] = user_id
-
         invocation_state = {
             "session_id": session_id,
             "user_id": user_id,
@@ -708,10 +921,19 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
 
         # Create execution in registry
         execution = await registry.create_execution(session_id, user_id, run_id)
+        if execution is None:
+            raise HTTPException(
+                status_code=409,
+                detail="Execution identifier is already in use",
+            )
         execution.media_type = media_type
 
-        # Parse message for special cases (HITL interrupt response)
-        message_content, special_params = _parse_message(message, request_type)
+        # Standard AG-UI resume takes precedence over the legacy JSON message.
+        resume_message = _parse_resume_entries(input_data.resume)
+        if resume_message is not None:
+            message_content, special_params = resume_message, {}
+        else:
+            message_content, special_params = _parse_message(message, request_type)
 
         # Build multimodal message using build_prompt() (handles size checks, sanitization, workspace storage)
         if isinstance(message_content, list):
@@ -771,8 +993,13 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
                         elicitation_bridge=getattr(agent, 'elicitation_bridge', None),
                     )
                     async for sse_chunk in stream:
-                        event_type = _extract_event_type(sse_chunk)
+                        if not sse_chunk:
+                            continue
+                        event_types = _extract_event_types(sse_chunk)
+                        event_type = event_types[0] if event_types else "unknown"
                         execution.append_event(sse_chunk, event_type)
+                        if "RUN_ERROR" in event_types:
+                            execution.status = ExecutionStatus.ERROR
 
                 if pending_research:
                     from agent.research_jobs import mark_delivered
@@ -786,16 +1013,27 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
                             )
             except Exception as e:
                 logger.error(f"[Execution] AG-UI agent error for {execution.execution_id}: {e}", exc_info=True)
-                error_event = f'data: {json.dumps({"type": "error", "message": str(e)})}\n\n'
-                execution.append_event(error_event, "error")
+                error_event = agui_processor.formatter.format_event(
+                    "error",
+                    error_message="Agent processing failed",
+                )
+                if error_event:
+                    execution.append_event(error_event, "RUN_ERROR")
+                execution.status = ExecutionStatus.ERROR
             finally:
                 async_tasks.end(task_id)
-                agent.close()
-                if execution.status == ExecutionStatus.RUNNING:
-                    execution.status = ExecutionStatus.COMPLETED
-                execution.completed_at = time.time()
-                execution._new_event.set()
-                logger.info(f"[Execution] AG-UI completed {execution.execution_id}, {len(execution.events)} events buffered")
+                try:
+                    agent.close()
+                finally:
+                    if execution.status == ExecutionStatus.RUNNING:
+                        execution.status = ExecutionStatus.COMPLETED
+                    execution.completed_at = time.time()
+                    execution._new_event.set()
+                logger.info(
+                    f"[Execution] AG-UI ended {execution.execution_id} "
+                    f"with status={execution.status.value}, "
+                    f"{len(execution.events)} events buffered"
+                )
                 if use_mailbox_delivery:
                     # The foreground run has reached a safe boundary. A
                     # coordinator holding this session's lease may now append
@@ -826,6 +1064,8 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
             }
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in AG-UI invocation: {e}", exc_info=True)
         raise HTTPException(
@@ -933,6 +1173,8 @@ async def deliver_research_job(record: dict, artifact: dict) -> None:
                         elicitation_bridge=getattr(agent, "elicitation_bridge", None),
                     )
                     async for sse_chunk in stream:
+                        if not sse_chunk:
+                            continue
                         execution.append_event(
                             sse_chunk,
                             _extract_event_type(sse_chunk),
@@ -1072,6 +1314,8 @@ async def deliver_delegation_job(record: dict, result: dict) -> None:
                         ),
                     )
                     async for sse_chunk in stream:
+                        if not sse_chunk:
+                            continue
                         execution.append_event(
                             sse_chunk,
                             _extract_event_type(sse_chunk),

--- a/chatbot-app/agentcore/src/streaming/agui_event_formatter.py
+++ b/chatbot-app/agentcore/src/streaming/agui_event_formatter.py
@@ -9,6 +9,8 @@ from ag_ui.core import (
     RunStartedEvent,
     RunFinishedEvent,
     RunErrorEvent,
+    RunFinishedInterruptOutcome,
+    Interrupt,
     TextMessageStartEvent,
     TextMessageContentEvent,
     TextMessageEndEvent,
@@ -16,6 +18,11 @@ from ag_ui.core import (
     ToolCallArgsEvent,
     ToolCallEndEvent,
     ToolCallResultEvent,
+    ReasoningStartEvent,
+    ReasoningMessageStartEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningEndEvent,
     CustomEvent,
     EventType,
 )
@@ -360,6 +367,9 @@ class AGUIStreamEventFormatter:
         self._started_tool_calls: set[str] = set()
         self._ended_tool_calls: set[str] = set()
         self._tool_call_names: Dict[str, str] = {}
+        self._terminal_emitted: bool = False
+        self._reasoning_open: bool = False
+        self._reasoning_message_id: Optional[str] = None
 
     # ------------------------------------------------------------------ #
     # Internal helpers                                                     #
@@ -379,6 +389,23 @@ class AGUIStreamEventFormatter:
             self._current_message_id = None
             return encoded
         return ""
+
+    def _close_open_reasoning(self) -> str:
+        if not self._reasoning_open or not self._reasoning_message_id:
+            return ""
+        message_id = self._reasoning_message_id
+        self._reasoning_open = False
+        self._reasoning_message_id = None
+        return (
+            self._encode(ReasoningMessageEndEvent(
+                type=EventType.REASONING_MESSAGE_END,
+                message_id=message_id,
+            ))
+            + self._encode(ReasoningEndEvent(
+                type=EventType.REASONING_END,
+                message_id=message_id,
+            ))
+        )
 
     # ------------------------------------------------------------------ #
     # Public dispatch                                                      #
@@ -402,10 +429,14 @@ class AGUIStreamEventFormatter:
           error               -> RunErrorEvent
           <all others>        -> CustomEvent(name=<original_type>, value=<payload>)
         """
+        if self._terminal_emitted and event_type != "init":
+            return ""
+
         _dispatch: Dict[str, Any] = {
             "init":        self._format_init,
             "thinking":    self._format_thinking,
             "reasoning":   self._format_reasoning,
+            "interrupt":   self._format_interrupt,
             "response":    self._format_response,
             "complete":    self._format_complete,
             "stop":        self._format_stop,
@@ -418,7 +449,10 @@ class AGUIStreamEventFormatter:
             "error":       self._format_error,
         }
         handler = _dispatch.get(event_type, self._format_custom)
-        return handler(event_type=event_type, **kwargs)
+        prefix = ""
+        if event_type != "reasoning":
+            prefix = self._close_open_reasoning()
+        return prefix + handler(event_type=event_type, **kwargs)
 
     # ------------------------------------------------------------------ #
     # Core AG-UI event formatters                                          #
@@ -427,6 +461,9 @@ class AGUIStreamEventFormatter:
     def _format_init(self, event_type: str = "init", **kwargs) -> str:
         self._run_id = self._initial_run_id or str(uuid.uuid4())
         self._initial_run_id = None  # consume once; subsequent calls (shouldn't happen) get a fresh uuid
+        self._terminal_emitted = False
+        self._reasoning_open = False
+        self._reasoning_message_id = None
         self._message_open = False
         self._current_message_id = None
         self._started_tool_calls.clear()
@@ -446,14 +483,71 @@ class AGUIStreamEventFormatter:
         ))
 
     def _format_reasoning(self, event_type: str = "reasoning", **kwargs) -> str:
-        return self._encode(CustomEvent(
+        if self._terminal_emitted:
+            return ""
+        text = kwargs.get("reasoning_text", kwargs.get("text", ""))
+        result = ""
+        if not self._reasoning_open:
+            self._reasoning_message_id = str(uuid.uuid4())
+            self._reasoning_open = True
+            result += self._encode(ReasoningStartEvent(
+                type=EventType.REASONING_START,
+                message_id=self._reasoning_message_id,
+            ))
+            result += self._encode(ReasoningMessageStartEvent(
+                type=EventType.REASONING_MESSAGE_START,
+                message_id=self._reasoning_message_id,
+                role="reasoning",
+            ))
+        if text:
+            result += self._encode(ReasoningMessageContentEvent(
+                type=EventType.REASONING_MESSAGE_CONTENT,
+                message_id=self._reasoning_message_id,
+                delta=text,
+            ))
+        return result
+
+    def _format_interrupt(self, event_type: str = "interrupt", **kwargs) -> str:
+        if self._terminal_emitted:
+            return ""
+
+        raw_interrupts = kwargs.get("interrupts") or []
+        standard_interrupts = []
+        for raw in raw_interrupts:
+            raw_reason = raw.get("reason")
+            reason = (
+                raw_reason
+                if isinstance(raw_reason, str)
+                else json.dumps(raw_reason or {}, ensure_ascii=False)
+            )
+            standard_interrupts.append(Interrupt(
+                id=str(raw.get("id") or uuid.uuid4()),
+                reason=reason,
+                message=raw.get("name"),
+                tool_call_id=raw.get("toolCallId"),
+                metadata={
+                    "name": raw.get("name"),
+                    "reason": raw_reason,
+                },
+            ))
+
+        result = self._close_open_message()
+        result += self._encode(CustomEvent(
             type=EventType.CUSTOM,
-            name="reasoning",
-            value={
-                "text": kwargs.get("reasoning_text", kwargs.get("text", "")),
-                "step": kwargs.get("step", "thinking"),
-            },
+            name="interrupt",
+            value={"interrupts": raw_interrupts},
         ))
+        run_id = self._run_id or str(uuid.uuid4())
+        result += self._encode(RunFinishedEvent(
+            type=EventType.RUN_FINISHED,
+            thread_id=self._thread_id,
+            run_id=run_id,
+            outcome=RunFinishedInterruptOutcome(
+                interrupts=standard_interrupts,
+            ),
+        ))
+        self._terminal_emitted = True
+        return result
 
     def _format_response(self, event_type: str = "response", **kwargs) -> str:
         text = kwargs.get("text", "")
@@ -474,6 +568,9 @@ class AGUIStreamEventFormatter:
         return result
 
     def _format_complete(self, event_type: str = "complete", **kwargs) -> str:
+        if self._terminal_emitted:
+            return ""
+
         message: str = kwargs.get("message", "")
         result = ""
 
@@ -499,14 +596,8 @@ class AGUIStreamEventFormatter:
             # Close any message that was built up through incremental response events.
             result += self._close_open_message()
 
-        run_id = self._run_id or str(uuid.uuid4())
-        result += self._encode(RunFinishedEvent(
-            type=EventType.RUN_FINISHED,
-            thread_id=self._thread_id,
-            run_id=run_id,
-        ))
         # Images and usage have no standard AG-UI home; relay as a CustomEvent
-        # so consumers that understand the schema can still act on them.
+        # before the terminal event so every consumer can observe them.
         images = kwargs.get("images")
         usage = kwargs.get("usage")
         if images or usage:
@@ -520,6 +611,13 @@ class AGUIStreamEventFormatter:
                 name="complete_metadata",
                 value=extra,
             ))
+        run_id = self._run_id or str(uuid.uuid4())
+        result += self._encode(RunFinishedEvent(
+            type=EventType.RUN_FINISHED,
+            thread_id=self._thread_id,
+            run_id=run_id,
+        ))
+        self._terminal_emitted = True
         return result
 
     def _format_tool_use(self, event_type: str = "tool_use", **kwargs) -> str:
@@ -705,26 +803,34 @@ class AGUIStreamEventFormatter:
 
     def _format_stop(self, event_type: str = "stop", **kwargs) -> str:
         """Emitted when the stream is gracefully stopped by the user."""
+        if self._terminal_emitted:
+            return ""
+
         result = self._close_open_message()
+        result += self._encode(CustomEvent(
+            type=EventType.CUSTOM,
+            name="stream_stopped",
+            value={"message": "Stream stopped by user"},
+        ))
         run_id = self._run_id or str(uuid.uuid4())
         result += self._encode(RunFinishedEvent(
             type=EventType.RUN_FINISHED,
             thread_id=self._thread_id,
             run_id=run_id,
         ))
-        result += self._encode(CustomEvent(
-            type=EventType.CUSTOM,
-            name="stream_stopped",
-            value={"message": "Stream stopped by user"},
-        ))
+        self._terminal_emitted = True
         return result
 
     def _format_error(self, event_type: str = "error", **kwargs) -> str:
+        if self._terminal_emitted:
+            return ""
+
         result = self._close_open_message()
         result += self._encode(RunErrorEvent(
             type=EventType.RUN_ERROR,
             message=kwargs.get("error_message", kwargs.get("message", "Unknown error")),
         ))
+        self._terminal_emitted = True
         return result
 
     # ------------------------------------------------------------------ #

--- a/chatbot-app/agentcore/src/streaming/agui_event_processor.py
+++ b/chatbot-app/agentcore/src/streaming/agui_event_processor.py
@@ -484,7 +484,10 @@ class AGUIStreamEventProcessor:
         self._active_streams.add(stream_id)
 
         if not agent:
-            yield self.formatter.format_event("error", error_message="Agent not available - please configure AWS credentials for Bedrock")
+            yield self.formatter.format_event(
+                "error",
+                error_message="Agent is unavailable",
+            )
             return
 
         # Register side-channel queue for skill executor events
@@ -1022,7 +1025,10 @@ class AGUIStreamEventProcessor:
                 yield self.formatter.format_event("tool_result", tool_result=error_tool_result)
             else:
                 # No pending tool, emit as error event (chat message)
-                yield self.formatter.format_event("error", error_message=f"Sorry, I encountered an error: {str(e)}")
+                yield self.formatter.format_event(
+                    "error",
+                    error_message="Agent processing failed",
+                )
 
         finally:
             # Cancel any pending next-event task to avoid leaks

--- a/chatbot-app/agentcore/src/streaming/execution_registry.py
+++ b/chatbot-app/agentcore/src/streaming/execution_registry.py
@@ -9,6 +9,8 @@ SSE connections tail the buffer, enabling reconnection with cursor-based replay.
 import asyncio
 import time
 import logging
+import os
+import json
 from enum import Enum
 from dataclasses import dataclass, field
 from typing import Optional
@@ -38,6 +40,7 @@ class Execution:
     user_id: str
     status: ExecutionStatus
     events: list[SSEEvent] = field(default_factory=list)
+    buffered_bytes: int = 0
     next_event_id: int = 1
     created_at: float = field(default_factory=time.time)
     completed_at: Optional[float] = None
@@ -49,17 +52,51 @@ class Execution:
     media_type: str = "text/event-stream"
 
     MAX_EVENTS = 10000
+    MAX_BUFFER_BYTES = int(os.environ.get("AGUI_MAX_BUFFER_BYTES", 16 * 1024 * 1024))
     TRUNCATE_RATIO = 0.2  # Remove oldest 20% when overflow
 
     def append_event(self, data: str, event_type: str = "unknown") -> SSEEvent:
         """Append an event to the buffer and notify subscribers."""
-        # Overflow protection
+        data_size = len(data.encode("utf-8"))
+        marker_reserve = min(1024, max(128, self.MAX_BUFFER_BYTES // 4))
+        if data_size > self.MAX_BUFFER_BYTES - marker_reserve:
+            data = "data: " + json.dumps({
+                "type": "CUSTOM",
+                "name": "event_dropped",
+                "value": {
+                    "eventType": event_type,
+                    "bytes": data_size,
+                },
+            }) + "\n\n"
+            event_type = "event_dropped"
+            data_size = len(data.encode("utf-8"))
+
+        truncated = False
         if len(self.events) >= self.MAX_EVENTS:
             trim_count = int(self.MAX_EVENTS * self.TRUNCATE_RATIO)
+            removed = self.events[:trim_count]
             self.events = self.events[trim_count:]
-            first_retained_id = self.events[0].event_id
-            # The marker represents the gap immediately before the retained
-            # window, so its id must preserve chronological cursor ordering.
+            self.buffered_bytes -= sum(
+                len(event.data.encode("utf-8"))
+                for event in removed
+            )
+            truncated = True
+
+        while (
+            self.events
+            and self.buffered_bytes + data_size + marker_reserve
+            > self.MAX_BUFFER_BYTES
+        ):
+            removed = self.events.pop(0)
+            self.buffered_bytes -= len(removed.data.encode("utf-8"))
+            truncated = True
+
+        if truncated:
+            first_retained_id = (
+                self.events[0].event_id
+                if self.events
+                else self.next_event_id
+            )
             marker = SSEEvent(
                 event_id=first_retained_id - 1,
                 data=(
@@ -70,6 +107,7 @@ class Execution:
                 event_type="buffer_truncated",
             )
             self.events.insert(0, marker)
+            self.buffered_bytes += len(marker.data.encode("utf-8"))
 
         event = SSEEvent(
             event_id=self.next_event_id,
@@ -79,6 +117,7 @@ class Execution:
         )
         self.next_event_id += 1
         self.events.append(event)
+        self.buffered_bytes += data_size
 
         # Wake up all subscribers waiting for new events.
         # Do NOT clear here — subscribers clear after waking to avoid race.
@@ -120,7 +159,8 @@ class ExecutionRegistry:
         supersede_running: bool = True,
     ) -> Optional[Execution]:
         async with self._lock:
-            latest_id = self._session_latest.get(session_id)
+            session_key = (user_id, session_id)
+            latest_id = self._session_latest.get(session_key)
             if latest_id:
                 latest = self._executions.get(latest_id)
                 if latest and latest.status == ExecutionStatus.RUNNING:
@@ -137,6 +177,14 @@ class ExecutionRegistry:
                         latest.task.cancel()
 
             execution_id = f"{session_id}:{run_id}"
+            existing = self._executions.get(execution_id)
+            if existing and existing.user_id != user_id:
+                logger.warning(
+                    "[ExecutionRegistry] Rejected cross-user execution id "
+                    "collision for %s",
+                    execution_id,
+                )
+                return None
             execution = Execution(
                 execution_id=execution_id,
                 session_id=session_id,
@@ -144,15 +192,19 @@ class ExecutionRegistry:
                 status=ExecutionStatus.RUNNING,
             )
             self._executions[execution_id] = execution
-            self._session_latest[session_id] = execution_id
+            self._session_latest[session_key] = execution_id
             logger.info(f"[ExecutionRegistry] Created execution {execution_id}")
             return execution
 
     def get_execution(self, execution_id: str) -> Optional[Execution]:
         return self._executions.get(execution_id)
 
-    def get_latest_execution(self, session_id: str) -> Optional[Execution]:
-        execution_id = self._session_latest.get(session_id)
+    def get_latest_execution(
+        self,
+        session_id: str,
+        user_id: str,
+    ) -> Optional[Execution]:
+        execution_id = self._session_latest.get((user_id, session_id))
         if execution_id:
             return self._executions.get(execution_id)
         return None
@@ -175,8 +227,9 @@ class ExecutionRegistry:
                 execution = self._executions.pop(eid, None)
                 if execution:
                     # Clean up session_latest if it points to this execution
-                    if self._session_latest.get(execution.session_id) == eid:
-                        del self._session_latest[execution.session_id]
+                    session_key = (execution.user_id, execution.session_id)
+                    if self._session_latest.get(session_key) == eid:
+                        del self._session_latest[session_key]
 
             if to_remove:
                 logger.info(f"[ExecutionRegistry] Cleaned up {len(to_remove)} expired executions")

--- a/chatbot-app/agentcore/tests/integration/e2e/sse_client.py
+++ b/chatbot-app/agentcore/tests/integration/e2e/sse_client.py
@@ -1,7 +1,7 @@
 """SSE client that POSTs to the BFF /api/stream/chat endpoint and collects events.
 
 The BFF accepts AG-UI RunAgentInput (camelCase `threadId`/`runId`) and forwards
-to the AgentCore runtime as snake_case. See
+the standard wire shape to the AgentCore runtime. See
 `chatbot-app/frontend/src/app/api/stream/chat/route.ts`.
 
 Event shape (subset used here): each `data: {...}` frame is a JSON object with a

--- a/chatbot-app/agentcore/tests/unit/test_agui_event_lifecycle.py
+++ b/chatbot-app/agentcore/tests/unit/test_agui_event_lifecycle.py
@@ -1,0 +1,136 @@
+import json
+
+from ag_ui.encoder import EventEncoder
+
+from streaming.agui_event_formatter import AGUIStreamEventFormatter
+
+
+def _events(stream: str) -> list[dict]:
+    return [
+        json.loads(line[6:])
+        for line in stream.splitlines()
+        if line.startswith("data: ")
+    ]
+
+
+def test_complete_metadata_precedes_terminal_event():
+    formatter = AGUIStreamEventFormatter(
+        EventEncoder(),
+        thread_id="thread-1",
+        run_id="run-1",
+    )
+
+    stream = formatter.format_event("init")
+    stream += formatter.format_event(
+        "complete",
+        message="done",
+        images=[{"data": "image"}],
+        usage={"totalTokens": 3},
+    )
+    events = _events(stream)
+
+    metadata_index = next(
+        index
+        for index, event in enumerate(events)
+        if event.get("name") == "complete_metadata"
+    )
+    finished_index = next(
+        index
+        for index, event in enumerate(events)
+        if event["type"] == "RUN_FINISHED"
+    )
+    assert metadata_index < finished_index
+    assert events[-1]["type"] == "RUN_FINISHED"
+
+
+def test_terminal_event_is_emitted_only_once():
+    formatter = AGUIStreamEventFormatter(
+        EventEncoder(),
+        thread_id="thread-1",
+        run_id="run-1",
+    )
+
+    stream = formatter.format_event("init")
+    stream += formatter.format_event("complete", message="done")
+    stream += formatter.format_event("error", error_message="late failure")
+    stream += formatter.format_event("complete", message="duplicate")
+    stream += formatter.format_event("browser_progress", content="late event")
+    terminal_events = [
+        event
+        for event in _events(stream)
+        if event["type"] in {"RUN_FINISHED", "RUN_ERROR"}
+    ]
+
+    assert [event["type"] for event in terminal_events] == ["RUN_FINISHED"]
+    assert not any(
+        event.get("name") == "browser_progress"
+        for event in _events(stream)
+    )
+
+
+def test_stop_notification_precedes_terminal_event():
+    formatter = AGUIStreamEventFormatter(
+        EventEncoder(),
+        thread_id="thread-1",
+        run_id="run-1",
+    )
+
+    stream = formatter.format_event("init")
+    stream += formatter.format_event("stop")
+    events = _events(stream)
+
+    assert events[-2]["type"] == "CUSTOM"
+    assert events[-2]["name"] == "stream_stopped"
+    assert events[-1]["type"] == "RUN_FINISHED"
+
+
+def test_reasoning_uses_standard_lifecycle():
+    formatter = AGUIStreamEventFormatter(
+        EventEncoder(),
+        thread_id="thread-1",
+        run_id="run-1",
+    )
+
+    stream = formatter.format_event("init")
+    stream += formatter.format_event("reasoning", reasoning_text="first")
+    stream += formatter.format_event("reasoning", reasoning_text="second")
+    stream += formatter.format_event("response", text="answer")
+    events = _events(stream)
+    event_types = [event["type"] for event in events]
+
+    assert event_types == [
+        "RUN_STARTED",
+        "REASONING_START",
+        "REASONING_MESSAGE_START",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_END",
+        "REASONING_END",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+    ]
+
+
+def test_interrupt_emits_legacy_event_then_standard_outcome():
+    formatter = AGUIStreamEventFormatter(
+        EventEncoder(),
+        thread_id="thread-1",
+        run_id="run-1",
+    )
+
+    stream = formatter.format_event("init")
+    stream += formatter.format_event(
+        "interrupt",
+        interrupts=[{
+            "id": "approval-1",
+            "name": "approve-action",
+            "reason": {"plan": "perform action"},
+        }],
+    )
+    events = _events(stream)
+
+    assert events[-2]["type"] == "CUSTOM"
+    assert events[-2]["name"] == "interrupt"
+    assert events[-1]["type"] == "RUN_FINISHED"
+    assert events[-1]["outcome"]["type"] == "interrupt"
+    assert events[-1]["outcome"]["interrupts"][0]["id"] == "approval-1"

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -120,7 +120,7 @@ class TestExecutionRegistry:
         found = registry.get_execution("sess1:run1")
         assert found is execution
 
-        latest = registry.get_latest_execution("sess1")
+        latest = registry.get_latest_execution("sess1", "user1")
         assert latest is execution
 
     @pytest.mark.asyncio
@@ -139,7 +139,49 @@ class TestExecutionRegistry:
 
         assert background is None
         assert foreground.status == ExecutionStatus.RUNNING
-        assert registry.get_latest_execution("sess-busy") is foreground
+        assert registry.get_latest_execution("sess-busy", "user1") is foreground
+
+    @pytest.mark.asyncio
+    async def test_same_session_id_is_isolated_by_user(self):
+        from streaming.execution_registry import ExecutionRegistry, ExecutionStatus
+
+        ExecutionRegistry.reset()
+        registry = ExecutionRegistry()
+        first = await registry.create_execution(
+            "shared-session",
+            "user-a",
+            "run-a",
+        )
+        second = await registry.create_execution(
+            "shared-session",
+            "user-b",
+            "run-b",
+        )
+
+        assert first.status == ExecutionStatus.RUNNING
+        assert second.status == ExecutionStatus.RUNNING
+        assert registry.get_latest_execution("shared-session", "user-a") is first
+        assert registry.get_latest_execution("shared-session", "user-b") is second
+
+    @pytest.mark.asyncio
+    async def test_cross_user_execution_id_collision_is_rejected(self):
+        from streaming.execution_registry import ExecutionRegistry
+
+        ExecutionRegistry.reset()
+        registry = ExecutionRegistry()
+        first = await registry.create_execution(
+            "shared-session",
+            "user-a",
+            "same-run",
+        )
+        second = await registry.create_execution(
+            "shared-session",
+            "user-b",
+            "same-run",
+        )
+
+        assert first is not None
+        assert second is None
 
     @pytest.mark.asyncio
     async def test_append_and_get_events(self):
@@ -186,6 +228,51 @@ class TestExecutionRegistry:
         assert event_ids == sorted(event_ids)
         assert execution.events[0].event_type == "buffer_truncated"
         assert '"type":"CUSTOM"' in execution.events[0].data
+
+    @pytest.mark.asyncio
+    async def test_buffer_enforces_byte_limit(self):
+        from streaming.execution_registry import ExecutionRegistry
+
+        ExecutionRegistry.reset()
+        execution = await ExecutionRegistry().create_execution(
+            "byte-limit-session",
+            "user1",
+            "run1",
+        )
+        execution.MAX_BUFFER_BYTES = 2048
+
+        for index in range(20):
+            execution.append_event(
+                'data: {"type":"CUSTOM","name":"payload",'
+                f'"value":"{index}-{"x" * 300}"}}\n\n',
+                "CUSTOM",
+            )
+
+        assert execution.buffered_bytes <= execution.MAX_BUFFER_BYTES
+        assert execution.events[0].event_type == "buffer_truncated"
+
+    @pytest.mark.asyncio
+    async def test_oversized_event_is_replaced_with_marker(self):
+        from streaming.execution_registry import ExecutionRegistry
+
+        ExecutionRegistry.reset()
+        execution = await ExecutionRegistry().create_execution(
+            "oversized-session",
+            "user1",
+            "run1",
+        )
+        execution.MAX_BUFFER_BYTES = 1024
+
+        event = execution.append_event(
+            f'data: {{"type":"CUSTOM","value":"{"x" * 2000}"}}\n\n',
+            'CUSTOM"with-quote',
+        )
+        payload = json.loads(event.data.removeprefix("data: ").strip())
+
+        assert event.event_type == "event_dropped"
+        assert payload["name"] == "event_dropped"
+        assert payload["value"]["eventType"] == 'CUSTOM"with-quote'
+        assert execution.buffered_bytes <= execution.MAX_BUFFER_BYTES
 
     @pytest.mark.asyncio
     async def test_cleanup_expired(self):
@@ -508,6 +595,149 @@ class TestInvocationsEndpoint:
 
         assert response.status_code == 422
 
+    @patch('routers.chat.create_agent')
+    def test_accepts_standard_camel_case_run_input(
+        self,
+        mock_factory,
+        mock_agent,
+    ):
+        mock_factory.return_value = mock_agent
+
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        payload = _agui_payload(session_id="camel-session")
+        payload["threadId"] = payload.pop("thread_id")
+        payload["runId"] = payload.pop("run_id")
+
+        response = client.post("/invocations", json=payload)
+
+        assert response.status_code == 200
+        assert response.headers["x-thread-id"] == "camel-session"
+
+    def test_rejects_claimed_user_that_differs_from_runtime_subject(
+        self,
+        monkeypatch,
+    ):
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            headers={
+                "Authorization": (
+                    f"Bearer {_unsigned_test_token({'sub': 'authenticated-user'})}"
+                )
+            },
+            json=_agui_payload(user_id="different-user"),
+        )
+
+        assert response.status_code == 403
+
+    def test_allows_trusted_m2m_client_to_delegate_user_identity(
+        self,
+        monkeypatch,
+    ):
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("M2M_CLIENT_ID", "trusted-service")
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            headers={
+                "Authorization": (
+                    f"Bearer {_unsigned_test_token({'client_id': 'trusted-service'})}"
+                )
+            },
+            json={
+                "threadId": "m2m-session",
+                "runId": str(uuid.uuid4()),
+                "state": {
+                    "action": "warmup",
+                    "user_id": "delegated-user",
+                },
+            },
+        )
+
+        assert response.status_code == 200
+
+    def test_rejects_untrusted_client_without_subject(
+        self,
+        monkeypatch,
+    ):
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("M2M_CLIENT_ID", "trusted-service")
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            headers={
+                "Authorization": (
+                    f"Bearer {_unsigned_test_token({'client_id': 'other-service'})}"
+                )
+            },
+            json={
+                "threadId": "m2m-session",
+                "runId": str(uuid.uuid4()),
+                "state": {
+                    "action": "warmup",
+                    "user_id": "delegated-user",
+                },
+            },
+        )
+
+        assert response.status_code == 401
+
+    def test_rejects_excessive_message_count(self):
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        payload = _agui_payload()
+        payload["messages"] = [
+            {"id": str(index), "role": "user", "content": "message"}
+            for index in range(501)
+        ]
+
+        response = client.post("/invocations", json=payload)
+
+        assert response.status_code == 422
+
+    def test_rejects_control_characters_in_thread_id(self):
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            json=_agui_payload(session_id="bad\nsession"),
+        )
+
+        assert response.status_code == 422
+
 
 # ============================================================
 # Lifecycle Action Tests (warmup, stop, elicitation)
@@ -772,9 +1002,13 @@ class TestLifecycleActions:
         response = client.post(
             "/invocations",
             json={
-                "thread_id": "status-session",
+                "thread_id": "sess-status",
                 "run_id": str(uuid.uuid4()),
-                "state": {"action": "execution_status", "execution_id": "sess-status:run-1"}
+                "state": {
+                    "action": "execution_status",
+                    "execution_id": "sess-status:run-1",
+                    "user_id": "user-1",
+                }
             }
         )
 
@@ -783,6 +1017,71 @@ class TestLifecycleActions:
 
         # Cleanup
         execution.status = __import__('streaming.execution_registry', fromlist=['ExecutionStatus']).ExecutionStatus.COMPLETED
+        execution.completed_at = __import__('time').time()
+
+    @pytest.mark.asyncio
+    async def test_execution_status_hides_other_users_execution(self):
+        from routers.chat import router, registry
+        from streaming.execution_registry import ExecutionStatus
+        from fastapi import FastAPI
+
+        execution = await registry.create_execution(
+            "owned-session",
+            "owner-user",
+            "owned-run",
+        )
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            json={
+                "thread_id": "owned-session",
+                "run_id": str(uuid.uuid4()),
+                "state": {
+                    "action": "execution_status",
+                    "execution_id": execution.execution_id,
+                    "user_id": "other-user",
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "not_found"}
+        execution.status = ExecutionStatus.COMPLETED
+        execution.completed_at = __import__('time').time()
+
+    @pytest.mark.asyncio
+    async def test_resume_hides_other_users_execution(self):
+        from routers.chat import router, registry
+        from streaming.execution_registry import ExecutionStatus
+        from fastapi import FastAPI
+
+        execution = await registry.create_execution(
+            "resume-owned-session",
+            "owner-user",
+            "owned-run",
+        )
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            json={
+                "thread_id": "resume-owned-session",
+                "run_id": str(uuid.uuid4()),
+                "state": {
+                    "action": "resume",
+                    "execution_id": execution.execution_id,
+                    "user_id": "other-user",
+                },
+            },
+        )
+
+        assert response.status_code == 404
+        execution.status = ExecutionStatus.COMPLETED
         execution.completed_at = __import__('time').time()
 
     def test_resume_missing_execution_id(self):
@@ -824,6 +1123,29 @@ class TestLifecycleActions:
         )
 
         assert response.status_code == 404
+
+    def test_resume_rejects_negative_cursor(self):
+        from routers.chat import router
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post(
+            "/invocations",
+            json={
+                "thread_id": "resume-session",
+                "run_id": str(uuid.uuid4()),
+                "state": {
+                    "action": "resume",
+                    "execution_id": "resume-session:run",
+                    "cursor": -1,
+                },
+            },
+        )
+
+        assert response.status_code == 400
 
     def test_get_execution_status_endpoint(self):
         """Test standalone GET /execution-status endpoint."""
@@ -934,6 +1256,38 @@ class TestInterruptResponseHandling:
 
         assert response.status_code == 200
 
+    def test_parses_standard_resume_entries(self):
+        from ag_ui.core import ResumeEntry
+        from routers.chat import _parse_resume_entries
+
+        result = _parse_resume_entries([
+            ResumeEntry(
+                interruptId="interrupt-123",
+                status="resolved",
+                payload="approved",
+            ),
+        ])
+
+        assert result == [{
+            "interruptResponse": {
+                "interruptId": "interrupt-123",
+                "response": "approved",
+            },
+        }]
+
+    def test_cancelled_resume_maps_to_declined(self):
+        from ag_ui.core import ResumeEntry
+        from routers.chat import _parse_resume_entries
+
+        result = _parse_resume_entries([
+            ResumeEntry(
+                interruptId="interrupt-123",
+                status="cancelled",
+            ),
+        ])
+
+        assert result[0]["interruptResponse"]["response"] == "declined"
+
 
 # ============================================================
 # Error Handling Tests
@@ -961,6 +1315,20 @@ class TestInvocationsErrorHandling:
 
         assert response.status_code == 500
         assert "Agent processing failed" in response.json()["detail"]
+
+    def test_extracts_run_error_from_batched_sse_chunk(self):
+        from routers.chat import _extract_event_type, _extract_event_types
+
+        chunk = (
+            'data: {"type":"TEXT_MESSAGE_END","messageId":"message-1"}\n\n'
+            'data: {"type":"RUN_ERROR","message":"failed"}\n\n'
+        )
+
+        assert _extract_event_type(chunk) == "TEXT_MESSAGE_END"
+        assert _extract_event_types(chunk) == [
+            "TEXT_MESSAGE_END",
+            "RUN_ERROR",
+        ]
 
 
 # ============================================================

--- a/chatbot-app/frontend/__tests__/sseParser.test.ts
+++ b/chatbot-app/frontend/__tests__/sseParser.test.ts
@@ -242,12 +242,12 @@ describe('sseParser', () => {
       expect(validateAGUIStreamEvent(missingName).errors[0]).toContain('name')
     })
 
-    it('should allow unknown event types for forward compatibility', () => {
+    it('should reject unknown event types at the protocol boundary', () => {
       const unknown = { type: 'unknown_type' } as unknown as AGUIStreamEvent
 
       const result = validateAGUIStreamEvent(unknown)
-      expect(result.valid).toBe(true)
-      expect(result.errors).toHaveLength(0)
+      expect(result.valid).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
     })
   })
 
@@ -344,7 +344,7 @@ describe('sseParser', () => {
     })
 
 
-    it('should allow legacy interrupt event (falls through to default, always valid)', () => {
+    it('should reject legacy lowercase interrupt events', () => {
       // interrupt is a legacy/custom type — validator allows all unknown types
       const missingInterrupts = { type: 'interrupt' } as unknown as AGUIStreamEvent
       const withInterrupts = {
@@ -352,8 +352,8 @@ describe('sseParser', () => {
         interrupts: [{ id: 'int-1', name: 'chatbot-research-approval' }]
       } as unknown as AGUIStreamEvent
 
-      expect(validateAGUIStreamEvent(missingInterrupts).valid).toBe(true)
-      expect(validateAGUIStreamEvent(withInterrupts).valid).toBe(true)
+      expect(validateAGUIStreamEvent(missingInterrupts).valid).toBe(false)
+      expect(validateAGUIStreamEvent(withInterrupts).valid).toBe(false)
     })
 
     it('should create mock interrupt event', () => {

--- a/chatbot-app/frontend/src/app/api/stream/chat/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/chat/route.ts
@@ -151,6 +151,7 @@ export async function POST(request: NextRequest) {
 
     const threadIdFromBody: string | undefined = body.threadId
     const runIdFromBody: string | undefined = body.runId
+    const resume = Array.isArray(body.resume) ? body.resume : undefined
     const aguiMessages: Array<{ id?: string; role?: string; content?: unknown }> = body.messages ?? []
 
     // Per-request config lives in body.state (replaces former top-level fields)
@@ -190,6 +191,12 @@ export async function POST(request: NextRequest) {
     // Extract user from Cognito JWT token in Authorization header
     const user = await extractUserFromRequest(request)
     const userId = user.userId
+    if (!IS_LOCAL && userId === 'anonymous') {
+      return new Response(
+        JSON.stringify({ error: 'Authentication required' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
 
     // Forward the verified caller token only as the Runtime Authorization header.
     const authHeader = request.headers.get('authorization') || ''
@@ -411,11 +418,12 @@ export async function POST(request: NextRequest) {
           }
 
           const aguiBody = {
-            thread_id: sessionId,
-            run_id: runIdFromBody || crypto.randomUUID(),
+            threadId: sessionId,
+            runId: runIdFromBody || crypto.randomUUID(),
             messages: aguiMessages,
             tools: [],
             context: [],
+            ...(resume && resume.length > 0 && { resume }),
             state: enrichedState,
           }
 
@@ -458,9 +466,8 @@ export async function POST(request: NextRequest) {
           }
           console.error('[BFF] Error:', error)
           const errorEvent = `data: ${JSON.stringify({
-            type: 'error',
-            message: error instanceof Error ? error.message : 'Unknown error',
-            metadata: { session_id: sessionId }
+            type: 'RUN_ERROR',
+            message: 'Agent stream failed'
           })}\n\n`
           try {
             if (!clientDisconnected) {

--- a/chatbot-app/frontend/src/app/api/stream/execution-status/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/execution-status/route.ts
@@ -6,6 +6,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { extractUserFromRequest } from '@/lib/auth-utils'
 import { getExecutionStatus } from '@/lib/agentcore-runtime-client'
 
+const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
+
 export async function GET(request: NextRequest) {
   const executionId = request.nextUrl.searchParams.get('executionId')
 
@@ -14,6 +16,12 @@ export async function GET(request: NextRequest) {
   }
 
   const user = await extractUserFromRequest(request)
+  if (!IS_LOCAL && user.userId === 'anonymous') {
+    return NextResponse.json(
+      { error: 'Authentication required' },
+      { status: 401 }
+    )
+  }
   const authToken = request.headers.get('authorization') || ''
 
   const result = await getExecutionStatus(executionId, user.userId, authToken)

--- a/chatbot-app/frontend/src/app/api/stream/resume/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/resume/route.ts
@@ -7,6 +7,7 @@ import { extractUserFromRequest } from '@/lib/auth-utils'
 import { resumeExecution } from '@/lib/agentcore-runtime-client'
 
 export const runtime = 'nodejs'
+const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 
 export async function GET(request: NextRequest) {
   const executionId = request.nextUrl.searchParams.get('executionId')
@@ -20,6 +21,12 @@ export async function GET(request: NextRequest) {
   }
 
   const user = await extractUserFromRequest(request)
+  if (!IS_LOCAL && user.userId === 'anonymous') {
+    return new Response(
+      JSON.stringify({ error: 'Authentication required' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
   const authToken = request.headers.get('authorization') || ''
 
   console.log(`[Resume] Proxying to backend: execution=${executionId}, cursor=${cursor}`)

--- a/chatbot-app/frontend/src/app/api/stream/stop/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/stop/route.ts
@@ -22,6 +22,12 @@ export async function POST(request: NextRequest) {
     // Extract user from request
     const user = await extractUserFromRequest(request)
     const userId = user.userId
+    if (!IS_LOCAL && userId === 'anonymous') {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
 
     // Get session ID from request body or header
     const body = await request.json().catch(() => ({}))
@@ -63,8 +69,8 @@ export async function POST(request: NextRequest) {
     if (IS_LOCAL) {
       // Local mode: Call local AgentCore /invocations with AG-UI stop action
       const payload = {
-        thread_id: sessionId,
-        run_id: crypto.randomUUID(),
+        threadId: sessionId,
+        runId: crypto.randomUUID(),
         messages: [],
         tools: [],
         context: [],

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -539,7 +539,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
     try {
       await apiSendMessage(
-        JSON.stringify([{ interruptResponse: { interruptId, response } }]),
+        '',
         undefined,
         // The resumed turn is the one that finishes the work the queue is waiting
         // on, so it has to settle the turn like any other. Without this the queue
@@ -549,6 +549,14 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
           setTurnSettled({ outcome: 'error' })
           setUIState(prev => ({ ...prev, isTyping: false, agentStatus: 'idle', turnPhase: 'idle' }))
         },
+        undefined,
+        undefined,
+        undefined,
+        [{
+          interruptId,
+          status: response === 'declined' ? 'cancelled' : 'resolved',
+          payload: response,
+        }],
       )
     } catch (error) {
       console.error('[Interrupt] Failed to respond to interrupt:', error)

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -8,6 +8,7 @@ import { buildToolMaps, createToolExecution } from '@/utils/messageParser'
 import { isSessionTimedOut, getLastActivity, updateLastActivity, clearSessionData, triggerWarmup, generateSessionId } from '@/config/session'
 import { isA2ATool } from './usePolling'
 import { useSSEReconnect } from './useSSEReconnect'
+import { validateAGUIStreamEvent } from '@/utils/sseParser'
 import { arrayBufferToBase64 } from '@/lib/base64'
 
 /**
@@ -193,6 +194,11 @@ interface UseChatAPIReturn {
     systemPrompt?: string,
     selectedArtifactId?: string | null,
     workspaceFiles?: WorkspaceAttachment[],
+    resume?: Array<{
+      interruptId: string
+      status: 'resolved' | 'cancelled'
+      payload?: unknown
+    }>,
   ) => Promise<void>
   replayExecution: (
     executionId: string,
@@ -495,6 +501,11 @@ export const useChatAPI = ({
     systemPrompt?: string,
     selectedArtifactId?: string | null,
     workspaceFiles?: WorkspaceAttachment[],
+    resume?: Array<{
+      interruptId: string
+      status: 'resolved' | 'cancelled'
+      payload?: unknown
+    }>,
   ) => {
     // Update last activity timestamp (for session timeout tracking)
     updateLastActivity()
@@ -559,6 +570,7 @@ export const useChatAPI = ({
           messages: [{ id: crypto.randomUUID(), role: 'user', content: contentParts }],
           tools: [],
           context: [],
+          ...(resume && resume.length > 0 && { resume }),
           state: {
             model_id: currentModelId,
             temperature: currentTemperature,
@@ -723,6 +735,12 @@ export const useChatAPI = ({
                 // Inject eventId for deduplication
                 if (currentEventId !== null && currentEventId > 0) {
                   eventData._eventId = currentEventId
+                  if (streamExecutionId) {
+                    reconnect.onEventReceived(
+                      streamExecutionId,
+                      currentEventId,
+                    )
+                  }
                 }
                 if (streamExecutionId) {
                   eventData._executionId = streamExecutionId
@@ -739,7 +757,16 @@ export const useChatAPI = ({
                 }
 
                 if (eventData.type && (AGUI_EVENT_TYPES as readonly string[]).includes(eventData.type)) {
-                  await handleStreamEvent(eventData as AGUIStreamEvent)
+                  const event = eventData as AGUIStreamEvent
+                  const validation = validateAGUIStreamEvent(event)
+                  if (!validation.valid) {
+                    logger.warn(
+                      '[useChatAPI] Rejected invalid AG-UI event:',
+                      validation.errors,
+                    )
+                    continue
+                  }
+                  await handleStreamEvent(event)
                 }
               } catch (error) {
                 logger.error('Error processing SSE event:', error)

--- a/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
+++ b/chatbot-app/frontend/src/hooks/useSSEReconnect.ts
@@ -1,9 +1,11 @@
 import { useCallback, useRef, useState } from 'react'
 import { getApiUrl } from '@/config/environment'
 import { AGUI_EVENT_TYPES, AGUIStreamEvent } from '@/types/events'
+import { validateAGUIStreamEvent } from '@/utils/sseParser'
 
 interface ReconnectState {
   executionId: string | null
+  cursor: number
   isReconnecting: boolean
   reconnectAttempt: number
 }
@@ -14,18 +16,19 @@ const MAX_DELAY_MS = 16000
 const FETCH_TIMEOUT_MS = 10000
 const STORAGE_KEY_PREFIX = 'sse_exec_'
 
-/** Persist executionId to sessionStorage. */
-function persistExecutionId(executionId: string) {
+/** Persist execution identity and the last processed event cursor. */
+function persistExecution(executionId: string, cursor: number) {
   try {
     sessionStorage.setItem(
       `${STORAGE_KEY_PREFIX}${executionId}`,
-      JSON.stringify({ executionId, ts: Date.now() })
+      JSON.stringify({ executionId, cursor, ts: Date.now() })
     )
   } catch { /* quota exceeded or unavailable */ }
 }
 
-/** Load persisted executionId for a given session. */
-function loadPersistedExecutionId(sessionId: string): string | null {
+function loadPersistedExecution(
+  sessionId: string,
+): { executionId: string; cursor: number } | null {
   try {
     for (let i = 0; i < sessionStorage.length; i++) {
       const key = sessionStorage.key(i)
@@ -40,7 +43,12 @@ function loadPersistedExecutionId(sessionId: string): string | null {
           sessionStorage.removeItem(key)
           continue
         }
-        return data.executionId
+        return {
+          executionId: data.executionId,
+          cursor: Number.isInteger(data.cursor) && data.cursor > 0
+            ? data.cursor
+            : 0,
+        }
       }
     }
   } catch { /* unavailable */ }
@@ -57,6 +65,7 @@ function clearPersistedExecutionId(executionId: string) {
 export function useSSEReconnect() {
   const stateRef = useRef<ReconnectState>({
     executionId: null,
+    cursor: 0,
     isReconnecting: false,
     reconnectAttempt: 0,
   })
@@ -68,10 +77,11 @@ export function useSSEReconnect() {
   const onStreamStart = useCallback((executionId: string) => {
     stateRef.current = {
       executionId,
+      cursor: 0,
       isReconnecting: false,
       reconnectAttempt: 0,
     }
-    persistExecutionId(executionId)
+    persistExecution(executionId, 0)
     setIsReconnecting(false)
     setReconnectAttempt(0)
   }, [])
@@ -96,6 +106,7 @@ export function useSSEReconnect() {
     }
     stateRef.current = {
       executionId: null,
+      cursor: 0,
       isReconnecting: false,
       reconnectAttempt: 0,
     }
@@ -106,14 +117,30 @@ export function useSSEReconnect() {
   /** Restore execution state from sessionStorage (for page refresh). */
   const restoreFromSession = useCallback((sessionId: string): boolean => {
     detach()
-    const executionId = loadPersistedExecutionId(sessionId)
+    const persisted = loadPersistedExecution(sessionId)
     stateRef.current = {
-      executionId,
+      executionId: persisted?.executionId ?? null,
+      cursor: persisted?.cursor ?? 0,
       isReconnecting: false,
       reconnectAttempt: 0,
     }
-    return executionId !== null
+    return persisted !== null
   }, [detach])
+
+  const onEventReceived = useCallback((
+    executionId: string,
+    eventId: number,
+  ) => {
+    if (
+      stateRef.current.executionId !== executionId
+      || !Number.isInteger(eventId)
+      || eventId <= stateRef.current.cursor
+    ) {
+      return
+    }
+    stateRef.current.cursor = eventId
+    persistExecution(executionId, eventId)
+  }, [])
 
   const attemptReconnect = useCallback(async (
     onEvent: (event: AGUIStreamEvent) => void | Promise<void>,
@@ -204,11 +231,12 @@ export function useSSEReconnect() {
           break
         }
 
-        // 2. Resume SSE stream from cursor=0 (full replay from BFF buffer)
+        // 2. Resume from the last event successfully processed by the client.
+        const resumeCursor = stateRef.current.cursor
         const resumeController = new AbortController()
         activeControllerRef.current = resumeController
         const resumeTimeout = setTimeout(() => resumeController.abort(), FETCH_TIMEOUT_MS)
-        const resumeUrl = `${getApiUrl('stream/resume')}?executionId=${encodeURIComponent(executionId)}&cursor=0`
+        const resumeUrl = `${getApiUrl('stream/resume')}?executionId=${encodeURIComponent(executionId)}&cursor=${resumeCursor}`
         let response: Response
         try {
           response = await fetch(resumeUrl, {
@@ -235,8 +263,8 @@ export function useSSEReconnect() {
           continue
         }
 
-        // 3. Parse SSE stream (full replay)
-        console.log(`[SSEReconnect] Resumed from cursor 0 (full replay)`)
+        // 3. Parse the resumed SSE stream.
+        console.log(`[SSEReconnect] Resumed from cursor ${resumeCursor}`)
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
         let buffer = ''
@@ -279,12 +307,22 @@ export function useSSEReconnect() {
                       : null
                   if (eventId !== null) {
                     eventData._eventId = eventId
+                    onEventReceived(executionId, eventId)
                   }
                   eventData._executionId = executionId
                   currentEventId = null
                   // Dispatch event
                   if (eventData.type && AGUI_EVENT_TYPES.includes(eventData.type)) {
-                    await onEvent(eventData as AGUIStreamEvent)
+                    const event = eventData as AGUIStreamEvent
+                    const validation = validateAGUIStreamEvent(event)
+                    if (!validation.valid) {
+                      console.warn(
+                        '[SSEReconnect] Rejected invalid AG-UI event:',
+                        validation.errors,
+                      )
+                      continue
+                    }
+                    await onEvent(event)
                     // Clear reconnecting badge on first real event
                     if (!connectedFired) {
                       connectedFired = true
@@ -338,10 +376,11 @@ export function useSSEReconnect() {
     setIsReconnecting(false)
     setReconnectAttempt(0)
     onFail()
-  }, [])
+  }, [onEventReceived])
 
   return {
     onStreamStart,
+    onEventReceived,
     attemptReconnect,
     restoreFromSession,
     reset,

--- a/chatbot-app/frontend/src/hooks/useStreamEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useStreamEvents.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, startTransition, useEffect } from 'react'
 import { flushSync } from 'react-dom'
 import { EventType, type TextMessageStartEvent, type TextMessageContentEvent, type TextMessageEndEvent, type ToolCallStartEvent, type ToolCallArgsEvent, type ToolCallEndEvent, type ToolCallResultEvent, type RunFinishedEvent, type RunErrorEvent, type CustomEvent } from '@ag-ui/core'
 import { Message, ToolExecution } from '@/types/chat'
-import { AGUIStreamEvent, ChatSessionState, ChatUIState, WorkspaceFile, SWARM_AGENT_DISPLAY_NAMES, SwarmAgentStep, TokenUsage } from '@/types/events'
+import { AGUIStreamEvent, ChatSessionState, ChatUIState, InterruptState, WorkspaceFile, SWARM_AGENT_DISPLAY_NAMES, SwarmAgentStep, TokenUsage } from '@/types/events'
 import { useMetadataTracking } from './useMetadataTracking'
 import { useTextBuffer } from './useTextBuffer'
 import { A2A_TOOLS_REQUIRING_POLLING, isA2ATool, getAgentStatusForTool } from './usePolling'
@@ -153,6 +153,33 @@ export const useStreamEvents = ({
     setSessionState(prev => ({
       ...prev,
       reasoning: { text: ev.text, isActive: true }
+    }))
+  }, [setSessionState, setUIState])
+
+  const handleReasoningContentEvent = useCallback((delta: string) => {
+    if (!delta) return
+    if (swarmModeRef.current.isActive) {
+      const stepIndex = swarmModeRef.current.agentSteps.length - 1
+      if (stepIndex >= 0) {
+        const currentStep = swarmModeRef.current.agentSteps[stepIndex]
+        swarmModeRef.current.agentSteps[stepIndex] = {
+          ...currentStep,
+          reasoningText: (currentStep.reasoningText || '') + delta,
+        }
+      }
+      return
+    }
+    setUIState(prev => ({
+      ...prev,
+      isTyping: true,
+      turnPhase: 'reasoning',
+    }))
+    setSessionState(prev => ({
+      ...prev,
+      reasoning: {
+        text: (prev.reasoning?.text || '') + delta,
+        isActive: true,
+      },
     }))
   }, [setSessionState, setUIState])
 
@@ -1625,7 +1652,49 @@ export const useStreamEvents = ({
         case EventType.TOOL_CALL_RESULT:
           handleToolCallResultEvent(event)
           break
+        case EventType.REASONING_START:
+        case EventType.REASONING_MESSAGE_START:
+          setSessionState(prev => ({
+            ...prev,
+            reasoning: { text: '', isActive: true },
+          }))
+          break
+        case EventType.REASONING_MESSAGE_CONTENT:
+          handleReasoningContentEvent(event.delta)
+          break
+        case EventType.REASONING_MESSAGE_END:
+        case EventType.REASONING_END:
+          setSessionState(prev => ({
+            ...prev,
+            reasoning: prev.reasoning
+              ? { ...prev.reasoning, isActive: false }
+              : null,
+          }))
+          break
         case EventType.RUN_FINISHED:
+          if (event.outcome?.type === 'interrupt') {
+            const interrupts = event.outcome.interrupts.map(interrupt => ({
+              id: interrupt.id,
+              name: String(interrupt.metadata?.name || interrupt.message || 'interrupt'),
+              reason: (
+                interrupt.metadata?.reason
+                && typeof interrupt.metadata.reason === 'object'
+              )
+                ? interrupt.metadata.reason as InterruptState['interrupts'][number]['reason']
+                : undefined,
+            }))
+            setSessionState(prev => ({
+              ...prev,
+              interrupt: { interrupts },
+            }))
+            setUIState(prev => ({
+              ...prev,
+              isTyping: false,
+              agentStatus: 'idle',
+              turnPhase: 'waiting_for_user',
+            }))
+            break
+          }
           // Return the cleanup promise so buffered background executions can
           // serialize complete runs. Live stream callers may ignore it.
           return handleCompleteEvent(event).catch(err => {
@@ -1733,6 +1802,7 @@ export const useStreamEvents = ({
     }
   }, [
     handleReasoningEvent,
+    handleReasoningContentEvent,
     handleTextMessageStartEvent,
     handleTextMessageContentEvent,
     handleTextMessageEndEvent,

--- a/chatbot-app/frontend/src/lib/agentcore-runtime-client.ts
+++ b/chatbot-app/frontend/src/lib/agentcore-runtime-client.ts
@@ -204,8 +204,8 @@ export async function getExecutionStatus(
     const runtimeUrl = await getAgentCoreRuntimeUrl()
     const sessionId = extractSessionId(executionId)
     const payload = {
-      thread_id: sessionId,
-      run_id: crypto.randomUUID(),
+      threadId: sessionId,
+      runId: crypto.randomUUID(),
       messages: [],
       tools: [],
       context: [],
@@ -261,8 +261,8 @@ export async function resumeExecution(
   const runtimeUrl = await getAgentCoreRuntimeUrl()
   const sessionId = extractSessionId(executionId)
   const payload = {
-    thread_id: sessionId,
-    run_id: crypto.randomUUID(),
+    threadId: sessionId,
+    runId: crypto.randomUUID(),
     messages: [],
     tools: [],
     context: [],
@@ -317,8 +317,8 @@ export async function pingAgentCoreRuntime(sessionId?: string, userId?: string, 
     console.log(`[AgentCore Warmup] Invoking with sessionId=${warmupSessionId}, userId=${warmupUserId}`)
 
     const payload = {
-      thread_id: warmupSessionId,
-      run_id: crypto.randomUUID(),
+      threadId: warmupSessionId,
+      runId: crypto.randomUUID(),
       messages: [],
       tools: [],
       context: [],

--- a/chatbot-app/frontend/src/types/events.ts
+++ b/chatbot-app/frontend/src/types/events.ts
@@ -10,6 +10,11 @@ import {
   type ToolCallArgsEvent,
   type ToolCallEndEvent,
   type ToolCallResultEvent,
+  type ReasoningStartEvent,
+  type ReasoningMessageStartEvent,
+  type ReasoningMessageContentEvent,
+  type ReasoningMessageEndEvent,
+  type ReasoningEndEvent,
   type CustomEvent,
   EventType,
 } from '@ag-ui/core';
@@ -85,6 +90,11 @@ export const AGUI_EVENT_TYPES = [
   EventType.TOOL_CALL_ARGS,
   EventType.TOOL_CALL_END,
   EventType.TOOL_CALL_RESULT,
+  EventType.REASONING_START,
+  EventType.REASONING_MESSAGE_START,
+  EventType.REASONING_MESSAGE_CONTENT,
+  EventType.REASONING_MESSAGE_END,
+  EventType.REASONING_END,
   EventType.CUSTOM,
 ] as const;
 
@@ -102,6 +112,11 @@ export type AGUIStreamEvent =
   | ToolCallArgsEvent
   | ToolCallEndEvent
   | ToolCallResultEvent
+  | ReasoningStartEvent
+  | ReasoningMessageStartEvent
+  | ReasoningMessageContentEvent
+  | ReasoningMessageEndEvent
+  | ReasoningEndEvent
   | CustomEvent;
 
 // Swarm mode types

--- a/chatbot-app/frontend/src/utils/sseParser.ts
+++ b/chatbot-app/frontend/src/utils/sseParser.ts
@@ -4,7 +4,7 @@
  */
 
 import type { AGUIStreamEvent } from '@/types/events'
-import { EventType } from '@ag-ui/core'
+import { EventSchemas, EventType } from '@ag-ui/core'
 
 /**
  * Parse a single SSE line into event type and data
@@ -120,8 +120,18 @@ export function parseSSEChunk(chunk: string): ParsedSSEChunk {
  * Validate a AGUIStreamEvent has required fields based on its type
  */
 export function validateAGUIStreamEvent(event: AGUIStreamEvent): { valid: boolean; errors: string[] } {
-  const errors: string[] = []
+  const schemaResult = EventSchemas.safeParse(event)
+  if (!schemaResult.success) {
+    return {
+      valid: false,
+      errors: schemaResult.error.issues.map(issue => {
+        const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+        return `${path}${issue.message}`
+      }),
+    }
+  }
 
+  const errors: string[] = []
   switch (event.type) {
     case EventType.RUN_STARTED:
     case EventType.RUN_FINISHED:

--- a/infra/scripts/test-api.sh
+++ b/infra/scripts/test-api.sh
@@ -65,6 +65,16 @@ AUTH_JSON=$(aws cognito-idp initiate-auth \
   --region "$AWS_REGION")
 
 ACCESS_TOKEN=$(echo "$AUTH_JSON" | python3 -c "import json,sys;print(json.load(sys.stdin)['AuthenticationResult']['AccessToken'])")
+USER_ID=$(python3 - "$ACCESS_TOKEN" <<'PY'
+import base64
+import json
+import sys
+
+payload = sys.argv[1].split(".")[1]
+payload += "=" * (-len(payload) % 4)
+print(json.loads(base64.urlsafe_b64decode(payload))["sub"])
+PY
+)
 echo "   got access_token (${#ACCESS_TOKEN} chars)"
 
 # Gateway MCP probe — complete the stateful MCP handshake:
@@ -116,10 +126,29 @@ PY
 # Warmup is the lightest valid action — confirms auth + container readiness.
 echo ""
 echo ">>> Orchestrator: warmup"
+SESSION_ID="smoke-$(python3 -c 'import uuid; print(uuid.uuid4().hex)')"
 curl -sS -X POST "$ORCH_URL" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"thread_id":"smoke-1","run_id":"smoke-run-1","messages":[],"state":{"action":"warmup","user_id":"smoke-test"}}' \
+  -H "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: $SESSION_ID" \
+  -d "$(python3 - "$SESSION_ID" "$USER_ID" <<'PY'
+import json
+import sys
+import uuid
+
+print(json.dumps({
+    "threadId": sys.argv[1],
+    "runId": str(uuid.uuid4()),
+    "messages": [],
+    "tools": [],
+    "context": [],
+    "state": {
+        "action": "warmup",
+        "user_id": sys.argv[2],
+    },
+}))
+PY
+)" \
   | head -c 500
 echo ""
 

--- a/mobile-app/src/hooks/useStreamEvents.ts
+++ b/mobile-app/src/hooks/useStreamEvents.ts
@@ -315,7 +315,48 @@ export function useStreamEvents(opts?: UseStreamEventsOpts) {
           break
         }
 
-        case 'RUN_FINISHED':
+        case 'REASONING_START':
+        case 'REASONING_MESSAGE_START':
+          setAgentStatus('thinking')
+          break
+
+        case 'REASONING_MESSAGE_CONTENT':
+          setMessages(prev => {
+            const lastIndex = prev.length - 1
+            const last = prev[lastIndex]
+            if (last?.role === 'assistant') {
+              return prev.map((message, index) =>
+                index === lastIndex
+                  ? {
+                      ...message,
+                      reasoningText: message.reasoningText + event.delta,
+                    }
+                  : message,
+              )
+            }
+            const carrier = makeEmptyMessage(uuidv4(), 'assistant')
+            return [
+              ...prev,
+              { ...carrier, reasoningText: event.delta },
+            ]
+          })
+          break
+
+        case 'REASONING_MESSAGE_END':
+        case 'REASONING_END':
+          break
+
+        case 'RUN_FINISHED': {
+          if (event.outcome?.type === 'interrupt') {
+            const interrupts = (event.outcome.interrupts ?? []).map(interrupt => ({
+              id: interrupt.id,
+              name: interrupt.metadata?.name ?? interrupt.message ?? 'interrupt',
+              reason: interrupt.metadata?.reason,
+            }))
+            if (interrupts.length > 0) {
+              setPendingInterrupt({ interrupts })
+            }
+          }
           stopTextBuffer()
           // Fire run_finished signal with all completed tools
           if (completedToolsRef.current.length > 0) {
@@ -327,6 +368,7 @@ export function useStreamEvents(opts?: UseStreamEventsOpts) {
           completedToolsRef.current = []
           setAgentStatus('idle')
           break
+        }
 
         case 'RUN_ERROR': {
           stopTextBuffer()

--- a/mobile-app/src/types/events.ts
+++ b/mobile-app/src/types/events.ts
@@ -76,11 +76,48 @@ export interface RunFinishedEvent {
   type: 'RUN_FINISHED'
   threadId: string
   runId: string
+  outcome?: {
+    type: 'success' | 'interrupt'
+    interrupts?: Array<{
+      id: string
+      message?: string
+      metadata?: {
+        name?: string
+        reason?: InterruptReason
+      }
+    }>
+  }
 }
 
 export interface RunErrorEvent {
   type: 'RUN_ERROR'
   message: string
+}
+
+export interface ReasoningStartEvent {
+  type: 'REASONING_START'
+  messageId: string
+}
+
+export interface ReasoningMessageStartEvent {
+  type: 'REASONING_MESSAGE_START'
+  messageId: string
+}
+
+export interface ReasoningMessageContentEvent {
+  type: 'REASONING_MESSAGE_CONTENT'
+  messageId: string
+  delta: string
+}
+
+export interface ReasoningMessageEndEvent {
+  type: 'REASONING_MESSAGE_END'
+  messageId: string
+}
+
+export interface ReasoningEndEvent {
+  type: 'REASONING_END'
+  messageId: string
 }
 
 // ─── CUSTOM event subtypes ────────────────────────────────────────────────────
@@ -210,6 +247,11 @@ export type AGUIEvent =
   | ToolCallArgsEvent
   | ToolCallEndEvent
   | ToolCallResultEvent
+  | ReasoningStartEvent
+  | ReasoningMessageStartEvent
+  | ReasoningMessageContentEvent
+  | ReasoningMessageEndEvent
+  | ReasoningEndEvent
   | RunFinishedEvent
   | RunErrorEvent
   | AnyCustomEvent
@@ -217,5 +259,7 @@ export type AGUIEvent =
 export const AGUI_STANDARD_TYPES = new Set([
   'RUN_STARTED', 'TEXT_MESSAGE_START', 'TEXT_MESSAGE_CONTENT', 'TEXT_MESSAGE_END',
   'TOOL_CALL_START', 'TOOL_CALL_ARGS', 'TOOL_CALL_END', 'TOOL_CALL_RESULT',
+  'REASONING_START', 'REASONING_MESSAGE_START', 'REASONING_MESSAGE_CONTENT',
+  'REASONING_MESSAGE_END', 'REASONING_END',
   'RUN_FINISHED', 'RUN_ERROR', 'CUSTOM',
 ])

--- a/telegram-app/src/agentcore-client.ts
+++ b/telegram-app/src/agentcore-client.ts
@@ -109,6 +109,11 @@ function buildPayload(
   chatId: number,
   content: string | ContentPart[],
   sessionId: string,
+  resume?: Array<{
+    interruptId: string;
+    status: "resolved" | "cancelled";
+    payload?: unknown;
+  }>,
 ) {
   const runId = randomUUID();
   const messages =
@@ -117,11 +122,12 @@ function buildPayload(
       : [{ id: "msg-1", role: "user", content }];
 
   return {
-    thread_id: sessionId,
-    run_id: runId,
+    threadId: sessionId,
+    runId,
     messages,
     tools: [],
     context: [],
+    ...(resume && resume.length > 0 ? { resume } : {}),
     state: {
       user_id: resolveUserId(chatId),
       channel: "telegram",
@@ -135,10 +141,15 @@ export async function invokeAgent(
   chatId: number,
   content: string | ContentPart[],
   onProgress?: ProgressCallback,
+  resume?: Array<{
+    interruptId: string;
+    status: "resolved" | "cancelled";
+    payload?: unknown;
+  }>,
 ): Promise<AgentResponse> {
   const sessionId = buildSessionId(chatId);
   const token = await getAccessToken();
-  const payload = buildPayload(chatId, content, sessionId);
+  const payload = buildPayload(chatId, content, sessionId, resume);
 
   logger.info({ chatId, sessionId }, "Invoking AgentCore");
 

--- a/telegram-app/src/message-handler.ts
+++ b/telegram-app/src/message-handler.ts
@@ -169,8 +169,17 @@ async function handleCallbackQuery(ctx: Context): Promise<void> {
   };
   onProgress("start");
 
-  const content = JSON.stringify([{ interruptResponse: { interruptId, response: approved ? "approved" : "declined" } }]);
-  const agentResponse = await invokeAgent(chatId, content, onProgress);
+  const response = approved ? "approved" : "declined";
+  const agentResponse = await invokeAgent(
+    chatId,
+    "",
+    onProgress,
+    [{
+      interruptId,
+      status: approved ? "resolved" : "cancelled",
+      payload: response,
+    }],
+  );
   await sendAgentResponse(ctx.api, chatId, agentResponse);
 }
 


### PR DESCRIPTION
## Summary
- bind Runtime-verified JWT identities to AG-UI threads, runs, resume, status, and stop operations
- accept the standard camelCase RunAgentInput contract and standardize error, reasoning, interrupt, and terminal event lifecycles
- isolate execution buffers by user, add cursor replay and byte limits, and update web, mobile, and Telegram consumers
- update the deployment smoke script to use the authenticated JWT subject and standard AG-UI payloads

## CI coverage
- add backend regression tests for ownership, M2M delegation, input bounds, buffer limits, cursor handling, terminal ordering, reasoning, and HITL outcomes
- validate frontend stream events with @ag-ui/core EventSchemas
- existing required jobs run backend lint/unit/integration, frontend type/test/build, mobile type-check, Telegram build, and infra validation

## Verification
- backend: 773 passed, 15 deselected; Ruff passed
- frontend: 731 passed; type-check and production build passed
- mobile: TypeScript check passed
- Telegram: build passed
- dev Runtime v53 READY; web revision 73 and Telegram revision 5 stable
- deployed smoke: authenticated camelCase request, real model SSE, single terminal event, official EventSchemas validation, identity mismatch rejection, and cross-user execution lookup isolation passed