### PR TITLE
Fix Code Interpreter mounted workspace persistence

### DIFF
--- a/chatbot-app/agentcore/skills/code-interpreter/SKILL.md
+++ b/chatbot-app/agentcore/skills/code-interpreter/SKILL.md
@@ -11,8 +11,7 @@ A general-purpose code execution environment powered by AWS Bedrock AgentCore Co
 
 - **execute_code(code, language, output_filename)**: Execute Python, JavaScript, or TypeScript code.
 - **execute_command(command)**: Execute shell commands.
-- **file_operations(operation, paths, content)**: Read, write, list, or remove files in the sandbox.
-- **ci_push_to_workspace(paths)**: Compatibility helper for environments without a mounted workspace. Do not call it when `/mnt/workspace` is available.
+- **file_operations(operation, paths, content)**: Read, write, list, or remove files in the mounted session workspace.
 
 ## Tool Parameters
 
@@ -144,6 +143,9 @@ Files written there are immediately available in the Workspace panel under the
 `code-interpreter/` namespace and remain available when the interpreter session
 is restarted.
 
+The mount is required. If it cannot be configured or attached, Code Interpreter
+returns an error instead of starting an isolated non-persistent session.
+
 **Create persistent files directly:**
 
 ```json
@@ -154,9 +156,7 @@ is restarted.
 ```
 
 `output_filename` may still be used when a generated file should be surfaced as
-an explicit artifact. It is not required for persistence. Do not call
-`ci_push_to_workspace` when the mount is available; that tool remains only for
-legacy fallback deployments.
+an explicit artifact. It is not required for persistence.
 
 **Uploaded files:**
 
@@ -164,10 +164,6 @@ Files uploaded by the user are available in the mounted workspace without
 manual loading or base64 transfer under `/mnt/workspace/inputs`. JSON, JSONL,
 and NDJSON attachments may be represented by a bounded text excerpt in the
 conversation; use the mounted file when the full dataset is needed.
-
-If the session reports that the S3 Files mount is unavailable, the legacy
-fallback preloads the same uploads into the Code Interpreter working directory
-by filename. Use `ls` to confirm the path, then read `<filename>` directly.
 
 **Read saved files via workspace skill:**
 ```

--- a/chatbot-app/agentcore/skills/workspace/SKILL.md
+++ b/chatbot-app/agentcore/skills/workspace/SKILL.md
@@ -19,11 +19,9 @@ Provides unified read/write access to all files in the current session. The `use
 | `documents/excel/<file>` | Excel spreadsheets |
 | `documents/image/<file>` | Images from other tools |
 
-> **Note:** When the S3 Files mount is active, files written under
-> `/mnt/workspace` persist for the chat session and user uploads are available
-> under `/mnt/workspace/inputs`. Legacy Code Interpreter sessions preload the
-> same uploads into their working directory by filename. Code Agent downloads
-> session uploads into its own working directory when delegated.
+> **Note:** Files written under `/mnt/workspace` persist for the chat session,
+> and user uploads are available under `/mnt/workspace/inputs`. Code Agent
+> downloads session uploads into its own working directory when delegated.
 
 ## Usage
 
@@ -52,8 +50,7 @@ workspace_write("code-agent/data.xlsx", result["content"], encoding="base64")
 - Text files return `encoding: "text"` with plain string content. Large text
   reads are bounded; when `truncated` is true, use Code Interpreter for the
   complete file instead of repeatedly reading it into model context. Code
-  Interpreter uses `/mnt/workspace/inputs/<file>` with the mount, or `<file>`
-  in its working directory in legacy fallback mode.
+  Interpreter uses `/mnt/workspace/inputs/<file>`.
 - JSON, JSONL, and NDJSON uploads are text files; large chat attachments may
   be truncated in model context, but the complete file remains under `uploads/`
 - Binary files (images, Office docs, PDF, etc.) return `encoding: "base64"`

