### PR TITLE
fix(agent): harden context overflow recovery

### DIFF
--- a/chatbot-app/agentcore/skills/powerpoint-presentations/editing-guide.md
+++ b/chatbot-app/agentcore/skills/powerpoint-presentations/editing-guide.md
@@ -44,7 +44,7 @@ The response includes:
 | Action | Required Fields | Description |
 |--------|----------------|-------------|
 | `set_text` | `element_id`, `text` | Replace all text in a shape |
-| `replace_text` | `element_id`, `old_text`, `new_text` | Replace specific text within a shape (preserves formatting) |
+| `replace_text` | `element_id`, `find`, `replace` | Replace specific text within a shape (preserves formatting) |
 | `replace_image` | `element_id`, `image_path` | Replace an existing image with a new one |
 
 ### EMU Unit Reference
@@ -92,10 +92,9 @@ If you need to add completely new visual elements or restructure a slide:
     {
       "slide_index": 1,
       "operations": [
-        { "action": "replace_text", "element_id": 3, "old_text": "Q3", "new_text": "Q4" }
+        { "action": "replace_text", "element_id": 3, "find": "Q3", "replace": "Q4" }
       ]
     }
   ]
 }
 ```
-

--- a/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
+++ b/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from strands.agent.agent import Agent
 
 logger = logging.getLogger(__name__)
+_HARD_TOOL_RESULT_LENGTH = 100_000
 
 
 @dataclass
@@ -571,7 +572,9 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
         - Truncating toolResult.content (large tool outputs)
         - Replacing image blocks with text placeholders
 
-        Protected messages (recent turns) are NOT truncated to preserve latest context.
+        Protected messages skip normal compaction, but a hard safety limit still
+        applies to textual tool results. This lets a poisoned recent turn recover
+        instead of repeatedly overflowing before compaction can run.
 
         Args:
             messages: List of message dicts
@@ -588,9 +591,7 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
             protected_indices = set()
 
         for msg_idx, msg in enumerate(modified_messages):
-            # Skip protected messages (recent turns)
-            if msg_idx in protected_indices:
-                continue
+            is_protected = msg_idx in protected_indices
             content = msg.get('content', [])
             if not isinstance(content, list):
                 continue
@@ -602,6 +603,8 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
 
                 # Replace image blocks with placeholder
                 if 'image' in block:
+                    if is_protected:
+                        continue
                     image_data = block['image']
                     image_format = image_data.get('format', 'unknown')
                     source = image_data.get('source', {})
@@ -616,6 +619,8 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
 
                 # Replace document blocks with placeholder
                 elif 'document' in block:
+                    if is_protected:
+                        continue
                     doc_data = block['document']
                     doc_format = doc_data.get('format', 'unknown')
                     doc_name = doc_data.get('name', 'unknown')
@@ -631,6 +636,8 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
 
                 # Truncate toolUse input
                 elif 'toolUse' in block:
+                    if is_protected:
+                        continue
                     tool_use = block['toolUse']
                     tool_input = tool_use.get('input', {})
 
@@ -656,6 +663,8 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
 
                             # Replace image in toolResult with placeholder
                             if 'image' in result_block:
+                                if is_protected:
+                                    continue
                                 image_data = result_block['image']
                                 image_format = image_data.get('format', 'unknown')
                                 source = image_data.get('source', {})
@@ -673,22 +682,49 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
 
                             elif 'text' in result_block:
                                 text = result_block['text']
-                                if len(text) > self.max_tool_content_length:
+                                replacement = self._strip_base64_tool_result(text)
+                                if replacement is not None:
                                     original_len = len(text)
-                                    result_block['text'] = self._truncate_text(text, self.max_tool_content_length)
+                                    result_block['text'] = replacement
                                     truncation_count += 1
-                                    total_chars_saved += original_len - self.max_tool_content_length
+                                    total_chars_saved += max(0, original_len - len(replacement))
+                                    continue
+
+                                limit = (
+                                    _HARD_TOOL_RESULT_LENGTH
+                                    if is_protected
+                                    else self.max_tool_content_length
+                                )
+                                if len(text) > limit:
+                                    original_len = len(text)
+                                    result_block['text'] = self._truncate_text(text, limit)
+                                    truncation_count += 1
+                                    total_chars_saved += original_len - limit
 
                             elif 'json' in result_block:
                                 json_content = result_block['json']
+                                sanitized_json = self._strip_base64_json_envelope(json_content)
+                                if sanitized_json is not None:
+                                    original_len = len(json.dumps(json_content, ensure_ascii=False))
+                                    result_block['json'] = sanitized_json
+                                    replacement_len = len(json.dumps(sanitized_json, ensure_ascii=False))
+                                    truncation_count += 1
+                                    total_chars_saved += max(0, original_len - replacement_len)
+                                    continue
+
                                 json_str = json.dumps(json_content, ensure_ascii=False)
-                                if len(json_str) > self.max_tool_content_length:
+                                limit = (
+                                    _HARD_TOOL_RESULT_LENGTH
+                                    if is_protected
+                                    else self.max_tool_content_length
+                                )
+                                if len(json_str) > limit:
                                     original_len = len(json_str)
                                     # Simply convert to truncated text instead of recursive dict processing
                                     result_block.pop('json')
-                                    result_block['text'] = self._truncate_text(json_str, self.max_tool_content_length)
+                                    result_block['text'] = self._truncate_text(json_str, limit)
                                     truncation_count += 1
-                                    total_chars_saved += original_len - self.max_tool_content_length
+                                    total_chars_saved += original_len - limit
 
         if truncation_count > 0:
             logger.debug(
@@ -697,6 +733,35 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
             )
 
         return modified_messages, truncation_count, total_chars_saved
+
+    @staticmethod
+    def _strip_base64_json_envelope(value: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(value, dict):
+            return None
+        if str(value.get("encoding", "")).lower() != "base64":
+            return None
+        if not isinstance(value.get("content"), str):
+            return None
+
+        sanitized = dict(value)
+        sanitized.pop("content", None)
+        sanitized["content_omitted"] = True
+        sanitized.setdefault(
+            "message",
+            "Inline base64 content omitted during context recovery.",
+        )
+        return sanitized
+
+    @classmethod
+    def _strip_base64_tool_result(cls, text: str) -> Optional[str]:
+        try:
+            parsed = json.loads(text)
+        except (TypeError, ValueError):
+            return None
+        sanitized = cls._strip_base64_json_envelope(parsed)
+        if sanitized is None:
+            return None
+        return json.dumps(sanitized, ensure_ascii=False)
 
     @staticmethod
     def _estimate_tokens(messages: List[Dict]) -> int:
@@ -852,7 +917,25 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
                 self.compaction_state = self.load_compaction_state(agent)
                 conv_manager_offset = agent.conversation_manager.removed_message_count
                 checkpoint = self.compaction_state.checkpoint
-                effective_offset = max(conv_manager_offset, checkpoint)
+                # A custom summary and Sliding Window's removed count are separate
+                # coordinate systems. Prefer the summarized checkpoint when one
+                # exists; taking max() can drop the unsummarized gap between them.
+                if checkpoint > 0 and self.compaction_state.summary:
+                    effective_offset = min(checkpoint, len(all_session_messages))
+                    if conv_manager_offset != effective_offset:
+                        logger.warning(
+                            "[Compaction] Reconciling conversation-manager offset "
+                            f"{conv_manager_offset} -> summarized checkpoint {effective_offset}"
+                        )
+                        agent.conversation_manager.removed_message_count = effective_offset
+                else:
+                    effective_offset = min(conv_manager_offset, len(all_session_messages))
+                    if conv_manager_offset != effective_offset:
+                        logger.warning(
+                            "[Compaction] Clamping conversation-manager offset "
+                            f"{conv_manager_offset} -> {effective_offset}"
+                        )
+                        agent.conversation_manager.removed_message_count = effective_offset
 
                 stage = "none"
                 self._valid_cutoff_message_ids = []
@@ -867,7 +950,7 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
                 messages_to_process = [sm.to_message() for sm in session_messages]
                 original_message_count = len(messages_to_process)
 
-                if checkpoint > 0 and effective_offset >= checkpoint:
+                if checkpoint > 0 and self.compaction_state.summary:
                     if self.compaction_state.summary and messages_to_process:
                         summary_prefix = f"""<conversation_summary>
 The following is a summary of our previous conversation:
@@ -881,13 +964,15 @@ Please continue the conversation with this context in mind.
                         messages_to_process = self._prepend_summary_to_first_message(messages_to_process, summary_prefix)
                     stage = "checkpoint"
 
-                # Truncate tool output only when the conversation is actually
-                # near the model's limit. Doing it on every load discarded
-                # detail that a 1M-token model had room for.
+                # Normal compaction runs near the model limit. The hard result
+                # cap runs on every load, including protected recent turns, so
+                # existing sessions containing inline base64 can recover.
                 should_truncate, estimated_tokens = self._should_truncate(messages_to_process)
-                truncation_count = 0
+                protected_indices = self._find_protected_message_indices(
+                    messages_to_process,
+                    self.protected_turns,
+                )
                 if should_truncate:
-                    protected_indices = self._find_protected_message_indices(messages_to_process, self.protected_turns)
                     truncated_messages, truncation_count, chars_saved = self._truncate_tool_contents(
                         messages_to_process, protected_indices=protected_indices
                     )
@@ -896,7 +981,11 @@ Please continue the conversation with this context in mind.
                         f"~{estimated_tokens:,} estimated tokens >= {self.truncation_threshold:,} threshold"
                     )
                 else:
-                    truncated_messages = messages_to_process
+                    all_protected = set(range(len(messages_to_process)))
+                    truncated_messages, truncation_count, chars_saved = self._truncate_tool_contents(
+                        messages_to_process,
+                        protected_indices=all_protected,
+                    )
                     # info, not debug: this is the decision the model-sized
                     # threshold exists to make, and the only record of which
                     # threshold was in effect for this model. At debug level it
@@ -906,6 +995,11 @@ Please continue the conversation with this context in mind.
                         f"[Compaction] Skipped truncation: ~{estimated_tokens:,} estimated tokens "
                         f"< {self.truncation_threshold:,} threshold"
                     )
+                    if truncation_count:
+                        logger.warning(
+                            f"[Compaction] Emergency-truncated {truncation_count} protected "
+                            f"tool result block(s), saving ~{chars_saved:,} chars"
+                        )
 
                 if truncation_count > 0:
                     stage = "checkpoint+truncation" if stage == "checkpoint" else "truncation"
@@ -945,11 +1039,28 @@ Please continue the conversation with this context in mind.
         if input_tokens > self.token_threshold:
             logger.info(f"Threshold exceeded: {input_tokens:,} > {self.token_threshold:,}")
 
-            # Always recompute cutoff points from current agent.messages
-            # Cache from initialize() becomes stale as new messages are appended
+            # Checkpoints are persisted-history offsets. Recompute from the full
+            # repository rather than agent.messages, which Sliding Window may
+            # already have trimmed and whose indices are therefore relative.
+            persisted_messages = None
+            repository = getattr(self, "session_repository", None)
+            if repository is not None:
+                try:
+                    stored = repository.list_messages(
+                        session_id=self.session_id,
+                        agent_id=agent_id,
+                    )
+                    persisted_messages = [sm.to_message() for sm in stored]
+                except Exception as e:
+                    logger.warning(
+                        "[Compaction] Failed to reload persisted messages; "
+                        f"using current agent history: {e}"
+                    )
+
+            source_messages = persisted_messages if persisted_messages is not None else agent.messages
             self._valid_cutoff_message_ids = []
             self._all_messages_for_summary = []
-            for idx, msg in enumerate(agent.messages):
+            for idx, msg in enumerate(source_messages):
                 self._all_messages_for_summary.append(msg)
                 if msg.get('role') == 'user' and not self._has_tool_result(msg):
                     self._valid_cutoff_message_ids.append(idx)

--- a/chatbot-app/agentcore/src/agents/model_factory.py
+++ b/chatbot-app/agentcore/src/agents/model_factory.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 import boto3
 from strands.models import BedrockModel, CacheConfig
+from strands.types.exceptions import ContextWindowOverflowException
 
 from agent.config.model_catalog import get_model_catalog
 # Re-exported for callers that already reach for model_factory. The registry
@@ -33,6 +34,20 @@ from agent.config.model_context_windows import (  # noqa: F401
 
 logger = logging.getLogger(__name__)
 _MODEL_CATALOG = get_model_catalog()
+_CONTEXT_OVERFLOW_MARKERS = (
+    "context_length_exceeded",
+    "prompt is too long",
+    "maximum context length",
+    "context length exceeded",
+    "context window exceeded",
+)
+
+
+def _is_context_overflow_error(error: BaseException) -> bool:
+    message = str(error).lower()
+    if "prompt tokens" in message and "exceed model maximum" in message:
+        return True
+    return any(marker in message for marker in _CONTEXT_OVERFLOW_MARKERS)
 
 
 # Reasoning models that reject the `temperature` inference param. Listed by
@@ -138,19 +153,26 @@ def _make_bedrock_mantle_responses_model(model_id: str, spec: MantleSpec, max_to
             while True:
                 lead_buffer = []
                 produced = False
-                async for event in super().stream(*args, **kwargs):
-                    if produced:
-                        yield event
-                        continue
-                    key = next(iter(event.keys())) if isinstance(event, dict) else None
-                    if key in self._CONTENT_KEYS:
-                        produced = True
-                        for held in lead_buffer:
-                            yield held
-                        lead_buffer = []
-                        yield event
-                    else:
-                        lead_buffer.append(event)
+                try:
+                    async for event in super().stream(*args, **kwargs):
+                        if produced:
+                            yield event
+                            continue
+                        key = next(iter(event.keys())) if isinstance(event, dict) else None
+                        if key in self._CONTENT_KEYS:
+                            produced = True
+                            for held in lead_buffer:
+                                yield held
+                            lead_buffer = []
+                            yield event
+                        else:
+                            lead_buffer.append(event)
+                except ContextWindowOverflowException:
+                    raise
+                except Exception as error:
+                    if _is_context_overflow_error(error):
+                        raise ContextWindowOverflowException(str(error)) from error
+                    raise
                 if produced:
                     return
                 if attempt < self.MAX_RETRIES:

--- a/chatbot-app/agentcore/src/local_tools/workspace.py
+++ b/chatbot-app/agentcore/src/local_tools/workspace.py
@@ -22,7 +22,8 @@ from workspace.paths import code_interpreter_prefix
 
 logger = logging.getLogger(__name__)
 
-# Extensions treated as binary (base64 encoded on read)
+# Extensions treated as binary. Binary payloads must not be returned as text:
+# a single base64-encoded Office file can exceed the model context window.
 _BINARY_EXTENSIONS = {
     '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
     '.pdf', '.pptx', '.ppt', '.docx', '.doc', '.xlsx', '.xls',
@@ -135,7 +136,8 @@ def workspace_read(path: str, tool_context: ToolContext = None) -> str:
     """Read a file from the shared session workspace.
 
     Text files are returned as plain strings.
-    Binary files (images, PDFs, Office docs) are returned base64-encoded.
+    Binary files return metadata only; use the relevant document tool or Code
+    Interpreter to inspect their contents.
 
     Args:
         path: Logical path, e.g.:
@@ -145,7 +147,7 @@ def workspace_read(path: str, tool_context: ToolContext = None) -> str:
               'documents/image/chart.png'
 
     Returns:
-        JSON with content (text or base64), encoding, and size.
+        JSON with text content, or metadata for binary files.
     """
     try:
         user_id, session_id = _get_ids(tool_context)
@@ -155,12 +157,16 @@ def workspace_read(path: str, tool_context: ToolContext = None) -> str:
         s3_key = _to_s3_key(user_id, session_id, path)
         response = s3.get_object(Bucket=bucket, Key=s3_key)
         if _is_binary(path):
-            data = response['Body'].read()
+            size = int(response.get('ContentLength', 0))
             return json.dumps({
                 'path': path,
-                'encoding': 'base64',
-                'content': base64.b64encode(data).decode('utf-8'),
-                'size': len(data),
+                'encoding': 'binary',
+                'size': size,
+                'content_omitted': True,
+                'message': (
+                    'Binary content is not returned inline. Use the appropriate '
+                    'document/presentation tool or Code Interpreter to inspect this file.'
+                ),
                 'status': 'ok',
             })
         else:

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -94,15 +94,16 @@ def _resolve_user_id(
             return None
         return claimed or "anonymous"
 
+    expected_m2m_client = os.environ.get("M2M_CLIENT_ID")
+    if (
+        expected_m2m_client
+        and claims.get("client_id") == expected_m2m_client
+        and claimed
+    ):
+        return claimed
+
     subject = claims.get("sub")
     if not isinstance(subject, str) or not subject:
-        expected_m2m_client = os.environ.get("M2M_CLIENT_ID")
-        if (
-            expected_m2m_client
-            and claims.get("client_id") == expected_m2m_client
-            and claimed
-        ):
-            return claimed
         raise HTTPException(status_code=401, detail="Bearer token subject is required")
     if claimed and claimed != subject:
         raise HTTPException(status_code=403, detail="User identity mismatch")

--- a/chatbot-app/agentcore/src/skill/skill_tools.py
+++ b/chatbot-app/agentcore/src/skill/skill_tools.py
@@ -7,8 +7,10 @@ Skill infrastructure tools for progressive disclosure.
 
 import asyncio
 import concurrent.futures
+import copy
 import json
 import logging
+import os
 from datetime import timedelta
 
 from strands import tool
@@ -20,6 +22,128 @@ logger = logging.getLogger(__name__)
 
 # Module-level registry reference, set by SkillChatAgent during init
 _registry = None
+_DEFAULT_SKILL_RESULT_MAX_CHARS = 100_000
+
+
+def _skill_result_max_chars() -> int:
+    try:
+        return max(1_000, int(os.getenv(
+            "SKILL_RESULT_MAX_CHARS",
+            str(_DEFAULT_SKILL_RESULT_MAX_CHARS),
+        )))
+    except ValueError:
+        return _DEFAULT_SKILL_RESULT_MAX_CHARS
+
+
+def _truncate_result_text(text: str, max_chars: int) -> str:
+    """Keep a bounded start/end preview of oversized tool text."""
+    if len(text) <= max_chars:
+        return text
+    marker = f"\n... [tool result truncated, {len(text) - max_chars:,} chars omitted] ...\n"
+    if max_chars <= len(marker):
+        return marker[:max_chars]
+    preview_chars = max(0, max_chars - len(marker))
+    start_chars = (preview_chars + 1) // 2
+    end_chars = preview_chars // 2
+    return text[:start_chars] + marker + (text[-end_chars:] if end_chars else "")
+
+
+def _strip_inline_base64_envelope(value):
+    """Remove binary text from common JSON envelopes while retaining metadata."""
+    if not isinstance(value, dict):
+        return value
+    if str(value.get("encoding", "")).lower() != "base64":
+        return value
+    if not isinstance(value.get("content"), str):
+        return value
+
+    sanitized = dict(value)
+    sanitized.pop("content", None)
+    sanitized["content_omitted"] = True
+    sanitized.setdefault(
+        "message",
+        "Inline base64 content was omitted. Use the appropriate file-processing tool.",
+    )
+    return sanitized
+
+
+def _content_embeds_metadata(content) -> bool:
+    if not isinstance(content, list):
+        return False
+    for block in content:
+        if not isinstance(block, dict) or not isinstance(block.get("text"), str):
+            continue
+        try:
+            parsed = json.loads(block["text"])
+        except (TypeError, ValueError):
+            continue
+        if isinstance(parsed, dict) and "metadata" in parsed:
+            return True
+    return False
+
+
+def _sanitize_content_text(text: str, max_chars: int) -> str:
+    """Sanitize a text block while keeping structured response envelopes valid."""
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError):
+        return _truncate_result_text(text, max_chars)
+
+    sanitized = _strip_inline_base64_envelope(parsed)
+    if isinstance(sanitized, dict) and isinstance(sanitized.get("text"), str):
+        nested_text = sanitized["text"]
+        without_text = dict(sanitized)
+        without_text["text"] = ""
+        overhead = len(json.dumps(without_text, ensure_ascii=False, default=str))
+        nested_limit = max(0, max_chars - overhead)
+        for _ in range(3):
+            sanitized["text"] = _truncate_result_text(nested_text, nested_limit)
+            serialized = json.dumps(sanitized, ensure_ascii=False, default=str)
+            overflow = len(serialized) - max_chars
+            if overflow <= 0:
+                return serialized
+            nested_limit = max(0, nested_limit - overflow)
+
+    serialized = json.dumps(sanitized, ensure_ascii=False, default=str)
+    return _truncate_result_text(serialized, max_chars)
+
+
+def _sanitize_skill_result(result, max_chars: int | None = None):
+    """Bound textual tool output without modifying native image/document blocks."""
+    limit = max_chars or _skill_result_max_chars()
+
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+        except (TypeError, ValueError):
+            return _truncate_result_text(result, limit)
+
+        sanitized = _strip_inline_base64_envelope(parsed)
+        serialized = json.dumps(sanitized, ensure_ascii=False, default=str)
+        return _truncate_result_text(serialized, limit)
+
+    if isinstance(result, dict):
+        sanitized = copy.deepcopy(_strip_inline_base64_envelope(result))
+        content = sanitized.get("content")
+        if isinstance(content, list):
+            remaining = limit
+            for block in content:
+                if not isinstance(block, dict) or not isinstance(block.get("text"), str):
+                    continue
+                text = block["text"]
+                block["text"] = _sanitize_content_text(text, remaining)
+                remaining = max(0, remaining - len(block["text"]))
+            if "metadata" in sanitized and _content_embeds_metadata(content):
+                sanitized.pop("metadata", None)
+            return sanitized
+
+        serialized = json.dumps(sanitized, ensure_ascii=False, default=str)
+        if len(serialized) > limit:
+            return _truncate_result_text(serialized, limit)
+        return sanitized
+
+    text = str(result)
+    return _truncate_result_text(text, limit)
 
 
 def set_dispatcher_registry(registry) -> None:
@@ -360,21 +484,23 @@ def skill_executor(
     try:
         # ========== Script Execution Path ==========
         if script_name:
-            return _execute_script(
+            result = _execute_script(
                 tool_context=tool_context,
                 skill_name=skill_name,
                 script_name=script_name,
                 script_input=script_input or {},
             )
+            return _sanitize_skill_result(result)
 
         # ========== Tool Execution Path ==========
         if tool_name:
-            return _execute_tool(
+            result = _execute_tool(
                 tool_context=tool_context,
                 skill_name=skill_name,
                 tool_name=tool_name,
                 tool_input=tool_input or {},
             )
+            return _sanitize_skill_result(result)
 
     except Exception as e:
         logger.error(f"Error executing {skill_name}/{tool_name or script_name}: {e}")

--- a/chatbot-app/agentcore/src/streaming/agui_event_processor.py
+++ b/chatbot-app/agentcore/src/streaming/agui_event_processor.py
@@ -497,6 +497,7 @@ class AGUIStreamEventProcessor:
 
         stream_iterator = None
         next_event_task = None  # Task for async generator polling (used with elicitation bridge)
+        compaction_update_attempted = False
         try:
             multimodal_message = self._create_multimodal_message(message, file_paths)
 
@@ -698,12 +699,9 @@ class AGUIStreamEventProcessor:
                         logger.error(f"[Token Usage] Error extracting token usage: {e}")
                         # Continue without usage data
 
-                    # Documents are fetched by frontend via S3 workspace API - no longer sent from backend
-                    logger.debug("[Final Result] Emitting complete event and closing stream")
-                    yield self.formatter.format_event("complete", message=result_text, images=images, usage=usage)
-                    logger.debug("[Final Result] Complete event emitted, stream ended")
-
-                    # Trigger compaction update using last LLM call's context size
+                    # Persist compaction before yielding the terminal event. A
+                    # client can close the generator immediately after complete,
+                    # so code placed after that yield is not reliable.
                     session_manager = invocation_state.get("session_manager") if invocation_state else None
                     if session_manager and hasattr(session_manager, 'update_after_turn'):
                         context_size = (
@@ -711,10 +709,16 @@ class AGUIStreamEventProcessor:
                             or self.last_llm_input_tokens
                         )
                         if context_size:
+                            compaction_update_attempted = True
                             try:
                                 session_manager.update_after_turn(context_size, agent.agent_id, agent)
                             except Exception as e:
                                 logger.warning(f"[Compaction] update_after_turn failed: {e}")
+
+                    # Documents are fetched by frontend via S3 workspace API - no longer sent from backend
+                    logger.debug("[Final Result] Emitting complete event and closing stream")
+                    yield self.formatter.format_event("complete", message=result_text, images=images, usage=usage)
+                    logger.debug("[Final Result] Complete event emitted, stream ended")
 
                     return
 
@@ -1031,6 +1035,24 @@ class AGUIStreamEventProcessor:
                 )
 
         finally:
+            # Cancellation or an exception can bypass the final-result branch.
+            # Persist any context metric that was already observed.
+            if not compaction_update_attempted:
+                session_manager = invocation_state.get("session_manager") if invocation_state else None
+                context_size = (
+                    getattr(getattr(agent, "event_loop_metrics", None), "latest_context_size", None)
+                    or self.last_llm_input_tokens
+                )
+                if (
+                    context_size
+                    and session_manager
+                    and hasattr(session_manager, "update_after_turn")
+                ):
+                    try:
+                        session_manager.update_after_turn(context_size, agent.agent_id, agent)
+                    except Exception as e:
+                        logger.warning(f"[Compaction] final update_after_turn failed: {e}")
+
             # Cancel any pending next-event task to avoid leaks
             if next_event_task is not None and not next_event_task.done():
                 next_event_task.cancel()

--- a/chatbot-app/agentcore/tests/unit/test_chat_router.py
+++ b/chatbot-app/agentcore/tests/unit/test_chat_router.py
@@ -659,7 +659,11 @@ class TestInvocationsEndpoint:
             "/invocations",
             headers={
                 "Authorization": (
-                    f"Bearer {_unsigned_test_token({'client_id': 'trusted-service'})}"
+                    "Bearer "
+                    + _unsigned_test_token({
+                        "client_id": "trusted-service",
+                        "sub": "trusted-service-token-subject",
+                    })
                 )
             },
             json={

--- a/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
+++ b/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
@@ -9,10 +9,12 @@ Tests cover:
 - Edge cases and error handling
 """
 
-import pytest
-from unittest.mock import Mock, MagicMock, patch
+import json
 import os
 import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
@@ -1301,6 +1303,59 @@ class TestTruncationWithProtectedIndices:
         assert truncation_count == 0
         assert chars_saved == 0
 
+    def test_hard_cap_applies_to_protected_tool_result(self, manager):
+        """A poisoned latest turn must be recoverable during session load."""
+        long_content = "D" * 120_000
+        messages = [{
+            "role": "user",
+            "content": [{
+                "toolResult": {
+                    "toolUseId": "1",
+                    "content": [{"text": long_content}],
+                },
+            }],
+        }]
+
+        result, truncation_count, chars_saved = manager._truncate_tool_contents(
+            messages,
+            protected_indices={0},
+        )
+
+        text = result[0]["content"][0]["toolResult"]["content"][0]["text"]
+        assert len(text) < len(long_content)
+        assert "[truncated," in text
+        assert truncation_count == 1
+        assert chars_saved == 20_000
+
+    def test_base64_envelope_is_removed_from_protected_tool_result(self, manager):
+        payload = json.dumps({
+            "path": "uploads/deck.pptx",
+            "encoding": "base64",
+            "content": "A" * 10_000,
+            "size": 7_500,
+            "status": "ok",
+        })
+        messages = [{
+            "role": "user",
+            "content": [{
+                "toolResult": {
+                    "toolUseId": "1",
+                    "content": [{"text": payload}],
+                },
+            }],
+        }]
+
+        result, truncation_count, _ = manager._truncate_tool_contents(
+            messages,
+            protected_indices={0},
+        )
+        text = result[0]["content"][0]["toolResult"]["content"][0]["text"]
+        parsed = json.loads(text)
+
+        assert parsed["content_omitted"] is True
+        assert "content" not in parsed
+        assert truncation_count == 1
+
 
 class TestEffectiveOffsetCalculation:
     """Test effective offset calculation combining conv_manager offset and checkpoint"""
@@ -1529,6 +1584,40 @@ class TestUpdateAfterTurnLogic:
 
         assert manager.compaction_state.checkpoint == 4
         assert manager.compaction_state.summary == "Updated summary"
+
+    def test_checkpoint_uses_absolute_persisted_history_index(self, manager):
+        """Sliding Window's relative agent history must not define the checkpoint."""
+        full_history = [
+            {"role": "user", "content": [{"text": "msg1"}]},
+            {"role": "assistant", "content": [{"text": "resp1"}]},
+            {"role": "user", "content": [{"text": "msg2"}]},
+            {"role": "assistant", "content": [{"text": "resp2"}]},
+            {"role": "user", "content": [{"text": "msg3"}]},
+            {"role": "assistant", "content": [{"text": "resp3"}]},
+            {"role": "user", "content": [{"text": "msg4"}]},
+            {"role": "assistant", "content": [{"text": "resp4"}]},
+        ]
+        stored_messages = []
+        for message in full_history:
+            stored = MagicMock()
+            stored.to_message.return_value = message
+            stored_messages.append(stored)
+
+        manager.session_id = "test-session"
+        manager.session_repository = MagicMock()
+        manager.session_repository.list_messages.return_value = stored_messages
+        agent = self._make_mock_agent(full_history[-4:])
+
+        with patch.object(manager, 'save_compaction_state'):
+            with patch.object(
+                manager,
+                '_generate_summary_for_compaction',
+                return_value="Absolute summary",
+            ) as summarize:
+                manager.update_after_turn(2000, 'test-agent', agent)
+
+        assert manager.compaction_state.checkpoint == 4
+        summarize.assert_called_once_with(full_history[:4])
 
     def test_does_not_update_checkpoint_backward(self, manager):
         """Should not update checkpoint if new_checkpoint <= current checkpoint"""

--- a/chatbot-app/agentcore/tests/unit/test_gateway_mcp_client.py
+++ b/chatbot-app/agentcore/tests/unit/test_gateway_mcp_client.py
@@ -208,3 +208,81 @@ class TestSkillExecutorMCPPath:
         parsed = json.loads(result)
         assert parsed["status"] == "error"
         assert "Connection closed" in parsed["error"]
+
+
+class TestSkillResultBudget:
+    def test_truncates_oversized_text_with_start_and_end_preview(self):
+        from skill.skill_tools import _sanitize_skill_result
+
+        result = _sanitize_skill_result("A" * 120 + "END", max_chars=100)
+
+        assert len(result) == 100
+        assert result.startswith("A")
+        assert result.endswith("END")
+        assert "tool result truncated" in result
+
+    def test_removes_inline_base64_json_envelope(self):
+        from skill.skill_tools import _sanitize_skill_result
+
+        result = _sanitize_skill_result(json.dumps({
+            "path": "uploads/deck.pptx",
+            "encoding": "base64",
+            "content": "A" * 20_000,
+            "size": 15_000,
+            "status": "ok",
+        }))
+        parsed = json.loads(result)
+
+        assert parsed["path"] == "uploads/deck.pptx"
+        assert parsed["size"] == 15_000
+        assert parsed["content_omitted"] is True
+        assert "content" not in parsed
+
+    def test_preserves_native_image_blocks_and_deduplicates_metadata(self):
+        from skill.skill_tools import _sanitize_skill_result
+
+        metadata = {"filename": "slide.png"}
+        image = {"image": {"format": "png", "source": {"bytes": b"png"}}}
+        result = _sanitize_skill_result({
+            "content": [
+                {"text": json.dumps({"text": "preview", "metadata": metadata})},
+                image,
+            ],
+            "status": "success",
+            "metadata": metadata,
+        })
+
+        assert result["content"][1] == image
+        assert result["status"] == "success"
+        assert "metadata" not in result
+
+    def test_bounds_text_inside_structured_content(self):
+        from skill.skill_tools import _sanitize_skill_result
+
+        result = _sanitize_skill_result({
+            "content": [{"text": "X" * 1_000}],
+            "status": "success",
+        }, max_chars=200)
+
+        assert len(result["content"][0]["text"]) == 200
+        assert result["status"] == "success"
+
+    def test_keeps_oversized_metadata_envelope_valid(self):
+        from skill.skill_tools import _sanitize_skill_result
+
+        result = _sanitize_skill_result({
+            "content": [{
+                "text": json.dumps({
+                    "text": "X" * 1_000,
+                    "metadata": {"filename": "report.pptx"},
+                }),
+            }],
+            "status": "success",
+            "metadata": {"filename": "report.pptx"},
+        }, max_chars=250)
+        envelope = json.loads(result["content"][0]["text"])
+
+        assert len(result["content"][0]["text"]) <= 250
+        assert "tool result truncated" in envelope["text"]
+        assert envelope["metadata"]["filename"] == "report.pptx"
+        assert "metadata" not in result

--- a/chatbot-app/agentcore/tests/unit/test_model_factory.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_factory.py
@@ -12,6 +12,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 import agents.model_factory as mf
+from strands.models.openai_responses import OpenAIResponsesModel
+from strands.types.exceptions import ContextWindowOverflowException
 from agents.model_factory import (
     build_model,
     model_rejects_temperature,
@@ -135,6 +137,36 @@ class TestMantleRouting:
         model = build_model("openai.gpt-5.6-sol")
         out = type(model)._format_request_message_content({"text": "hi"})
         assert out == {"type": "input_text", "text": "hi"}
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
+    async def test_normalizes_mantle_prompt_token_overflow(self):
+        async def failing_stream(_self, *args, **kwargs):
+            if False:
+                yield None
+            raise RuntimeError(
+                "prompt tokens (1209034) exceed model maximum (1050000)"
+            )
+
+        model = build_model("openai.gpt-5.6-sol")
+        with patch.object(OpenAIResponsesModel, "stream", failing_stream):
+            with pytest.raises(ContextWindowOverflowException, match="1209034"):
+                async for _ in model.stream([]):
+                    pass
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
+    async def test_preserves_unrelated_mantle_errors(self):
+        async def failing_stream(_self, *args, **kwargs):
+            if False:
+                yield None
+            raise RuntimeError("upstream connection reset")
+
+        model = build_model("openai.gpt-5.6-sol")
+        with patch.object(OpenAIResponsesModel, "stream", failing_stream):
+            with pytest.raises(RuntimeError, match="connection reset"):
+                async for _ in model.stream([]):
+                    pass
 
 
 class TestApiKeyResolution:

--- a/chatbot-app/agentcore/tests/unit/test_workspace_tools.py
+++ b/chatbot-app/agentcore/tests/unit/test_workspace_tools.py
@@ -235,22 +235,26 @@ class TestWorkspaceRead:
 
     @patch('local_tools.workspace._s3_client')
     @patch('local_tools.workspace.get_workspace_bucket', return_value='my-bucket')
-    def test_reads_binary_file_as_base64(self, mock_bucket, mock_s3_factory):
-        import base64
+    def test_returns_binary_metadata_without_inline_content(self, mock_bucket, mock_s3_factory):
         mock_s3 = MagicMock()
         mock_s3_factory.return_value = mock_s3
-        binary_data = b'\x89PNG\r\n\x1a\n'
+        body = MagicMock()
         mock_s3.get_object.return_value = {
-            'Body': MagicMock(read=MagicMock(return_value=binary_data))
+            'Body': body,
+            'ContentLength': 1_325_581,
         }
 
         from local_tools.workspace import workspace_read
-        result = workspace_read(path='code-interpreter/chart.png', tool_context=_make_context())
+        result = workspace_read(path='uploads/deck.pptx', tool_context=_make_context())
         data = json.loads(result)
 
         assert data['status'] == 'ok'
-        assert data['encoding'] == 'base64'
-        assert base64.b64decode(data['content']) == binary_data
+        assert data['encoding'] == 'binary'
+        assert data['size'] == 1_325_581
+        assert data['content_omitted'] is True
+        assert 'content' not in data
+        assert 'presentation tool' in data['message']
+        body.read.assert_not_called()
 
     @patch('local_tools.workspace._s3_client')
     @patch('local_tools.workspace.get_workspace_bucket', return_value='my-bucket')


### PR DESCRIPTION
## Summary
- prevent binary workspace reads and oversized skill results from injecting large inline payloads into model context
- make compaction checkpoints use persisted-history coordinates, persist updates before stream completion, and normalize Mantle overflow errors for recovery
- allow trusted M2M user delegation and correct the PowerPoint `replace_text` parameter guide

## Verification
- `python -m ruff check src/`
- `python -m pytest tests/unit/ -v --tb=short` (647 passed)
- `python -m pytest tests/integration/ -v --tb=short` (136 passed, 15 deselected)
- development deploy completed; Terraform reports no changes
- general-subagent and orchestrator AgentCore runtimes are READY
- deployed `/api/health` returns healthy