--- a/chatbot-app/agentcore/src/agent/processor/file_processor.py
+++ b/chatbot-app/agentcore/src/agent/processor/file_processor.py
@@ -286,6 +286,7 @@ def auto_store_files(
             import boto3
 
             from workspace.config import get_workspace_bucket
+            from workspace.paths import code_interpreter_prefix
 
             s3 = boto3.client(
                 "s3",
@@ -294,7 +295,7 @@ def auto_store_files(
             bucket = get_workspace_bucket()
             for file_info in uploaded_files:
                 key = (
-                    f"code-interpreter-workspace/{user_id}/{session_id}/"
+                    f"{code_interpreter_prefix(user_id, session_id)}"
                     f"inputs/{file_info['filename']}"
                 )
                 try:

--- a/chatbot-app/agentcore/src/builtin_tools/__init__.py
+++ b/chatbot-app/agentcore/src/builtin_tools/__init__.py
@@ -87,10 +87,6 @@ _EXPORTS = {
     "execute_code": (".code_interpreter_tool", "execute_code"),
     "execute_command": (".code_interpreter_tool", "execute_command"),
     "file_operations": (".code_interpreter_tool", "file_operations"),
-    "ci_push_to_workspace": (
-        ".code_interpreter_tool",
-        "ci_push_to_workspace",
-    ),
 }
 
 __all__ = list(_EXPORTS)

--- a/chatbot-app/agentcore/src/builtin_tools/code_interpreter_tool.py
+++ b/chatbot-app/agentcore/src/builtin_tools/code_interpreter_tool.py
@@ -1,23 +1,22 @@
 """General-purpose Code Interpreter tools using AWS Bedrock AgentCore Code Interpreter.
 
-Provides 4 tools wrapping CodeInterpreter (bedrock_agentcore):
+Provides 3 tools wrapping CodeInterpreter (bedrock_agentcore):
   - execute_code:    Run Python/JS/TS code
   - execute_command: Run shell commands
-  - file_operations: Read/write/list/remove files in the sandbox
-  - ci_push_to_workspace: Save sandbox files to S3
+  - file_operations: Read/write/list/remove files in the mounted workspace
 
 All tools share a single persistent CI session per user/session — files and
 variables persist across tool calls. Word, Excel, and other document tools
 use the same session via get_ci_session().
 
 Session ID is cached in agent.state so it survives across turns without
-creating new sessions. If a session times out (15 min idle), a new one is
-created automatically and workspace files are re-synced.
+creating new sessions. Every session requires the session-scoped S3 Files
+workspace mounted at /mnt/workspace.
 """
 
 from strands import tool, ToolContext
 from skill import register_skill
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 import json
 import logging
 import os
@@ -28,10 +27,6 @@ logger = logging.getLogger(__name__)
 # This avoids re-creating CodeInterpreter objects within the same process.
 # The actual session_id is stored in agent.state for cross-turn persistence.
 _ci_clients: Dict[str, Any] = {}
-
-# Tracks which S3 keys have been synced to legacy CI sessions to avoid re-downloading.
-# Key: session_key (user_id-session_id), Value: set of S3 object keys already loaded.
-_synced_s3_keys: Dict[str, set] = {}
 
 # agent.state keys for CI session persistence
 _STATE_CI_SESSION_ID = "ci_session_id"
@@ -46,7 +41,7 @@ def invalidate_session(user_id: str, session_id: str) -> None:
     """Remove cached CI client so next tool call creates a fresh session.
 
     Called by file_processor.auto_store_files() after uploading new files,
-    so the next tool call will re-create the session and preload workspace.
+    so the next tool call will create a new mounted session.
     """
     session_key = f"{user_id}-{session_id}"
     if session_key in _ci_clients:
@@ -56,7 +51,6 @@ def invalidate_session(user_id: str, session_id: str) -> None:
             pass
         del _ci_clients[session_key]
         logger.info(f"Invalidated CI client cache: {session_key}")
-    _synced_s3_keys.pop(session_key, None)
 
 
 
@@ -91,14 +85,14 @@ def _is_session_alive(ci: Any, identifier: str, ci_session_id: str) -> bool:
         return False
 
 
-def get_ci_session(tool_context: ToolContext) -> Optional[Any]:
+def get_ci_session(tool_context: ToolContext) -> Any:
     """Get or create a shared CodeInterpreter session for all tools.
 
     Session lifecycle:
     1. Check in-process cache (_ci_clients) for existing client
     2. Check agent.state for stored session_id (cross-turn persistence)
     3. Verify session is still READY via get_session() API
-    4. If expired/missing, create new session and preload workspace files
+    4. If expired/missing, create a new session with the S3 Files mount
     5. Store new session_id in agent.state
 
     All tools (execute_code, word, excel, powerpoint, etc.) call this to get
@@ -108,7 +102,11 @@ def get_ci_session(tool_context: ToolContext) -> Optional[Any]:
         tool_context: Strands ToolContext (provides agent.state + invocation_state)
 
     Returns:
-        CodeInterpreter instance, or None if CODE_INTERPRETER_ID not configured.
+        CodeInterpreter instance with the session workspace mounted.
+
+    Raises:
+        RuntimeError: If Code Interpreter or the S3 Files workspace is not
+            configured, or the mounted session cannot be started.
     """
     from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
 
@@ -121,13 +119,32 @@ def get_ci_session(tool_context: ToolContext) -> Optional[Any]:
     # Step 1: Try in-process cache (fast path — same process, same turn or consecutive turns)
     ci = _ci_clients.get(session_key)
     if ci is not None:
+        if tool_context.agent.state.get(_STATE_CI_MOUNTED_WORKSPACE) is not True:
+            logger.info("Discarding non-mounted cached CI session: %s", session_key)
+            try:
+                ci.stop()
+            except Exception:
+                pass
+            del _ci_clients[session_key]
+            ci = None
+
+    if ci is not None:
         # Verify the cached client's session is still alive
         stored_id = ci.session_id
         stored_identifier = ci.identifier
         if stored_id and stored_identifier and _is_session_alive(ci, stored_identifier, stored_id):
-            if tool_context.agent.state.get(_STATE_CI_MOUNTED_WORKSPACE) is not True:
-                _sync_new_workspace_files(ci, user_id, session_id)
-            return ci
+            try:
+                _prepare_mounted_workspace(ci)
+                return ci
+            except Exception as error:
+                logger.warning(
+                    "Cached CI session workspace is unavailable; recreating: %s",
+                    error,
+                )
+                try:
+                    ci.stop()
+                except Exception:
+                    pass
         # Session expired — remove stale cache
         logger.info(f"Cached CI session expired: {session_key}")
         del _ci_clients[session_key]
@@ -137,74 +154,97 @@ def get_ci_session(tool_context: ToolContext) -> Optional[Any]:
     stored_session_id = agent_state.get(_STATE_CI_SESSION_ID)
     stored_identifier = agent_state.get(_STATE_CI_IDENTIFIER)
 
-    if stored_session_id and stored_identifier:
+    mounted_session = agent_state.get(_STATE_CI_MOUNTED_WORKSPACE) is True
+    if stored_session_id and stored_identifier and mounted_session:
         ci = CodeInterpreter(region)
         ci.identifier = stored_identifier
         ci.session_id = stored_session_id
         if _is_session_alive(ci, stored_identifier, stored_session_id):
-            logger.info(f"Reattached to existing CI session: {stored_session_id}")
-            _ci_clients[session_key] = ci
-            if agent_state.get(_STATE_CI_MOUNTED_WORKSPACE) is not True:
-                _sync_new_workspace_files(ci, user_id, session_id)
-            return ci
+            try:
+                _prepare_mounted_workspace(ci)
+                logger.info(f"Reattached to existing CI session: {stored_session_id}")
+                _ci_clients[session_key] = ci
+                return ci
+            except Exception as error:
+                logger.warning(
+                    "Stored CI session workspace is unavailable; recreating: %s",
+                    error,
+                )
+                try:
+                    ci.stop()
+                except Exception:
+                    pass
         logger.info(f"Stored CI session expired ({stored_session_id}), creating new one")
+    elif stored_session_id:
+        logger.info(
+            "Ignoring stored CI session without a mounted workspace: %s",
+            stored_session_id,
+        )
 
     # Step 3: Create a new session
     identifier = stored_identifier or _get_code_interpreter_id()
     if not identifier:
-        return None
+        raise RuntimeError(
+            "Code Interpreter is not configured: CODE_INTERPRETER_ID is missing"
+        )
 
     ci = CodeInterpreter(region)
-    mounted_workspace = False
+    from workspace.s3_files import get_or_create_session_access_point
+
+    workspace = get_or_create_session_access_point(
+        agent_state,
+        user_id,
+        session_id,
+    )
+    if not workspace:
+        raise RuntimeError(
+            "Code Interpreter workspace is not configured: "
+            "S3_FILES_FILE_SYSTEM_ID and S3_FILES_FILE_SYSTEM_ARN are required"
+        )
+
     try:
-        from workspace.s3_files import get_or_create_session_access_point
-
-        workspace = get_or_create_session_access_point(
-            agent_state,
-            user_id,
-            session_id,
+        response = ci.data_plane_client.start_code_interpreter_session(
+            codeInterpreterIdentifier=identifier,
+            name=f"workspace-{session_id[:32]}",
+            sessionTimeoutSeconds=_SESSION_TIMEOUT_SECONDS,
+            filesystemConfigurations=[{
+                "s3FilesConfiguration": {
+                    "fileSystemArn": workspace["file_system_arn"],
+                    "accessPointArn": workspace["access_point_arn"],
+                    "mountPath": workspace["mount_path"],
+                },
+            }],
         )
-        if workspace:
-            response = ci.data_plane_client.start_code_interpreter_session(
-                codeInterpreterIdentifier=identifier,
-                name=f"workspace-{session_id[:32]}",
-                sessionTimeoutSeconds=_SESSION_TIMEOUT_SECONDS,
-                filesystemConfigurations=[{
-                    "s3FilesConfiguration": {
-                        "fileSystemArn": workspace["file_system_arn"],
-                        "accessPointArn": workspace["access_point_arn"],
-                        "mountPath": workspace["mount_path"],
-                    },
-                }],
-            )
-            ci.identifier = response["codeInterpreterIdentifier"]
-            ci.session_id = response["sessionId"]
-            mounted_workspace = True
+        ci.identifier = response["codeInterpreterIdentifier"]
+        ci.session_id = response["sessionId"]
     except Exception as error:
-        logger.exception(
-            "Could not start Code Interpreter with S3 Files; using legacy sync: %s",
-            error,
-        )
+        raise RuntimeError(
+            f"Could not start Code Interpreter with the S3 Files workspace: {error}"
+        ) from error
 
-    if not mounted_workspace:
-        ci.start(
-            identifier=identifier,
-            session_timeout_seconds=_SESSION_TIMEOUT_SECONDS,
-        )
     logger.info(f"Created new CI session: {ci.session_id} (identifier: {identifier}, timeout: {_SESSION_TIMEOUT_SECONDS}s)")
 
     # Store in agent.state for cross-turn persistence
     agent_state.set(_STATE_CI_SESSION_ID, ci.session_id)
     agent_state.set(_STATE_CI_IDENTIFIER, identifier)
-    agent_state.set(_STATE_CI_MOUNTED_WORKSPACE, mounted_workspace)
+    agent_state.set(_STATE_CI_MOUNTED_WORKSPACE, True)
 
     # Cache in-process
     _ci_clients[session_key] = ci
 
-    if mounted_workspace:
+    try:
         _prepare_mounted_workspace(ci)
-    else:
-        _preload_workspace_files(ci, user_id, session_id)
+    except Exception as error:
+        _ci_clients.pop(session_key, None)
+        agent_state.set(_STATE_CI_SESSION_ID, None)
+        agent_state.set(_STATE_CI_MOUNTED_WORKSPACE, False)
+        try:
+            ci.stop()
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"Could not initialize the mounted Code Interpreter workspace: {error}"
+        ) from error
 
     return ci
 
@@ -214,7 +254,9 @@ def _prepare_mounted_workspace(ci: Any) -> None:
     mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
     code = (
         "import os\n"
-        f"os.makedirs({mount_path!r}, exist_ok=True)\n"
+        f"_mount = {mount_path!r}\n"
+        "if not os.path.isdir(_mount):\n"
+        "    raise RuntimeError(f'Mounted workspace is unavailable: {_mount}')\n"
         f"os.chdir({mount_path!r})\n"
         "_inputs = os.path.join(os.getcwd(), 'inputs')\n"
         "if os.path.isdir(_inputs):\n"
@@ -228,10 +270,6 @@ def _prepare_mounted_workspace(ci: Any) -> None:
     _, stderr, has_error = _parse_stream(response)
     if has_error:
         raise RuntimeError(f"Could not initialize mounted workspace: {stderr}")
-
-
-def _uses_mounted_workspace(tool_context: ToolContext) -> bool:
-    return tool_context.agent.state.get(_STATE_CI_MOUNTED_WORKSPACE) is True
 
 
 def _mounted_path(path: str) -> str:
@@ -254,7 +292,7 @@ def _prepare_code_for_mounted_workspace(code: str, language: str) -> str:
     return f"Deno.chdir({json.dumps(mount_path)});\n{code}"
 
 
-def _get_ci_from_context(tool_context: ToolContext) -> Optional[Any]:
+def _get_ci_from_context(tool_context: ToolContext) -> Any:
     """Get CI session using ToolContext (convenience wrapper)."""
     return get_ci_session(tool_context)
 
@@ -277,194 +315,6 @@ def _parse_stream(response: dict) -> tuple:
         if stdout:
             stdout_parts.append(stdout)
     return "".join(stdout_parts), stderr, has_error
-
-
-def _get_workspace_s3_prefixes(user_id: str, session_id: str) -> List[str]:
-    """Return S3 prefixes for all workspace document types."""
-    return [
-        f"code-interpreter-workspace/{user_id}/{session_id}/inputs/",
-        f"documents/{user_id}/{session_id}/zip/",
-        f"documents/{user_id}/{session_id}/word/",
-        f"documents/{user_id}/{session_id}/excel/",
-        f"documents/{user_id}/{session_id}/powerpoint/",
-        f"documents/{user_id}/{session_id}/image/",
-        f"documents/{user_id}/{session_id}/code-output/",
-        f"documents/{user_id}/{session_id}/raw/",
-    ]
-
-
-def _upload_s3_file_to_ci(ci: Any, s3_client: Any, bucket: str, s3_key: str) -> None:
-    """Download a single file from S3 and write it into the CI sandbox."""
-    import base64
-
-    filename = s3_key.split('/')[-1]
-    if not filename:
-        return
-    data = s3_client.get_object(Bucket=bucket, Key=s3_key)['Body'].read()
-    b64 = base64.b64encode(data).decode('utf-8')
-    code = (
-        f"import base64\n"
-        f"with open('{filename}', 'wb') as _f:\n"
-        f"    _f.write(base64.b64decode('{b64}'))\n"
-        f"print('Loaded: {filename}')\n"
-    )
-    ci.invoke("executeCode", {
-        "code": code,
-        "language": "python",
-        "clearContext": False,
-    })
-
-
-def _preload_workspace_files(ci: Any, user_id: str, session_id: str) -> None:
-    """Load all workspace files from S3 into a newly created CI sandbox."""
-    import boto3
-
-    session_key = f"{user_id}-{session_id}"
-    _synced_s3_keys[session_key] = set()
-
-    try:
-        from workspace.config import get_workspace_bucket
-        bucket = get_workspace_bucket()
-        s3 = boto3.client('s3', region_name=os.getenv('AWS_REGION', 'us-west-2'))
-
-        for prefix in _get_workspace_s3_prefixes(user_id, session_id):
-            response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
-            for obj in response.get('Contents', []):
-                s3_key = obj['Key']
-                try:
-                    _upload_s3_file_to_ci(ci, s3, bucket, s3_key)
-                    _synced_s3_keys[session_key].add(s3_key)
-                    logger.info(f"Preloaded into CI sandbox: {s3_key.split('/')[-1]}")
-                except Exception as e:
-                    logger.warning(f"Failed to preload {s3_key}: {e}")
-
-    except Exception as e:
-        logger.warning(f"_preload_workspace_files failed: {e}")
-
-
-def _sync_new_workspace_files(ci: Any, user_id: str, session_id: str) -> None:
-    """Sync only new S3 files into an existing CI session (delta sync)."""
-    import boto3
-
-    session_key = f"{user_id}-{session_id}"
-    synced = _synced_s3_keys.get(session_key)
-    if synced is None:
-        # No tracking info — skip rather than re-downloading everything
-        _synced_s3_keys[session_key] = set()
-        synced = _synced_s3_keys[session_key]
-
-    try:
-        from workspace.config import get_workspace_bucket
-        bucket = get_workspace_bucket()
-        s3 = boto3.client('s3', region_name=os.getenv('AWS_REGION', 'us-west-2'))
-
-        new_count = 0
-        for prefix in _get_workspace_s3_prefixes(user_id, session_id):
-            response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
-            for obj in response.get('Contents', []):
-                s3_key = obj['Key']
-                if s3_key in synced:
-                    continue
-                try:
-                    _upload_s3_file_to_ci(ci, s3, bucket, s3_key)
-                    synced.add(s3_key)
-                    new_count += 1
-                    logger.info(f"Delta-synced to CI sandbox: {s3_key.split('/')[-1]}")
-                except Exception as e:
-                    logger.warning(f"Failed to delta-sync {s3_key}: {e}")
-
-        if new_count:
-            logger.info(f"Delta sync complete: {new_count} new file(s) synced to CI")
-
-    except Exception as e:
-        logger.warning(f"_sync_new_workspace_files failed: {e}")
-
-
-def _resolve_doc_type(filename: str) -> str:
-    """Determine workspace document type from file extension."""
-    ext = filename.lower().rsplit('.', 1)[-1] if '.' in filename else ''
-    if ext == 'docx':
-        return 'word'
-    if ext == 'xlsx':
-        return 'excel'
-    if ext == 'pptx':
-        return 'powerpoint'
-    if ext in ('png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'pdf'):
-        return 'image'
-    return 'code-output'
-
-
-def _save_to_workspace(tool_context: ToolContext, filename: str, file_bytes: bytes) -> Optional[dict]:
-    """Save a generated file to the workspace (S3) under the correct documents/ prefix.
-
-    Routes files based on extension:
-      .docx → word/  |  .xlsx → excel/  |  .pptx → powerpoint/
-      images/pdf → image/  |  everything else → code-output/
-    """
-    try:
-        from workspace import WordManager, ExcelManager, PowerPointManager, ImageManager
-        from workspace.base_manager import BaseDocumentManager
-
-        invocation_state = tool_context.invocation_state
-        user_id = invocation_state.get('user_id', 'default_user')
-        session_id = invocation_state.get('session_id', 'default_session')
-
-        doc_type = _resolve_doc_type(filename)
-        manager_map = {
-            'word': lambda: WordManager(user_id, session_id),
-            'excel': lambda: ExcelManager(user_id, session_id),
-            'powerpoint': lambda: PowerPointManager(user_id, session_id),
-            'image': lambda: ImageManager(user_id, session_id),
-        }
-        if doc_type in manager_map:
-            manager = manager_map[doc_type]()
-        else:
-            manager = BaseDocumentManager(user_id, session_id, document_type='code-output')
-
-        s3_info = manager.save_to_s3(
-            filename,
-            file_bytes,
-            metadata={'source': 'code_interpreter_tool'},
-        )
-        logger.info(f"Saved to workspace: {s3_info['s3_key']} (type={doc_type})")
-
-        # Save artifact to agent.state for Canvas display
-        try:
-            from datetime import datetime, timezone
-            artifact_id = f"ci-{filename.rsplit('.', 1)[0]}"
-            artifacts = tool_context.agent.state.get("artifacts") or {}
-            artifacts[artifact_id] = {
-                "id": artifact_id,
-                "type": doc_type,
-                "title": filename,
-                "content": s3_info.get('s3_url', s3_info['s3_key']),
-                "tool_name": "execute_code",
-                "metadata": {
-                    "filename": filename,
-                    "s3_key": s3_info['s3_key'],
-                    "size_kb": f"{len(file_bytes) / 1024:.1f}",
-                    "doc_type": doc_type,
-                },
-                "created_at": artifacts.get(artifact_id, {}).get(
-                    "created_at", datetime.now(timezone.utc).isoformat()
-                ),
-                "updated_at": datetime.now(timezone.utc).isoformat(),
-            }
-            tool_context.agent.state.set("artifacts", artifacts)
-
-            session_manager = tool_context.invocation_state.get("session_manager")
-            if not session_manager and hasattr(tool_context.agent, "session_manager"):
-                session_manager = tool_context.agent.session_manager
-            if session_manager:
-                session_manager.sync_agent(tool_context.agent)
-                logger.info(f"Saved CI artifact: {artifact_id}")
-        except Exception as e:
-            logger.warning(f"Failed to save CI artifact to agent.state: {e}")
-
-        return {'s3_key': s3_info['s3_key'], 'doc_type': doc_type, 'bucket': manager.bucket}
-    except Exception as e:
-        logger.warning(f"Could not save to workspace: {e}")
-        return None
 
 
 # -----------------------------------------------------------------------
@@ -492,18 +342,9 @@ def execute_code(
     Returns:
         Execution stdout, or file confirmation if output_filename is set.
     """
-    ci = _get_ci_from_context(tool_context)
-    if ci is None:
-        return json.dumps({
-            "error": "Code Interpreter not available. Deploy AgentCore Runtime Stack.",
-            "status": "error",
-        })
-
     try:
-        mounted = _uses_mounted_workspace(tool_context)
-        if mounted:
-            _prepare_mounted_workspace(ci)
-            code = _prepare_code_for_mounted_workspace(code, language)
+        ci = _get_ci_from_context(tool_context)
+        code = _prepare_code_for_mounted_workspace(code, language)
         response = ci.invoke("executeCode", {
             "code": code,
             "language": language,
@@ -522,7 +363,7 @@ def execute_code(
             return stdout or "(no output)"
 
         # Download output file
-        output_path = _mounted_path(output_filename) if mounted else output_filename
+        output_path = _mounted_path(output_filename)
         download_response = ci.invoke("readFiles", {"paths": [output_path]})
         for event in download_response.get("stream", []):
             result = event.get("result", {})
@@ -531,14 +372,8 @@ def execute_code(
                     continue
                 blob = item.get("data") or item.get("resource", {}).get("blob")
                 if blob:
-                    if not mounted:
-                        _save_to_workspace(tool_context, output_filename, blob)
                     size_kb = len(blob) / 1024
-                    workspace_path = (
-                        f"code-interpreter/{output_filename}"
-                        if mounted
-                        else output_filename
-                    )
+                    workspace_path = f"code-interpreter/{output_filename}"
                     summary = f"Code executed. File saved: {workspace_path} ({size_kb:.1f} KB)"
                     if stdout:
                         summary += f"\n\nstdout:\n{stdout[:500]}"
@@ -588,17 +423,10 @@ def execute_command(
     Returns:
         Command stdout/stderr output.
     """
-    ci = _get_ci_from_context(tool_context)
-    if ci is None:
-        return json.dumps({
-            "error": "Code Interpreter not available. Deploy AgentCore Runtime Stack.",
-            "status": "error",
-        })
-
     try:
-        if _uses_mounted_workspace(tool_context):
-            mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
-            command = f"cd {json.dumps(mount_path)} && {command}"
+        ci = _get_ci_from_context(tool_context)
+        mount_path = os.getenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
+        command = f"cd {json.dumps(mount_path)} && {command}"
         response = ci.invoke("executeCommand", {"command": command})
         stdout, stderr, has_error = _parse_stream(response)
         if has_error:
@@ -621,7 +449,7 @@ def file_operations(
     content: list = None,
     tool_context: ToolContext = None,
 ) -> str:
-    """Manage files in the Code Interpreter sandbox.
+    """Manage files in the mounted Code Interpreter workspace.
 
     Args:
         operation: One of "read", "write", "list", "remove".
@@ -635,46 +463,54 @@ def file_operations(
     Returns:
         Operation result (file content, file list, or confirmation).
     """
-    ci = _get_ci_from_context(tool_context)
-    if ci is None:
-        return json.dumps({
-            "error": "Code Interpreter not available. Deploy AgentCore Runtime Stack.",
-            "status": "error",
-        })
-
     try:
+        ci = _get_ci_from_context(tool_context)
         if operation == "read":
             if not paths:
                 return json.dumps({"error": "paths required for read operation", "status": "error"})
-            resolved_paths = (
-                [_mounted_path(path) for path in paths]
-                if _uses_mounted_workspace(tool_context)
-                else paths
+            resolved_paths = [_mounted_path(path) for path in paths]
+            code = (
+                "import json\n"
+                f"_paths = {json.dumps(resolved_paths)}\n"
+                "_results = []\n"
+                "for _p in _paths:\n"
+                "    with open(_p, 'r', encoding='utf-8', errors='replace') as _f:\n"
+                "        _text = _f.read(1000001)\n"
+                "    _results.append({\n"
+                "        'path': _p,\n"
+                "        'text': _text[:1000000],\n"
+                "        'truncated': len(_text) > 1000000,\n"
+                "    })\n"
+                "print(json.dumps(_results))\n"
             )
-            download_response = ci.invoke("readFiles", {"paths": resolved_paths})
-            parts = []
-            for event in download_response.get("stream", []):
-                result = event.get("result", {})
-                for item in result.get("content", []):
-                    if not isinstance(item, dict):
-                        continue
-                    text = item.get("text", "")
-                    if text:
-                        parts.append(text)
-            return "\n".join(parts) if parts else "(empty)"
+            response = ci.invoke(
+                "executeCode",
+                {"code": code, "language": "python", "clearContext": False},
+            )
+            stdout, stderr, has_error = _parse_stream(response)
+            if has_error:
+                return json.dumps({"error": stderr, "status": "error"})
+            try:
+                results = json.loads(stdout)
+            except json.JSONDecodeError:
+                return json.dumps({
+                    "error": "Code Interpreter returned an invalid read result",
+                    "status": "error",
+                })
+            if len(results) == 1 and not results[0]["truncated"]:
+                return results[0]["text"] or "(empty)"
+            return json.dumps({"files": results, "status": "success"})
 
         elif operation == "write":
             if not content:
                 return json.dumps({"error": "content required for write operation", "status": "error"})
             results = []
             for entry in content:
-                path = (
-                    _mounted_path(entry["path"])
-                    if _uses_mounted_workspace(tool_context)
-                    else entry["path"]
-                )
+                path = _mounted_path(entry["path"])
                 code = (
-                    f"with open({path!r}, 'w') as _f:\n"
+                    "import os\n"
+                    f"os.makedirs(os.path.dirname({path!r}), exist_ok=True)\n"
+                    f"with open({path!r}, 'w', encoding='utf-8') as _f:\n"
                     f"    _f.write({entry['text']!r})\n"
                     f"print('Written: {path}')\n"
                 )
@@ -688,8 +524,7 @@ def file_operations(
 
         elif operation == "list":
             list_path = paths[0] if paths else "."
-            if _uses_mounted_workspace(tool_context):
-                list_path = _mounted_path(list_path)
+            list_path = _mounted_path(list_path)
             code = (
                 "import os, json\n"
                 f"_p = {list_path!r}\n"
@@ -708,11 +543,7 @@ def file_operations(
         elif operation == "remove":
             if not paths:
                 return json.dumps({"error": "paths required for remove operation", "status": "error"})
-            resolved_paths = (
-                [_mounted_path(path) for path in paths]
-                if _uses_mounted_workspace(tool_context)
-                else paths
-            )
+            resolved_paths = [_mounted_path(path) for path in paths]
             escaped = json.dumps(resolved_paths)
             code = (
                 f"import os\n"
@@ -737,123 +568,7 @@ def file_operations(
         return json.dumps({"error": str(e), "status": "error"})
 
 
-# -----------------------------------------------------------------------
-# Tool 4: ci_push_to_workspace
-# -----------------------------------------------------------------------
-
-@tool(context=True)
-def ci_push_to_workspace(
-    paths: list = None,
-    tool_context: ToolContext = None,
-) -> str:
-    """Persist files for legacy Code Interpreter deployments.
-
-    Mounted workspace deployments persist files automatically. In that mode,
-    this helper only verifies that the requested files exist. It copies files
-    to S3 only when the session is using the legacy sandbox configuration.
-
-    Args:
-        paths: Sandbox file paths to save (e.g. ["chart.png", "results.json"]).
-               If omitted, all files in the sandbox root are saved.
-
-    Returns:
-        JSON with the list of saved files and their workspace paths.
-    """
-    ci = _get_ci_from_context(tool_context)
-    if ci is None:
-        return json.dumps({"error": "Code Interpreter not available.", "status": "error"})
-
-    try:
-        if _uses_mounted_workspace(tool_context):
-            if not paths:
-                code = (
-                    "import os, json\n"
-                    "_root = os.getcwd()\n"
-                    "print(json.dumps([name for name in os.listdir(_root) "
-                    "if os.path.isfile(os.path.join(_root, name))]))\n"
-                )
-                response = ci.invoke("executeCode", {
-                    "code": code,
-                    "language": "python",
-                    "clearContext": False,
-                })
-                stdout, _, _ = _parse_stream(response)
-                paths = json.loads(stdout.strip()) if stdout.strip() else []
-
-            saved = []
-            for path in paths or []:
-                resolved = _mounted_path(path)
-                code = (
-                    "import os\n"
-                    f"_p = {resolved!r}\n"
-                    "print('ok' if os.path.isfile(_p) else 'missing')\n"
-                )
-                response = ci.invoke("executeCode", {
-                    "code": code,
-                    "language": "python",
-                    "clearContext": False,
-                })
-                stdout, _, has_error = _parse_stream(response)
-                if not has_error and stdout.strip() == "ok":
-                    relative = os.path.relpath(resolved, os.getenv(
-                        "S3_FILES_MOUNT_PATH",
-                        "/mnt/workspace",
-                    ))
-                    saved.append(f"code-interpreter/{relative}")
-
-            return json.dumps({
-                "files_saved": saved,
-                "count": len(saved),
-                "status": "ok",
-                "storage": "mounted",
-            })
-
-        # Discover files if no paths given
-        if not paths:
-            code = "import os, json; print(json.dumps([f for f in os.listdir('.') if os.path.isfile(f)]))\n"
-            response = ci.invoke("executeCode", {"code": code, "language": "python", "clearContext": False})
-            stdout, _, _ = _parse_stream(response)
-            try:
-                paths = json.loads(stdout.strip()) if stdout.strip() else []
-            except Exception:
-                paths = []
-            if not paths:
-                return json.dumps({"files_saved": [], "count": 0, "status": "ok"})
-
-        saved = []
-        for path in paths:
-            try:
-                download_response = ci.invoke("readFiles", {"paths": [path]})
-                filename = os.path.basename(path)
-                for event in download_response.get("stream", []):
-                    result = event.get("result", {})
-                    for item in result.get("content", []):
-                        if not isinstance(item, dict):
-                            continue
-                        blob = item.get("data") or item.get("resource", {}).get("blob")
-                        if blob:
-                            info = _save_to_workspace(tool_context, filename, blob)
-                            doc_type = info.get('doc_type', 'code-output') if info else 'code-output'
-                            saved.append(f"{doc_type}/{filename}")
-                            break
-                        text = item.get("text", "")
-                        if text:
-                            info = _save_to_workspace(tool_context, filename, text.encode("utf-8"))
-                            doc_type = info.get('doc_type', 'code-output') if info else 'code-output'
-                            saved.append(f"{doc_type}/{filename}")
-                            break
-            except Exception as e:
-                logger.warning(f"ci_push: could not save '{path}': {e}")
-
-        return json.dumps({"files_saved": saved, "count": len(saved), "status": "ok"})
-
-    except Exception as e:
-        logger.error(f"ci_push_to_workspace error: {e}")
-        return json.dumps({"error": str(e), "status": "error"})
-
-
 # --- Skill registration ---
 register_skill("code-interpreter", tools=[
     execute_code, execute_command, file_operations,
-    ci_push_to_workspace,
 ])

--- a/chatbot-app/agentcore/src/local_tools/workspace.py
+++ b/chatbot-app/agentcore/src/local_tools/workspace.py
@@ -1,7 +1,7 @@
 """Shared workspace tools — read/write files across all skill namespaces.
 
 Path conventions (userId/sessionId are injected automatically from context):
-  uploads/<file>              →  code-interpreter-workspace/{userId}/{sessionId}/inputs/<file>
+  uploads/<file>              →  code-interpreter-workspace/{workspaceId}/inputs/<file>
   code-agent/<file>           →  code-agent-workspace/{userId}/{sessionId}/<file>
   documents/<type>/<file>     →  documents/{userId}/{sessionId}/<type>/<file>
 
@@ -18,6 +18,7 @@ import botocore.exceptions
 from strands import tool, ToolContext
 from skill import register_skill
 from workspace.config import get_workspace_bucket
+from workspace.paths import code_interpreter_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -35,22 +36,22 @@ def _get_ids(context: ToolContext):
     return state.get('user_id', 'default_user'), state.get('session_id', 'default_session')
 
 
-_NAMESPACE_MAP = [
-    # (logical prefix, s3 prefix template)
-    ('uploads',             'code-interpreter-workspace/{user_id}/{session_id}/inputs/'),
-    ('code-agent',          'code-agent-workspace/{user_id}/{session_id}/'),
-    ('code-interpreter',    'code-interpreter-workspace/{user_id}/{session_id}/'),
-    ('documents',           'documents/{user_id}/{session_id}/'),
-]
+def _namespace_map(user_id: str, session_id: str):
+    ci_prefix = code_interpreter_prefix(user_id, session_id)
+    return [
+        ('uploads',          f'{ci_prefix}inputs/'),
+        ('code-agent',       f'code-agent-workspace/{user_id}/{session_id}/'),
+        ('code-interpreter', ci_prefix),
+        ('documents',        f'documents/{user_id}/{session_id}/'),
+    ]
 
 
 def _to_s3_key(user_id: str, session_id: str, path: str) -> str:
     """Map logical path to S3 key."""
     path = path.lstrip('/')
-    for prefix, template in _NAMESPACE_MAP:
+    for prefix, base in _namespace_map(user_id, session_id):
         if path == prefix or path.startswith(prefix + '/'):
             suffix = path[len(prefix):].lstrip('/')
-            base = template.format(user_id=user_id, session_id=session_id)
             return base + suffix
     # default: documents namespace
     return f"documents/{user_id}/{session_id}/{path}"
@@ -58,8 +59,7 @@ def _to_s3_key(user_id: str, session_id: str, path: str) -> str:
 
 def _to_logical_path(user_id: str, session_id: str, s3_key: str) -> str:
     """Convert S3 key back to logical path."""
-    for prefix, template in _NAMESPACE_MAP:
-        s3_base = template.format(user_id=user_id, session_id=session_id)
+    for prefix, s3_base in _namespace_map(user_id, session_id):
         if s3_key.startswith(s3_base):
             return prefix + '/' + s3_key[len(s3_base):]
     return s3_key
@@ -95,10 +95,11 @@ def workspace_list(path: str = '', tool_context: ToolContext = None) -> str:
         s3 = _s3_client()
 
         if not path or path.strip('/') == '':
+            ci_prefix = code_interpreter_prefix(user_id, session_id)
             s3_prefixes = [
-                f"code-interpreter-workspace/{user_id}/{session_id}/inputs/",
+                f"{ci_prefix}inputs/",
                 f"code-agent-workspace/{user_id}/{session_id}/",
-                f"code-interpreter-workspace/{user_id}/{session_id}/",
+                ci_prefix,
                 f"documents/{user_id}/{session_id}/",
             ]
         else:

--- a/chatbot-app/agentcore/src/workspace/paths.py
+++ b/chatbot-app/agentcore/src/workspace/paths.py
@@ -1,0 +1,17 @@
+"""Deterministic physical paths for session workspace storage."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def code_interpreter_workspace_id(user_id: str, session_id: str) -> str:
+    """Return a bounded, opaque directory name for one user/session pair."""
+    source = f"{user_id}\0{session_id}".encode("utf-8")
+    return hashlib.sha256(source).hexdigest()[:48]
+
+
+def code_interpreter_prefix(user_id: str, session_id: str) -> str:
+    """Return the S3 key prefix for a Code Interpreter session workspace."""
+    workspace_id = code_interpreter_workspace_id(user_id, session_id)
+    return f"code-interpreter-workspace/{workspace_id}/"

--- a/chatbot-app/agentcore/src/workspace/s3_files.py
+++ b/chatbot-app/agentcore/src/workspace/s3_files.py
@@ -12,11 +12,13 @@ from typing import Any, Dict, Optional
 
 import boto3
 
+from workspace.paths import code_interpreter_prefix
+
 logger = logging.getLogger(__name__)
 
 _SAFE_ID = re.compile(r"^[A-Za-z0-9_-]+$")
-_STATE_ACCESS_POINT_ID = "ci_workspace_access_point_id"
-_STATE_ACCESS_POINT_ARN = "ci_workspace_access_point_arn"
+_STATE_ACCESS_POINT_ID = "ci_workspace_access_point_v2_id"
+_STATE_ACCESS_POINT_ARN = "ci_workspace_access_point_v2_arn"
 
 
 def get_s3_files_configuration() -> Optional[Dict[str, str]]:
@@ -76,10 +78,13 @@ def get_or_create_session_access_point(
     agent_state: Any,
     user_id: str,
     session_id: str,
-) -> Optional[Dict[str, str]]:
+) -> Dict[str, str]:
     config = get_s3_files_configuration()
     if not config:
-        return None
+        raise RuntimeError(
+            "S3 Files workspace is not configured: "
+            "S3_FILES_FILE_SYSTEM_ID and S3_FILES_FILE_SYSTEM_ARN are required"
+        )
 
     _validate_identity(user_id, "user_id")
     _validate_identity(session_id, "session_id")
@@ -111,7 +116,7 @@ def get_or_create_session_access_point(
         f"{config['file_system_id']}:{user_id}:{session_id}:code-interpreter"
     )
     client_token = hashlib.sha256(token_source.encode("utf-8")).hexdigest()
-    root_path = f"/code-interpreter-workspace/{user_id}/{session_id}"
+    root_path = f"/{code_interpreter_prefix(user_id, session_id).rstrip('/')}"
     response = client.create_access_point(
         clientToken=client_token,
         fileSystemId=config["file_system_id"],

--- a/chatbot-app/agentcore/tests/unit/test_ci_workspace_sync.py
+++ b/chatbot-app/agentcore/tests/unit/test_ci_workspace_sync.py
@@ -1,33 +1,24 @@
-"""
-Tests for CI workspace sync tools (ci_push_to_workspace)
-and the shared CI session helper (get_ci_session / _get_ci_from_context).
+"""Tests for the required mounted Code Interpreter workspace."""
 
-The original helpers _is_text_file, _ws_path_to_s3_key, _extract_file_list,
-and the ci_pull_from_workspace tool were removed in a refactor that simplified
-the CI tools to use ci.invoke() directly.  These tests cover the current API.
-"""
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 
-def _make_context(user_id="user1", session_id="sess1"):
+
+def _make_context(user_id="user1", session_id="sess1", state_values=None):
+    values = dict(state_values or {})
+    state = MagicMock()
+    state.get.side_effect = values.get
+    state.set.side_effect = values.__setitem__
+
     ctx = MagicMock()
     ctx.invocation_state = {"user_id": user_id, "session_id": session_id}
-    return ctx
+    ctx.agent.state = state
+    return ctx, values
 
 
-def _text_invoke_response(text: str) -> dict:
-    """Build a ci.invoke() response carrying a text content block."""
-    return {"stream": [{"result": {"content": [{"text": text}]}}]}
-
-
-def _binary_invoke_response(data: bytes) -> dict:
-    """Build a ci.invoke() response carrying a binary data content block."""
-    return {"stream": [{"result": {"content": [{"data": data}]}}]}
-
-
-def _exec_code_invoke_response(stdout: str) -> dict:
-    """Build a ci.invoke('executeCode') response via _parse_stream format."""
+def _exec_response(stdout: str = "") -> dict:
     return {
         "stream": [{
             "result": {
@@ -36,6 +27,15 @@ def _exec_code_invoke_response(stdout: str) -> dict:
             }
         }]
     }
+
+
+@pytest.fixture(autouse=True)
+def _clear_ci_clients():
+    from builtin_tools import code_interpreter_tool
+
+    code_interpreter_tool._ci_clients.clear()
+    yield
+    code_interpreter_tool._ci_clients.clear()
 
 
 def test_mounted_javascript_runs_from_workspace(monkeypatch):
@@ -65,162 +65,187 @@ def test_mounted_python_code_is_not_rewritten():
     ) == "open('output.txt', 'w').write('ok')"
 
 
-def test_legacy_sync_includes_workspace_panel_uploads():
-    from builtin_tools.code_interpreter_tool import _get_workspace_s3_prefixes
+def test_mounted_path_resolves_relative_paths_and_rejects_escape(monkeypatch):
+    monkeypatch.setenv("S3_FILES_MOUNT_PATH", "/mnt/workspace")
 
-    assert (
-        "code-interpreter-workspace/user1/sess1/inputs/"
-        in _get_workspace_s3_prefixes("user1", "sess1")
+    from builtin_tools.code_interpreter_tool import _mounted_path
+
+    assert _mounted_path("reports/result.md") == "/mnt/workspace/reports/result.md"
+    assert _mounted_path("/mnt/workspace/result.md") == "/mnt/workspace/result.md"
+    with pytest.raises(ValueError, match="inside the session workspace"):
+        _mounted_path("../other-session/result.md")
+    with pytest.raises(ValueError, match="inside the session workspace"):
+        _mounted_path("/tmp/result.md")
+
+
+@patch("workspace.s3_files.get_or_create_session_access_point")
+@patch("bedrock_agentcore.tools.code_interpreter_client.CodeInterpreter")
+@patch("builtin_tools.code_interpreter_tool._get_code_interpreter_id")
+def test_starts_session_with_required_filesystem_configuration(
+    mock_get_identifier,
+    mock_code_interpreter,
+    mock_access_point,
+):
+    mock_get_identifier.return_value = "ci-123"
+    mock_access_point.return_value = {
+        "file_system_arn": "arn:aws:s3files:us-west-2:123:file-system/fs-123",
+        "access_point_arn": "arn:aws:s3files:us-west-2:123:access-point/ap-123",
+        "mount_path": "/mnt/workspace",
+    }
+    ci = mock_code_interpreter.return_value
+    ci.data_plane_client.start_code_interpreter_session.return_value = {
+        "codeInterpreterIdentifier": "ci-123",
+        "sessionId": "session-123",
+    }
+    ci.invoke.return_value = _exec_response()
+    ctx, values = _make_context()
+
+    from builtin_tools.code_interpreter_tool import get_ci_session
+
+    assert get_ci_session(ctx) is ci
+    request = ci.data_plane_client.start_code_interpreter_session.call_args.kwargs
+    assert request["filesystemConfigurations"] == [{
+        "s3FilesConfiguration": {
+            "fileSystemArn": "arn:aws:s3files:us-west-2:123:file-system/fs-123",
+            "accessPointArn": "arn:aws:s3files:us-west-2:123:access-point/ap-123",
+            "mountPath": "/mnt/workspace",
+        },
+    }]
+    ci.start.assert_not_called()
+    assert values["ci_mounted_workspace"] is True
+    assert values["ci_session_id"] == "session-123"
+
+
+@patch("workspace.s3_files.get_or_create_session_access_point")
+@patch("bedrock_agentcore.tools.code_interpreter_client.CodeInterpreter")
+@patch("builtin_tools.code_interpreter_tool._get_code_interpreter_id")
+def test_mount_start_failure_does_not_start_unmounted_session(
+    mock_get_identifier,
+    mock_code_interpreter,
+    mock_access_point,
+):
+    mock_get_identifier.return_value = "ci-123"
+    mock_access_point.return_value = {
+        "file_system_arn": "fs-arn",
+        "access_point_arn": "ap-arn",
+        "mount_path": "/mnt/workspace",
+    }
+    ci = mock_code_interpreter.return_value
+    ci.data_plane_client.start_code_interpreter_session.side_effect = RuntimeError(
+        "mount rejected"
+    )
+    ctx, _ = _make_context()
+
+    from builtin_tools.code_interpreter_tool import get_ci_session
+
+    with pytest.raises(RuntimeError, match="S3 Files workspace"):
+        get_ci_session(ctx)
+    ci.start.assert_not_called()
+
+
+@patch("workspace.s3_files.get_or_create_session_access_point")
+@patch("bedrock_agentcore.tools.code_interpreter_client.CodeInterpreter")
+def test_missing_workspace_configuration_fails_fast(
+    mock_code_interpreter,
+    mock_access_point,
+):
+    mock_access_point.side_effect = RuntimeError("S3 Files workspace is not configured")
+    ctx, _ = _make_context(state_values={"ci_identifier": "ci-123"})
+
+    from builtin_tools.code_interpreter_tool import get_ci_session
+
+    with pytest.raises(RuntimeError, match="not configured"):
+        get_ci_session(ctx)
+    mock_code_interpreter.return_value.start.assert_not_called()
+
+
+@patch("workspace.s3_files.get_or_create_session_access_point")
+@patch("bedrock_agentcore.tools.code_interpreter_client.CodeInterpreter")
+def test_non_mounted_stored_session_is_not_reattached(
+    mock_code_interpreter,
+    mock_access_point,
+):
+    mock_access_point.return_value = {
+        "file_system_arn": "fs-arn",
+        "access_point_arn": "ap-arn",
+        "mount_path": "/mnt/workspace",
+    }
+    ci = mock_code_interpreter.return_value
+    ci.data_plane_client.start_code_interpreter_session.return_value = {
+        "codeInterpreterIdentifier": "ci-123",
+        "sessionId": "new-mounted-session",
+    }
+    ci.invoke.return_value = _exec_response()
+    ctx, values = _make_context(state_values={
+        "ci_identifier": "ci-123",
+        "ci_session_id": "old-unmounted-session",
+        "ci_mounted_workspace": False,
+    })
+
+    from builtin_tools.code_interpreter_tool import get_ci_session
+
+    get_ci_session(ctx)
+
+    ci.get_session.assert_not_called()
+    ci.data_plane_client.start_code_interpreter_session.assert_called_once()
+    assert values["ci_session_id"] == "new-mounted-session"
+    assert values["ci_mounted_workspace"] is True
+
+
+@patch("builtin_tools.code_interpreter_tool._get_ci_from_context")
+def test_file_operations_writes_only_to_mounted_workspace(mock_get_ci):
+    ci = MagicMock()
+    ci.invoke.return_value = _exec_response("Written: /mnt/workspace/result.md\n")
+    mock_get_ci.return_value = ci
+    ctx, _ = _make_context()
+
+    from builtin_tools.code_interpreter_tool import file_operations
+
+    result = file_operations(
+        operation="write",
+        content=[{"path": "result.md", "text": "# Result"}],
+        tool_context=ctx,
     )
 
-
-# ============================================================
-# ci_push_to_workspace Tests
-# ============================================================
-
-class TestCiPushToWorkspace:
-    """Tests for ci_push_to_workspace tool (current implementation)."""
-
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    @patch('builtin_tools.code_interpreter_tool._save_to_workspace')
-    def test_pushes_specific_text_file(self, mock_save, mock_get_ci):
-        ci = MagicMock()
-        mock_get_ci.return_value = ci
-        mock_save.return_value = {'doc_type': 'code-output', 's3_key': 'k', 'bucket': 'b'}
-        ci.invoke.return_value = _text_invoke_response("x = 1\n")
-
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(paths=["script.py"], tool_context=_make_context())
-        data = json.loads(result)
-
-        assert data['status'] == 'ok'
-        assert data['count'] == 1
-        assert "code-output/script.py" in data['files_saved']
-        mock_save.assert_called_once()
-
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    @patch('builtin_tools.code_interpreter_tool._save_to_workspace')
-    def test_pushes_binary_blob_file(self, mock_save, mock_get_ci):
-        ci = MagicMock()
-        mock_get_ci.return_value = ci
-        mock_save.return_value = {'doc_type': 'image', 's3_key': 'k', 'bucket': 'b'}
-        png_bytes = b'\x89PNG\r\n\x1a\n'
-        ci.invoke.return_value = _binary_invoke_response(png_bytes)
-
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(paths=["chart.png"], tool_context=_make_context())
-        data = json.loads(result)
-
-        assert data['status'] == 'ok'
-        assert data['count'] == 1
-        mock_save.assert_called_once()
-        saved_bytes = mock_save.call_args[0][2]
-        assert saved_bytes == png_bytes
-
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    @patch('builtin_tools.code_interpreter_tool._save_to_workspace')
-    def test_auto_discovers_files_when_no_paths(self, mock_save, mock_get_ci):
-        ci = MagicMock()
-        mock_get_ci.return_value = ci
-        mock_save.return_value = {'doc_type': 'code-output', 's3_key': 'k', 'bucket': 'b'}
-
-        def invoke_side_effect(operation, params):
-            if operation == "executeCode":
-                return _exec_code_invoke_response('["auto_file.csv"]')
-            return _text_invoke_response("a,b\n1,2\n")
-
-        ci.invoke.side_effect = invoke_side_effect
-
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(paths=None, tool_context=_make_context())
-        data = json.loads(result)
-
-        assert data['status'] == 'ok'
-        assert data['count'] == 1
-        # First call should be the file-listing executeCode
-        first_call = ci.invoke.call_args_list[0]
-        assert first_call[0][0] == "executeCode"
-
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    def test_returns_empty_when_no_files_discovered(self, mock_get_ci):
-        ci = MagicMock()
-        mock_get_ci.return_value = ci
-        ci.invoke.return_value = _exec_code_invoke_response("[]")
-
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(paths=None, tool_context=_make_context())
-        data = json.loads(result)
-
-        assert data['status'] == 'ok'
-        assert data['count'] == 0
-        assert data['files_saved'] == []
-
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    @patch('builtin_tools.code_interpreter_tool._save_to_workspace')
-    def test_skips_failed_file_and_continues(self, mock_save, mock_get_ci):
-        ci = MagicMock()
-        mock_get_ci.return_value = ci
-        mock_save.return_value = {'doc_type': 'code-output', 's3_key': 'k', 'bucket': 'b'}
-
-        def invoke_side_effect(operation, params):
-            if operation == "readFiles" and "fail.py" in params.get("paths", []):
-                raise Exception("read error")
-            return _text_invoke_response("ok")
-
-        ci.invoke.side_effect = invoke_side_effect
-
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(
-            paths=["ok.py", "fail.py"],
-            tool_context=_make_context(),
-        )
-        data = json.loads(result)
-
-        assert data['status'] == 'ok'
-        assert data['count'] == 1
-        assert any("ok.py" in p for p in data['files_saved'])
-
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    def test_returns_error_when_ci_not_available(self, mock_get_ci):
-        mock_get_ci.return_value = None
-
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(paths=["file.py"], tool_context=_make_context())
-        data = json.loads(result)
-
-        assert data['status'] == 'error'
-        assert 'not available' in data['error'].lower()
+    assert "Written: /mnt/workspace/result.md" in result
+    code = ci.invoke.call_args.args[1]["code"]
+    assert "os.makedirs(os.path.dirname('/mnt/workspace/result.md')" in code
+    assert "open('/mnt/workspace/result.md', 'w', encoding='utf-8')" in code
 
 
-# ============================================================
-# Response Format Tests
-# ============================================================
+@patch("builtin_tools.code_interpreter_tool._get_ci_from_context")
+def test_file_operations_reads_mounted_files_via_python(mock_get_ci):
+    ci = MagicMock()
+    ci.invoke.return_value = _exec_response(json.dumps([{
+        "path": "/mnt/workspace/smoke/result.txt",
+        "text": "MOUNTED_WORKSPACE_SMOKE_OK",
+        "truncated": False,
+    }]))
+    mock_get_ci.return_value = ci
+    ctx, _ = _make_context()
 
-class TestCiSyncResponseFormat:
-    """Tests that sync tools always return valid JSON."""
+    from builtin_tools.code_interpreter_tool import file_operations
 
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    def test_push_error_returns_valid_json(self, mock_get_ci):
-        ci = MagicMock()
-        mock_get_ci.return_value = ci
-        # Make auto-discovery (executeCode) raise so the outer except fires
-        ci.invoke.side_effect = Exception("CI exploded")
+    result = file_operations(
+        operation="read",
+        paths=["smoke/result.txt"],
+        tool_context=ctx,
+    )
 
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(paths=None, tool_context=_make_context())
-        data = json.loads(result)
-        assert isinstance(data, dict)
-        assert data['status'] == 'error'
+    assert result == "MOUNTED_WORKSPACE_SMOKE_OK"
+    method, request = ci.invoke.call_args.args
+    assert method == "executeCode"
+    assert "/mnt/workspace/smoke/result.txt" in request["code"]
 
-    @patch('builtin_tools.code_interpreter_tool._get_ci_from_context')
-    def test_push_unavailable_returns_valid_json(self, mock_get_ci):
-        mock_get_ci.return_value = None
 
-        from builtin_tools.code_interpreter_tool import ci_push_to_workspace
-        result = ci_push_to_workspace(
-            paths=["code-output/x.csv"],
-            tool_context=_make_context(),
-        )
-        data = json.loads(result)
-        assert isinstance(data, dict)
-        assert 'status' in data
+@patch("builtin_tools.code_interpreter_tool._get_ci_from_context")
+def test_session_initialization_errors_are_returned_by_tools(mock_get_ci):
+    mock_get_ci.side_effect = RuntimeError("S3 Files workspace is not configured")
+    ctx, _ = _make_context()
+
+    from builtin_tools.code_interpreter_tool import execute_code
+
+    result = json.loads(execute_code("print('hello')", tool_context=ctx))
+
+    assert result["status"] == "error"
+    assert "S3 Files workspace is not configured" in result["error"]

--- a/chatbot-app/agentcore/tests/unit/test_s3_files_workspace.py
+++ b/chatbot-app/agentcore/tests/unit/test_s3_files_workspace.py
@@ -43,10 +43,20 @@ def test_creates_session_scoped_access_point(mock_client, _sleep):
     request = client.create_access_point.call_args.kwargs
     assert request["fileSystemId"] == "fs-123"
     assert request["rootDirectory"]["path"] == (
-        "/code-interpreter-workspace/user-1/session-1"
+        "/code-interpreter-workspace/"
+        "c75baf0822512599e9fb5404e22693cffa5c19b706f1f6c2"
     )
+    assert len(request["rootDirectory"]["path"]) <= 100
     assert "tags" not in request
-    assert values["ci_workspace_access_point_id"] == "ap-123"
+    assert values["ci_workspace_access_point_v2_id"] == "ap-123"
+
+
+def test_workspace_path_is_bounded_for_long_runtime_session_ids():
+    from workspace.paths import code_interpreter_prefix
+
+    root_path = "/" + code_interpreter_prefix("u" * 64, "s" * 100).rstrip("/")
+
+    assert len(root_path) == 76
 
 
 @patch.dict(
@@ -65,11 +75,12 @@ def test_rejects_identity_that_can_escape_root():
 
 
 @patch.dict("os.environ", {}, clear=True)
-def test_returns_none_when_s3_files_is_disabled():
+def test_raises_when_s3_files_is_not_configured():
     from workspace.s3_files import get_or_create_session_access_point
 
-    assert get_or_create_session_access_point(
-        MagicMock(),
-        "user-1",
-        "session-1",
-    ) is None
+    with pytest.raises(RuntimeError, match="S3 Files workspace is not configured"):
+        get_or_create_session_access_point(
+            MagicMock(),
+            "user-1",
+            "session-1",
+        )

--- a/chatbot-app/agentcore/tests/unit/test_workspace_tools.py
+++ b/chatbot-app/agentcore/tests/unit/test_workspace_tools.py
@@ -34,7 +34,10 @@ class TestPathRouting:
     def test_code_interpreter_prefix_maps_correctly(self):
         from local_tools.workspace import _to_s3_key
         key = _to_s3_key("u1", "s1", "code-interpreter/chart.png")
-        assert key == "code-interpreter-workspace/u1/s1/chart.png"
+        assert key == (
+            "code-interpreter-workspace/"
+            "4bbb6a0cadc45672cce19f083c25006dc9dd503fa17461d2/chart.png"
+        )
 
     def test_documents_prefix_maps_correctly(self):
         from local_tools.workspace import _to_s3_key
@@ -58,7 +61,12 @@ class TestPathRouting:
 
     def test_logical_path_from_code_interpreter_s3_key(self):
         from local_tools.workspace import _to_logical_path
-        logical = _to_logical_path("u1", "s1", "code-interpreter-workspace/u1/s1/chart.png")
+        logical = _to_logical_path(
+            "u1",
+            "s1",
+            "code-interpreter-workspace/"
+            "4bbb6a0cadc45672cce19f083c25006dc9dd503fa17461d2/chart.png",
+        )
         assert logical == "code-interpreter/chart.png"
 
     def test_logical_path_from_mounted_input_key(self):
@@ -66,7 +74,8 @@ class TestPathRouting:
         logical = _to_logical_path(
             "u1",
             "s1",
-            "code-interpreter-workspace/u1/s1/inputs/data.json",
+            "code-interpreter-workspace/"
+            "4bbb6a0cadc45672cce19f083c25006dc9dd503fa17461d2/inputs/data.json",
         )
         assert logical == "uploads/data.json"
 
@@ -128,7 +137,10 @@ class TestWorkspaceList:
         paginator = MagicMock()
         paginator.paginate.return_value = [
             {'Contents': [
-                {'Key': 'code-interpreter-workspace/u1/s1/chart.png', 'Size': 5000,
+                {'Key': (
+                    'code-interpreter-workspace/'
+                    '4bbb6a0cadc45672cce19f083c25006dc9dd503fa17461d2/chart.png'
+                ), 'Size': 5000,
                  'LastModified': datetime(2024, 1, 1)},
             ]},
         ]
@@ -398,7 +410,10 @@ class TestWorkspaceWrite:
         )
 
         call_kwargs = mock_s3.put_object.call_args[1]
-        assert call_kwargs['Key'] == 'code-interpreter-workspace/alice/sess1/result.json'
+        assert call_kwargs['Key'] == (
+            'code-interpreter-workspace/'
+            'e0fba2dec7cc6f707ae0530f028bb3de98c5652a1913e090/result.json'
+        )
 
     @patch('local_tools.workspace._s3_client')
     @patch('local_tools.workspace.get_workspace_bucket', return_value='my-bucket')
@@ -521,4 +536,7 @@ class TestResponseFormat:
     def test_uploads_prefix_maps_to_mounted_inputs(self):
         from local_tools.workspace import _to_s3_key
         key = _to_s3_key("u1", "s1", "uploads/data.jsonl")
-        assert key == "code-interpreter-workspace/u1/s1/inputs/data.jsonl"
+        assert key == (
+            "code-interpreter-workspace/"
+            "4bbb6a0cadc45672cce19f083c25006dc9dd503fa17461d2/inputs/data.jsonl"
+        )

--- a/chatbot-app/frontend/__tests__/api/workspace.test.ts
+++ b/chatbot-app/frontend/__tests__/api/workspace.test.ts
@@ -8,6 +8,7 @@
  * - Error responses
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createHash } from 'node:crypto'
 
 // Mock dependencies
 vi.mock('@/lib/auth-utils', () => ({
@@ -324,7 +325,13 @@ describe('Workspace Download API', async () => {
 
     it('should map code-interpreter paths', async () => {
       const path = 'code-interpreter/chart.png'
-      const expected = `code-interpreter-workspace/${userId}/${sessionId}/chart.png`
+      const workspaceId = createHash('sha256')
+        .update(userId)
+        .update('\0')
+        .update(sessionId)
+        .digest('hex')
+        .slice(0, 48)
+      const expected = `code-interpreter-workspace/${workspaceId}/chart.png`
       const result = toS3Key(userId, sessionId, path)
       expect(result).toBe(expected)
     })
@@ -388,9 +395,15 @@ describe('Workspace Download API', async () => {
 
 // Reusable path mapper (mirrors route.ts logic)
 function toS3Key(userId: string, sessionId: string, path: string): string {
+  const workspaceId = createHash('sha256')
+    .update(userId)
+    .update('\0')
+    .update(sessionId)
+    .digest('hex')
+    .slice(0, 48)
   const NAMESPACE_MAP: [string, string][] = [
     ['code-agent', `code-agent-workspace/${userId}/${sessionId}/`],
-    ['code-interpreter', `code-interpreter-workspace/${userId}/${sessionId}/`],
+    ['code-interpreter', `code-interpreter-workspace/${workspaceId}/`],
     ['documents', `documents/${userId}/${sessionId}/`],
   ]
   const cleanPath = path.replace(/^\//, '')

--- a/chatbot-app/frontend/__tests__/lib/mounted-workspace-repository.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/mounted-workspace-repository.test.ts
@@ -13,6 +13,7 @@ import {
   symlink,
   writeFile,
 } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -22,7 +23,13 @@ describe('mounted Code Interpreter workspace', () => {
 
   beforeEach(async () => {
     mountPath = await mkdtemp(join(tmpdir(), 'workspace-mount-'))
-    sessionRoot = join(mountPath, 'user-1', 'session-1')
+    const workspaceId = createHash('sha256')
+      .update('user-1')
+      .update('\0')
+      .update('session-1')
+      .digest('hex')
+      .slice(0, 48)
+    sessionRoot = join(mountPath, workspaceId)
     await mkdir(sessionRoot, { recursive: true })
     vi.stubEnv('S3_FILES_MOUNT_PATH', mountPath)
     vi.stubEnv('ARTIFACT_BUCKET', 'workspace-bucket')

--- a/chatbot-app/frontend/__tests__/lib/workspace-repository.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/workspace-repository.test.ts
@@ -134,7 +134,10 @@ describe('S3WorkspaceRepository', () => {
     })
     expect(vi.mocked(getSignedUrl).mock.calls[0][1].input).toMatchObject({
       Bucket: 'workspace-bucket',
-      Key: 'code-interpreter-workspace/user-1/session-1/inputs/records.jsonl',
+      Key: (
+        'code-interpreter-workspace/'
+        + 'c75baf0822512599e9fb5404e22693cffa5c19b706f1f6c2/inputs/records.jsonl'
+      ),
       ContentType: 'application/x-ndjson',
     })
     expect(send).not.toHaveBeenCalled()

--- a/chatbot-app/frontend/src/components/chat/ToolExecutionContainer.tsx
+++ b/chatbot-app/frontend/src/components/chat/ToolExecutionContainer.tsx
@@ -27,7 +27,7 @@ const POWERPOINT_TOOLS = ['create_presentation', 'update_slide_content', 'add_sl
 // Workspace file tools (download button on read/write)
 const WORKSPACE_FILE_TOOLS = ['workspace_read', 'workspace_write']
 // Code Interpreter tools that save files to workspace
-const CI_WORKSPACE_TOOLS = ['execute_code', 'ci_push_to_workspace']
+const CI_WORKSPACE_TOOLS = ['execute_code']
 
 interface ToolExecutionContainerProps {
   toolExecutions: ToolExecution[]
@@ -532,17 +532,10 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
 
       let paths: string[] = []
 
-      if (toolName === 'ci_push_to_workspace') {
-        const parsed = JSON.parse(toolResult)
-        if (parsed.status === 'ok' && parsed.files_saved?.length) {
-          paths = parsed.files_saved.map((f: string) => `documents/${f}`)
-        }
-      } else if (toolName === 'execute_code') {
+      if (toolName === 'execute_code') {
         const match = toolResult.match(/File saved:\s*(\S+)/)
         if (match) {
-          const filename = match[1]
-          const docType = /\.(png|jpg|jpeg|gif|webp)$/i.test(filename) ? 'image' : 'code-output'
-          paths = [`documents/${docType}/${filename}`]
+          paths = [match[1]]
         }
       } else {
         const parsed = JSON.parse(toolResult)
@@ -643,9 +636,6 @@ export const ToolExecutionContainer = React.memo<ToolExecutionContainerProps>(({
       )}
       {CI_WORKSPACE_TOOLS.includes(toolExecution.toolName) &&
         toolExecution.isComplete && !toolExecution.isCancelled && toolExecution.toolResult && (() => {
-          if (toolExecution.toolName === 'ci_push_to_workspace') {
-            try { const p = JSON.parse(toolExecution.toolResult || ''); return p.status === 'ok' && p.files_saved?.length > 0 } catch { return false }
-          }
           return /File saved:\s*\S+/.test(toolExecution.toolResult || '')
         })() && (
         <button

--- a/chatbot-app/frontend/src/config/document-tools.ts
+++ b/chatbot-app/frontend/src/config/document-tools.ts
@@ -52,10 +52,6 @@ export const TOOL_TO_DOC_TYPE: Record<string, DocumentType> = {
   'generate_chart': 'diagram',
   'create_visual_design': 'diagram',
 
-  // Code Interpreter tools (from code_interpreter_tool)
-  'execute_code': 'code-output',
-  'ci_push_to_workspace': 'code-output',
-
   // Browser tools (screenshots saved as images)
   'browser_save_screenshot': 'image',
 }

--- a/chatbot-app/frontend/src/config/tools-config.json
+++ b/chatbot-app/frontend/src/config/tools-config.json
@@ -398,28 +398,10 @@
         {
           "id": "file_operations",
           "name": "File Operations",
-          "description": "Read, write, list, or remove files in the sandbox",
+          "description": "Read, write, list, or remove files in the mounted session workspace",
           "displayName": {
             "running": "Managing files",
             "complete": "Managed files"
-          }
-        },
-        {
-          "id": "ci_push_to_workspace",
-          "name": "Push to Workspace",
-          "description": "Save sandbox files to the shared workspace (S3)",
-          "displayName": {
-            "running": "Saving to workspace",
-            "complete": "Saved to workspace"
-          }
-        },
-        {
-          "id": "ci_pull_from_workspace",
-          "name": "Pull from Workspace",
-          "description": "Load workspace files into the sandbox",
-          "displayName": {
-            "running": "Loading from workspace",
-            "complete": "Loaded from workspace"
           }
         }
       ]

--- a/chatbot-app/frontend/src/hooks/useStreamEvents.ts
+++ b/chatbot-app/frontend/src/hooks/useStreamEvents.ts
@@ -885,6 +885,17 @@ export const useStreamEvents = ({
         }
       }
 
+      const codeInterpreterMayHaveChangedWorkspace = currentToolExecutionsRef.current.some(
+        toolExec => (
+          toolExec.isComplete
+          && !toolExec.isCancelled
+          && ['execute_code', 'execute_command', 'file_operations'].includes(toolExec.toolName)
+        ),
+      )
+      if (codeInterpreterMayHaveChangedWorkspace) {
+        window.dispatchEvent(new CustomEvent('workspace-files-changed'))
+      }
+
       // Trigger Excalidraw diagram artifact creation (JSON content direct from tool result)
       if (onExcalidrawCreated) {
         for (const toolExec of currentToolExecutionsRef.current) {

--- a/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
+++ b/chatbot-app/frontend/src/lib/workspace/s3-repository.ts
@@ -6,6 +6,7 @@ import {
 } from '@aws-sdk/client-s3'
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { createHash } from 'node:crypto'
 import { constants as fsConstants, type Stats } from 'node:fs'
 import type { FileHandle } from 'node:fs/promises'
 import { open, readdir, realpath, stat } from 'node:fs/promises'
@@ -30,13 +31,24 @@ interface Namespace {
   prefix: (userId: string, sessionId: string) => string
 }
 
+function codeInterpreterWorkspaceId(userId: string, sessionId: string): string {
+  return createHash('sha256')
+    .update(userId)
+    .update('\0')
+    .update(sessionId)
+    .digest('hex')
+    .slice(0, 48)
+}
+
+function codeInterpreterPrefix(userId: string, sessionId: string): string {
+  return `code-interpreter-workspace/${codeInterpreterWorkspaceId(userId, sessionId)}/`
+}
+
 const NAMESPACES: Namespace[] = [
   {
     logicalPath: 'uploads',
     label: 'Uploads',
-    prefix: (userId, sessionId) => (
-      `code-interpreter-workspace/${userId}/${sessionId}/inputs/`
-    ),
+    prefix: (userId, sessionId) => `${codeInterpreterPrefix(userId, sessionId)}inputs/`,
   },
   {
     logicalPath: 'documents',
@@ -46,7 +58,7 @@ const NAMESPACES: Namespace[] = [
   {
     logicalPath: 'code-interpreter',
     label: 'Code Interpreter',
-    prefix: (userId, sessionId) => `code-interpreter-workspace/${userId}/${sessionId}/`,
+    prefix: codeInterpreterPrefix,
   },
   {
     logicalPath: 'code-agent',
@@ -246,11 +258,9 @@ async function mountedSessionRoot(
     throw error
   })
   if (!mountRoot) return undefined
-  const userRoot = await findMountedEntry(mountRoot, userId, 'directory')
-  if (!userRoot) return undefined
-  const sessionRoot = await findMountedEntry(userRoot, sessionId, 'directory')
-  if (!sessionRoot) return undefined
-  return realpath(sessionRoot)
+  const workspaceId = codeInterpreterWorkspaceId(userId, sessionId)
+  const sessionRoot = await findMountedEntry(mountRoot, workspaceId, 'directory')
+  return sessionRoot ? realpath(sessionRoot) : undefined
 }
 
 async function resolveMountedPath(

--- a/docs/architecture/session-workspace.md
+++ b/docs/architecture/session-workspace.md
@@ -26,7 +26,7 @@ The initial repository maps existing S3 prefixes into these namespaces:
 | Logical path | Current storage prefix |
 | --- | --- |
 | `documents/` | `documents/{userId}/{sessionId}/` |
-| `code-interpreter/` | `code-interpreter-workspace/{userId}/{sessionId}/` |
+| `code-interpreter/` | `code-interpreter-workspace/{workspaceId}/` |
 | `code-agent/` | `code-agent-workspace/{userId}/{sessionId}/` |
 
 The repository contract supports directory listing, file metadata, preview, and
@@ -64,13 +64,17 @@ workspace API.
 Code Interpreter receives a dynamically created access point rooted at:
 
 ```text
-/code-interpreter-workspace/{userId}/{sessionId}
+/code-interpreter-workspace/{workspaceId}
 ```
 
 That access point is mounted at `/mnt/workspace`. The access point root is the
 security boundary; path validation or a working directory is not treated as an
 isolation mechanism. A Code Interpreter session cannot traverse to another
 user or chat session.
+
+`workspaceId` is the first 48 hexadecimal characters of
+`SHA-256(userId + NUL + sessionId)`. The bounded opaque ID keeps the access
+point root below the S3 Files path-length limit.
 
 The trusted frontend task mounts an access point rooted at
 `/code-interpreter-workspace` read-only. Workspace API authorization still
@@ -88,7 +92,7 @@ Existing logical namespaces remain unchanged:
 ```text
 uploads/            S3 API, mapped to Code Interpreter inputs/
 documents/          S3 API
-code-interpreter/   S3 Files mount, with S3 API fallback
+code-interpreter/   S3 Files mount
 code-agent/         S3 API
 ```
 
@@ -104,17 +108,13 @@ pass through the frontend task. Dev currently accepts workspace uploads up to
 model context by at most 40,000 characters; the complete object remains in
 `inputs/` for Code Interpreter.
 S3 Files imports that prefix on first directory access. Code Interpreter output
-files are created directly in `/mnt/workspace`; the previous base64 preload and
-push path remains only as a rollout fallback.
+files are created directly in `/mnt/workspace`. Code Interpreter does not start
+when its session-scoped S3 Files mount cannot be configured or attached.
 
 Access point metadata is stored under the hidden
 `.workspace-access-points/{userId}/{sessionId}.json` prefix. Session deletion
 removes the access point best-effort before removing this registry object. File
 data follows the existing workspace retention policy.
-
-The dev rollout is controlled by `enable_s3_files_workspace`. Disabling it
-removes S3 Files IAM permissions, mounts, and environment configuration and
-returns Code Interpreter to the legacy synchronization path.
 
 ## Network Boundary
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,5 +1,10 @@
 data "aws_caller_identity" "current" {}
 
+moved {
+  from = module.session_workspace[0]
+  to   = module.session_workspace
+}
+
 locals {
   account_id    = data.aws_caller_identity.current.account_id
   root_dir      = abspath("${path.module}/../../..")
@@ -52,26 +57,14 @@ module "data" {
 module "agentcore_shared" {
   source = "../../modules/agentcore-shared"
 
-  project_name           = var.project_name
-  environment            = var.environment
-  aws_region             = var.aws_region
-  account_id             = local.account_id
-  nova_act_workflow_name = var.nova_act_workflow_name
-  code_interpreter_execution_role_arn = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].code_interpreter_execution_role_arn
-    : ""
-  )
-  code_interpreter_subnet_ids = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].code_interpreter_subnet_ids
-    : []
-  )
-  code_interpreter_security_group_ids = (
-    var.enable_s3_files_workspace
-    ? [module.session_workspace[0].mount_target_security_group_id]
-    : []
-  )
+  project_name                        = var.project_name
+  environment                         = var.environment
+  aws_region                          = var.aws_region
+  account_id                          = local.account_id
+  nova_act_workflow_name              = var.nova_act_workflow_name
+  code_interpreter_execution_role_arn = module.session_workspace.code_interpreter_execution_role_arn
+  code_interpreter_subnet_ids         = module.session_workspace.code_interpreter_subnet_ids
+  code_interpreter_security_group_ids = [module.session_workspace.mount_target_security_group_id]
 
   depends_on = [module.session_workspace]
 }
@@ -271,16 +264,8 @@ module "runtime_code_agent" {
   secret_arns = var.enable_mantle_models ? [
     data.aws_secretsmanager_secret.bedrock_api_key[0].arn
   ] : []
-  workspace_file_system_id = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].file_system_id
-    : ""
-  )
-  workspace_file_system_arn = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].file_system_arn
-    : ""
-  )
+  workspace_file_system_id  = module.session_workspace.file_system_id
+  workspace_file_system_arn = module.session_workspace.file_system_arn
 
   extra_env_vars = {
     CLAUDE_CODE_USE_BEDROCK = "1"
@@ -356,23 +341,16 @@ module "runtime_general_subagent" {
   secret_arns = var.enable_mantle_models ? [
     data.aws_secretsmanager_secret.bedrock_api_key[0].arn
   ] : []
-  workspace_file_system_id = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].file_system_id
-    : ""
-  )
-  workspace_file_system_arn = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].file_system_arn
-    : ""
-  )
+  workspace_file_system_id       = module.session_workspace.file_system_id
+  workspace_file_system_arn      = module.session_workspace.file_system_arn
+  enable_workspace_access_points = true
 
   extra_env_vars = merge(
     {
       CODE_INTERPRETER_ID      = module.agentcore_shared.code_interpreter_id
       MODEL_ID                 = local.general_subagent_default_model_id
-      S3_FILES_FILE_SYSTEM_ID  = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_id : ""
-      S3_FILES_FILE_SYSTEM_ARN = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_arn : ""
+      S3_FILES_FILE_SYSTEM_ID  = module.session_workspace.file_system_id
+      S3_FILES_FILE_SYSTEM_ARN = module.session_workspace.file_system_arn
       S3_FILES_MOUNT_PATH      = "/mnt/workspace"
     },
     var.enable_mantle_models ? {
@@ -421,18 +399,11 @@ module "runtime_orchestrator" {
   orchestration_table_arn  = module.data.session_orchestration_table_arn
   orchestration_table_name = module.data.session_orchestration_table_name
 
-  artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
-  artifact_bucket_name = aws_s3_bucket.artifacts.id
-  workspace_file_system_id = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].file_system_id
-    : ""
-  )
-  workspace_file_system_arn = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].file_system_arn
-    : ""
-  )
+  artifact_bucket_arn            = aws_s3_bucket.artifacts.arn
+  artifact_bucket_name           = aws_s3_bucket.artifacts.id
+  workspace_file_system_id       = module.session_workspace.file_system_id
+  workspace_file_system_arn      = module.session_workspace.file_system_arn
+  enable_workspace_access_points = true
 
   extra_env_vars = merge(
     {
@@ -447,8 +418,8 @@ module "runtime_orchestrator" {
       GENERAL_SUBAGENT_RUNTIME_URL          = module.runtime_general_subagent.runtime_invocation_url
       MCP_3LO_RUNTIME_ARN                   = module.runtime_mcp_3lo.runtime_arn
       CODE_INTERPRETER_ID                   = module.agentcore_shared.code_interpreter_id
-      S3_FILES_FILE_SYSTEM_ID               = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_id : ""
-      S3_FILES_FILE_SYSTEM_ARN              = var.enable_s3_files_workspace ? module.session_workspace[0].file_system_arn : ""
+      S3_FILES_FILE_SYSTEM_ID               = module.session_workspace.file_system_id
+      S3_FILES_FILE_SYSTEM_ARN              = module.session_workspace.file_system_arn
       S3_FILES_MOUNT_PATH                   = "/mnt/workspace"
       BROWSER_ID                            = module.agentcore_shared.browser_id
       BROWSER_NAME                          = module.agentcore_shared.browser_name
@@ -584,10 +555,7 @@ data "aws_subnets" "default" {
 
 check "code_interpreter_has_supported_subnet" {
   assert {
-    condition = (
-      !var.enable_s3_files_workspace ||
-      length(var.code_interpreter_private_subnets) > 0
-    )
+    condition     = length(var.code_interpreter_private_subnets) > 0
     error_message = "code_interpreter_private_subnets must configure at least one supported availability zone."
   }
 }
@@ -605,21 +573,16 @@ check "code_interpreter_private_subnets_match_supported_azs" {
 
 module "session_workspace" {
   source = "../../modules/session-workspace"
-  count  = var.enable_s3_files_workspace ? 1 : 0
 
-  project_name         = var.project_name
-  environment          = var.environment
-  aws_region           = var.aws_region
-  account_id           = local.account_id
-  artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
-  artifact_bucket_name = aws_s3_bucket.artifacts.id
-  vpc_id               = data.aws_vpc.default.id
-  subnet_ids           = data.aws_subnets.default.ids
-  code_interpreter_private_subnets = (
-    var.enable_s3_files_workspace
-    ? var.code_interpreter_private_subnets
-    : {}
-  )
+  project_name                     = var.project_name
+  environment                      = var.environment
+  aws_region                       = var.aws_region
+  account_id                       = local.account_id
+  artifact_bucket_arn              = aws_s3_bucket.artifacts.arn
+  artifact_bucket_name             = aws_s3_bucket.artifacts.id
+  vpc_id                           = data.aws_vpc.default.id
+  subnet_ids                       = data.aws_subnets.default.ids
+  code_interpreter_private_subnets = var.code_interpreter_private_subnets
 
   depends_on = [aws_s3_bucket_versioning.artifacts]
 }
@@ -647,20 +610,12 @@ module "chat" {
   session_orchestration_table_name = module.data.session_orchestration_table_name
   session_orchestration_table_arn  = module.data.session_orchestration_table_arn
 
-  memory_id            = module.memory.memory_id
-  gateway_url          = module.gateway.gateway_url
-  artifact_bucket_arn  = aws_s3_bucket.artifacts.arn
-  artifact_bucket_name = aws_s3_bucket.artifacts.id
-  workspace_file_system_arn = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].file_system_arn
-    : ""
-  )
-  workspace_access_point_arn = (
-    var.enable_s3_files_workspace
-    ? module.session_workspace[0].frontend_access_point_arn
-    : ""
-  )
+  memory_id                  = module.memory.memory_id
+  gateway_url                = module.gateway.gateway_url
+  artifact_bucket_arn        = aws_s3_bucket.artifacts.arn
+  artifact_bucket_name       = aws_s3_bucket.artifacts.id
+  workspace_file_system_arn  = module.session_workspace.file_system_arn
+  workspace_access_point_arn = module.session_workspace.frontend_access_point_arn
 
   orchestrator_runtime_arn = module.runtime_orchestrator.runtime_arn
   orchestrator_runtime_url = module.runtime_orchestrator.runtime_invocation_url

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -37,12 +37,6 @@ variable "enable_mantle_models" {
   default     = false
 }
 
-variable "enable_s3_files_workspace" {
-  description = "Mount the artifact bucket through S3 Files for session Code Interpreter workspaces."
-  type        = bool
-  default     = true
-}
-
 variable "code_interpreter_supported_az_ids" {
   description = "Stable availability zone IDs supported by AgentCore Code Interpreter VPC mode. Empty uses every subnet in the selected VPC."
   type        = list(string)

--- a/infra/modules/agentcore-shared/main.tf
+++ b/infra/modules/agentcore-shared/main.tf
@@ -41,17 +41,14 @@ resource "aws_iam_role_policy" "browser" {
 resource "aws_bedrockagentcore_code_interpreter" "this" {
   name               = "${local.name_prefix}_ci_${local.code_interpreter_config_suffix}"
   description        = "Shared Code Interpreter for ${var.project_name} ${var.environment}"
-  execution_role_arn = var.code_interpreter_execution_role_arn != "" ? var.code_interpreter_execution_role_arn : null
+  execution_role_arn = var.code_interpreter_execution_role_arn
 
   network_configuration {
-    network_mode = length(var.code_interpreter_subnet_ids) > 0 ? "VPC" : "PUBLIC"
+    network_mode = "VPC"
 
-    dynamic "vpc_config" {
-      for_each = length(var.code_interpreter_subnet_ids) > 0 ? [1] : []
-      content {
-        subnets         = var.code_interpreter_subnet_ids
-        security_groups = var.code_interpreter_security_group_ids
-      }
+    vpc_config {
+      subnets         = var.code_interpreter_subnet_ids
+      security_groups = var.code_interpreter_security_group_ids
     }
   }
 }

--- a/infra/modules/agentcore-shared/variables.tf
+++ b/infra/modules/agentcore-shared/variables.tf
@@ -15,18 +15,30 @@ variable "account_id" {
 }
 
 variable "code_interpreter_execution_role_arn" {
-  type    = string
-  default = ""
+  type = string
+
+  validation {
+    condition     = var.code_interpreter_execution_role_arn != ""
+    error_message = "code_interpreter_execution_role_arn is required."
+  }
 }
 
 variable "code_interpreter_subnet_ids" {
-  type    = list(string)
-  default = []
+  type = list(string)
+
+  validation {
+    condition     = length(var.code_interpreter_subnet_ids) > 0
+    error_message = "At least one Code Interpreter subnet is required."
+  }
 }
 
 variable "code_interpreter_security_group_ids" {
-  type    = list(string)
-  default = []
+  type = list(string)
+
+  validation {
+    condition     = length(var.code_interpreter_security_group_ids) > 0
+    error_message = "At least one Code Interpreter security group is required."
+  }
 }
 
 variable "nova_act_workflow_name" {

--- a/infra/modules/chat/main.tf
+++ b/infra/modules/chat/main.tf
@@ -362,24 +362,21 @@ resource "aws_iam_role_policy" "ecs_task" {
         },
       ],
       [
-        for statement in [
-          {
-            Effect   = "Allow"
-            Action   = ["s3files:ClientMount", "s3files:GetAccessPoint"]
-            Resource = var.workspace_file_system_arn
-            Condition = {
-              ArnEquals = {
-                "s3files:AccessPointArn" = var.workspace_access_point_arn
-              }
+        {
+          Effect   = "Allow"
+          Action   = ["s3files:ClientMount", "s3files:GetAccessPoint"]
+          Resource = var.workspace_file_system_arn
+          Condition = {
+            ArnEquals = {
+              "s3files:AccessPointArn" = var.workspace_access_point_arn
             }
-          },
-          {
-            Effect   = "Allow"
-            Action   = ["s3files:DeleteAccessPoint", "s3files:GetAccessPoint"]
-            Resource = "${var.workspace_file_system_arn}/access-point/*"
-          },
-        ] : statement
-        if var.workspace_file_system_arn != "" && var.workspace_access_point_arn != ""
+          }
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["s3files:DeleteAccessPoint", "s3files:GetAccessPoint"]
+          Resource = "${var.workspace_file_system_arn}/access-point/*"
+        },
       ],
       [
         {
@@ -419,8 +416,8 @@ resource "aws_ecs_task_definition" "frontend" {
       { name = "DYNAMODB_SESSIONS_TABLE", value = var.sessions_table_name },
       { name = "SESSION_ORCHESTRATION_TABLE", value = var.session_orchestration_table_name },
       { name = "ARTIFACT_BUCKET", value = var.artifact_bucket_name },
-      { name = "S3_FILES_MOUNT_PATH", value = var.workspace_file_system_arn != "" ? "/mnt/session-workspaces" : "" },
-      { name = "S3_FILES_FILE_SYSTEM_ID", value = var.workspace_file_system_arn != "" ? split("/", var.workspace_file_system_arn)[1] : "" },
+      { name = "S3_FILES_MOUNT_PATH", value = "/mnt/session-workspaces" },
+      { name = "S3_FILES_FILE_SYSTEM_ID", value = split("/", var.workspace_file_system_arn)[1] },
       { name = "MEMORY_ID", value = var.memory_id },
       { name = "MCP_GATEWAY_URL", value = var.gateway_url },
       { name = "ORCHESTRATOR_RUNTIME_ARN", value = var.orchestrator_runtime_arn },
@@ -432,11 +429,11 @@ resource "aws_ecs_task_definition" "frontend" {
       name      = "AWS_BEARER_TOKEN_BEDROCK"
       valueFrom = var.bedrock_api_key_secret_arn
     }] : []
-    mountPoints = var.workspace_file_system_arn != "" ? [{
+    mountPoints = [{
       sourceVolume  = "session-workspace"
       containerPath = "/mnt/session-workspaces"
       readOnly      = true
-    }] : []
+    }]
     logConfiguration = {
       logDriver = "awslogs"
       options = {
@@ -447,15 +444,12 @@ resource "aws_ecs_task_definition" "frontend" {
     }
   }])
 
-  dynamic "volume" {
-    for_each = var.workspace_file_system_arn != "" ? [1] : []
-    content {
-      name = "session-workspace"
+  volume {
+    name = "session-workspace"
 
-      s3files_volume_configuration {
-        file_system_arn  = var.workspace_file_system_arn
-        access_point_arn = var.workspace_access_point_arn
-      }
+    s3files_volume_configuration {
+      file_system_arn  = var.workspace_file_system_arn
+      access_point_arn = var.workspace_access_point_arn
     }
   }
 

--- a/infra/modules/chat/variables.tf
+++ b/infra/modules/chat/variables.tf
@@ -88,13 +88,21 @@ variable "artifact_bucket_name" {
 }
 
 variable "workspace_file_system_arn" {
-  type    = string
-  default = ""
+  type = string
+
+  validation {
+    condition     = var.workspace_file_system_arn != ""
+    error_message = "workspace_file_system_arn is required."
+  }
 }
 
 variable "workspace_access_point_arn" {
-  type    = string
-  default = ""
+  type = string
+
+  validation {
+    condition     = var.workspace_access_point_arn != ""
+    error_message = "workspace_access_point_arn is required."
+  }
 }
 
 variable "orchestrator_runtime_arn" {

--- a/infra/modules/runtime/main.tf
+++ b/infra/modules/runtime/main.tf
@@ -483,7 +483,7 @@ resource "aws_iam_role_policy" "orchestrator_artifacts" {
 }
 
 resource "aws_iam_role_policy" "orchestrator_workspace_access_points" {
-  count = contains(["orchestrator", "a2a_agent"], var.runtime_type) && var.workspace_file_system_id != "" ? 1 : 0
+  count = var.enable_workspace_access_points ? 1 : 0
   name  = "workspace-access-points"
   role  = aws_iam_role.execution.id
 

--- a/infra/modules/runtime/variables.tf
+++ b/infra/modules/runtime/variables.tf
@@ -136,6 +136,12 @@ variable "workspace_file_system_arn" {
   default = ""
 }
 
+variable "enable_workspace_access_points" {
+  description = "Allow this runtime to create session-scoped S3 Files access points."
+  type        = bool
+  default     = false
+}
+
 variable "read_only_bucket_arns" {
   type    = list(string)
   default = []


### PR DESCRIPTION
## Summary
- require S3 Files-backed Code Interpreter sessions and remove legacy fallback/sync tools
- use bounded session workspace paths and keep frontend/sidebar path mapping consistent
- make mounted file reads and writes reliable, including parent directory creation
- require workspace infrastructure in dev and refresh sidebar files after tool completion

## Validation
- Python workspace tests: 54 passed
- Frontend full suite: 731 passed
- Frontend workspace tests: 54 passed
- Frontend type-check passed
- Terraform validate passed
- Dev deployment completed
- End-to-end smoke: 64-character session, file_operations write/read, and sidebar list/preview all passed