### PR TITLE
fix(auth): refresh tokens before AgentCore invocation

### DIFF
--- a/chatbot-app/frontend/__tests__/api/chat-auth.test.ts
+++ b/chatbot-app/frontend/__tests__/api/chat-auth.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  extractUserFromRequest: vi.fn(),
+  getSessionId: vi.fn(),
+  ensureSessionExists: vi.fn(),
+  invokeAgentCoreRuntime: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-utils', () => ({
+  extractUserFromRequest: mocks.extractUserFromRequest,
+  getSessionId: mocks.getSessionId,
+  ensureSessionExists: mocks.ensureSessionExists,
+}))
+
+vi.mock('@/lib/agentcore-runtime-client', () => ({
+  AgentCoreRuntimeError: class AgentCoreRuntimeError extends Error {},
+  isAbortError: (error: unknown) => (
+    typeof error === 'object'
+    && error !== null
+    && 'name' in error
+    && error.name === 'AbortError'
+  ),
+  invokeAgentCoreRuntime: mocks.invokeAgentCoreRuntime,
+}))
+
+vi.mock('@/lib/chat-hooks', () => ({
+  createDefaultHookManager: vi.fn(),
+}))
+
+vi.mock('sharp', () => ({ default: vi.fn() }))
+
+function request() {
+  return {
+    headers: {
+      get: vi.fn((name: string) => (
+        name.toLowerCase() === 'authorization' ? 'Bearer stale-token' : null
+      )),
+    },
+    signal: { addEventListener: vi.fn() },
+    json: vi.fn().mockResolvedValue({
+      threadId: 'session-1',
+      runId: 'run-1',
+      messages: [{ id: 'm1', role: 'user', content: 'hello' }],
+      tools: [],
+      context: [],
+      state: {},
+    }),
+  }
+}
+
+describe('POST /api/stream/chat — Runtime token freshness', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
+    vi.setSystemTime(new Date('2026-08-25T12:00:00Z'))
+  })
+
+  it('rejects a verified token with less than two minutes remaining before side effects', async () => {
+    mocks.extractUserFromRequest.mockResolvedValue({
+      userId: 'user-1',
+      tokenExpiresAt: Date.now() / 1000 + 60,
+    })
+    const { POST } = await import('@/app/api/stream/chat/route')
+
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({
+      code: 'AUTH_TOKEN_STALE',
+    })
+    expect(mocks.ensureSessionExists).not.toHaveBeenCalled()
+    expect(mocks.invokeAgentCoreRuntime).not.toHaveBeenCalled()
+  })
+})

--- a/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
+++ b/chatbot-app/frontend/__tests__/hooks/useChatAPI-interrupt-stop.test.ts
@@ -18,6 +18,9 @@ const reconnectMocks = vi.hoisted(() => ({
   restoreFromSession: vi.fn().mockReturnValue(false),
   attemptReconnect: vi.fn(),
 }))
+const authMocks = vi.hoisted(() => ({
+  fetchAuthSession: vi.fn(),
+}))
 
 vi.mock('@/hooks/useSSEReconnect', () => ({
   useSSEReconnect: () => ({
@@ -32,9 +35,7 @@ vi.mock('@/config/environment', () => ({
 }))
 
 vi.mock('aws-amplify/auth', () => ({
-  fetchAuthSession: vi.fn().mockResolvedValue({
-    tokens: { accessToken: { toString: () => 'test-token' } },
-  }),
+  fetchAuthSession: authMocks.fetchAuthSession,
 }))
 
 /** Builds an SSE response body from the given event objects. */
@@ -70,6 +71,18 @@ const INTERRUPT = {
       { id: 'int-1', name: 'chatbot-research-approval', reason: { tool_name: 'research_agent' } },
     ],
   },
+}
+
+function resetAuthMock() {
+  authMocks.fetchAuthSession.mockReset()
+  authMocks.fetchAuthSession.mockResolvedValue({
+    tokens: {
+      accessToken: {
+        payload: { exp: Date.now() / 1000 + 3600 },
+        toString: () => 'test-token',
+      },
+    },
+  })
 }
 
 function setup(handleStreamEvent = vi.fn()) {
@@ -129,6 +142,7 @@ describe('useChatAPI — stopping a turn that parked at an interrupt', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sessionStorage.clear()
+    resetAuthMock()
   })
 
   it('still has a run to stop after an interrupt ends the stream', async () => {
@@ -211,12 +225,67 @@ describe('useChatAPI — stopping a turn that parked at an interrupt', () => {
     const body = JSON.parse(String(chatCall?.[1]?.body))
     expect(body.state.workspace_paths).toEqual(['uploads/large.jsonl'])
   })
+
+  it('force-refreshes once when the BFF rejects a stale Runtime token', async () => {
+    authMocks.fetchAuthSession.mockImplementation(
+      (options?: { forceRefresh?: boolean }) => Promise.resolve({
+        tokens: {
+          accessToken: {
+            payload: { exp: Date.now() / 1000 + 3600 },
+            toString: () => options?.forceRefresh
+              ? 'refreshed-token'
+              : 'cached-token',
+          },
+        },
+      }),
+    )
+    const staleResponse = new Response(JSON.stringify({
+      code: 'AUTH_TOKEN_STALE',
+    }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+    let chatAttempts = 0
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes('/api/warmup')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          latencyMs: 1,
+          mode: 'local',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }))
+      }
+      chatAttempts += 1
+      return Promise.resolve(
+        chatAttempts === 1
+          ? staleResponse
+          : sseResponse([RUN_FINISHED]),
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { hook } = setup()
+
+    await act(async () => {
+      await hook.result.current.sendMessage('hello')
+    })
+
+    const chatCalls = fetchMock.mock.calls.filter(call =>
+      String(call[0]).includes('stream/chat'),
+    )
+    expect(chatCalls).toHaveLength(2)
+    expect(chatCalls[1][1]?.headers).toMatchObject({
+      Authorization: 'Bearer refreshed-token',
+    })
+    expect(authMocks.fetchAuthSession).toHaveBeenCalledWith({ forceRefresh: true })
+  })
 })
 
 describe('useChatAPI — background execution replay', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sessionStorage.clear()
+    resetAuthMock()
     vi.mocked(sessionStorage.getItem).mockImplementation(key =>
       key === 'chat-session-id' ? 'session-1' : null,
     )
@@ -301,6 +370,7 @@ describe('useChatAPI — durable session restore', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sessionStorage.clear()
+    resetAuthMock()
     reconnectMocks.restoreFromSession.mockReturnValue(false)
     reconnectMocks.attemptReconnect.mockReset()
   })

--- a/chatbot-app/frontend/__tests__/lib/agentcore-runtime-client.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/agentcore-runtime-client.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('agentcore-runtime-client errors', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubEnv('NEXT_PUBLIC_AGENTCORE_LOCAL', 'false')
+    vi.stubEnv('AGENTCORE_RUNTIME_URL', 'https://runtime.example/invocations')
+  })
+
+  it('preserves AbortError so client disconnects are not reported as failures', async () => {
+    const abortError = new DOMException('This operation was aborted', 'AbortError')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError))
+    const { invokeAgentCoreRuntime } = await import('@/lib/agentcore-runtime-client')
+
+    await expect(
+      invokeAgentCoreRuntime({}, 'user-1', 'session-1', 'Bearer token'),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('preserves Runtime status and response details', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('{"error":"stale"}', { status: 401 }),
+    ))
+    const {
+      AgentCoreRuntimeError,
+      invokeAgentCoreRuntime,
+    } = await import('@/lib/agentcore-runtime-client')
+
+    const error = await invokeAgentCoreRuntime(
+      {},
+      'user-1',
+      'session-1',
+      'Bearer token',
+    ).catch(value => value)
+
+    expect(error).toBeInstanceOf(AgentCoreRuntimeError)
+    expect(error).toMatchObject({
+      status: 401,
+      responseBody: '{"error":"stale"}',
+    })
+  })
+})

--- a/chatbot-app/frontend/__tests__/lib/auth-utils.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/auth-utils.test.ts
@@ -86,7 +86,8 @@ describe('extractUserFromRequest', async () => {
       const token = createMockJWT({
         sub: 'user-123-uuid',
         email: 'test@example.com',
-        'cognito:username': 'testuser'
+        'cognito:username': 'testuser',
+        exp: 1787659200,
       })
       const request = createMockRequest({ authorization: `Bearer ${token}` })
 
@@ -95,6 +96,7 @@ describe('extractUserFromRequest', async () => {
       expect(result.userId).toBe('user-123-uuid')
       expect(result.email).toBe('test@example.com')
       expect(result.username).toBe('testuser')
+      expect(result.tokenExpiresAt).toBe(1787659200)
     })
 
     it('should fallback to cognito:username when sub is missing', async () => {

--- a/chatbot-app/frontend/__tests__/lib/runtime-auth.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/runtime-auth.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchAuthSession = vi.hoisted(() => vi.fn())
+
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession,
+}))
+
+function session(token: string, expiresAtSeconds: number) {
+  return {
+    tokens: {
+      accessToken: {
+        payload: { exp: expiresAtSeconds },
+        toString: () => token,
+      },
+    },
+  }
+}
+
+describe('runtime-auth', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.setSystemTime(new Date('2026-08-25T12:00:00Z'))
+  })
+
+  it('reuses a token with at least two minutes remaining', async () => {
+    fetchAuthSession.mockResolvedValue(
+      session('cached-token', Date.now() / 1000 + 121),
+    )
+    const { getRuntimeAuthHeaders } = await import('@/lib/runtime-auth')
+
+    await expect(getRuntimeAuthHeaders()).resolves.toEqual({
+      Authorization: 'Bearer cached-token',
+    })
+    expect(fetchAuthSession).toHaveBeenCalledTimes(1)
+    expect(fetchAuthSession).toHaveBeenCalledWith()
+  })
+
+  it('force-refreshes a token inside the AgentCore validity window', async () => {
+    fetchAuthSession
+      .mockResolvedValueOnce(session('stale-token', Date.now() / 1000 + 119))
+      .mockResolvedValueOnce(session('fresh-token', Date.now() / 1000 + 3600))
+    const { getRuntimeAuthHeaders } = await import('@/lib/runtime-auth')
+
+    await expect(getRuntimeAuthHeaders()).resolves.toEqual({
+      Authorization: 'Bearer fresh-token',
+    })
+    expect(fetchAuthSession).toHaveBeenNthCalledWith(2, { forceRefresh: true })
+  })
+
+  it('coalesces concurrent forced refreshes', async () => {
+    let finishRefresh: ((value: ReturnType<typeof session>) => void) | undefined
+    const refresh = new Promise<ReturnType<typeof session>>(resolve => {
+      finishRefresh = resolve
+    })
+    fetchAuthSession.mockImplementation((options?: { forceRefresh?: boolean }) => (
+      options?.forceRefresh
+        ? refresh
+        : Promise.resolve(session('stale-token', Date.now() / 1000 + 30))
+    ))
+    const { getRuntimeAuthHeaders } = await import('@/lib/runtime-auth')
+
+    const first = getRuntimeAuthHeaders()
+    const second = getRuntimeAuthHeaders()
+    await vi.waitFor(() => {
+      expect(fetchAuthSession).toHaveBeenCalledWith({ forceRefresh: true })
+    })
+    finishRefresh?.(session('fresh-token', Date.now() / 1000 + 3600))
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { Authorization: 'Bearer fresh-token' },
+      { Authorization: 'Bearer fresh-token' },
+    ])
+    expect(
+      fetchAuthSession.mock.calls.filter(([options]) => options?.forceRefresh),
+    ).toHaveLength(1)
+  })
+
+  it('rejects a refreshed token that is still too close to expiry', async () => {
+    fetchAuthSession
+      .mockResolvedValueOnce(session('stale-token', Date.now() / 1000 + 30))
+      .mockResolvedValueOnce(session('still-stale', Date.now() / 1000 + 60))
+    const { getRuntimeAccessToken } = await import('@/lib/runtime-auth')
+
+    await expect(getRuntimeAccessToken()).rejects.toThrow(
+      'not valid long enough',
+    )
+  })
+})

--- a/chatbot-app/frontend/src/app/api/stream/chat/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/chat/route.ts
@@ -3,9 +3,14 @@
  * Invokes AgentCore Runtime and streams responses
  */
 import { NextRequest } from 'next/server'
-import { invokeAgentCoreRuntime } from '@/lib/agentcore-runtime-client'
+import {
+  AgentCoreRuntimeError,
+  invokeAgentCoreRuntime,
+  isAbortError,
+} from '@/lib/agentcore-runtime-client'
 import { extractUserFromRequest, getSessionId, ensureSessionExists } from '@/lib/auth-utils'
 import { createDefaultHookManager } from '@/lib/chat-hooks'
+import { isRuntimeTokenFresh } from '@/lib/runtime-auth-policy'
 import sharp from 'sharp'
 
 // Maximum image size in bytes — must stay well under AgentCore Memory's
@@ -194,6 +199,15 @@ export async function POST(request: NextRequest) {
     if (!IS_LOCAL && userId === 'anonymous') {
       return new Response(
         JSON.stringify({ error: 'Authentication required' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+    if (!IS_LOCAL && !isRuntimeTokenFresh(user.tokenExpiresAt)) {
+      return new Response(
+        JSON.stringify({
+          error: 'Authentication token must be refreshed before invoking AgentCore Runtime',
+          code: 'AUTH_TOKEN_STALE',
+        }),
         { status: 401, headers: { 'Content-Type': 'application/json' } }
       )
     }
@@ -458,16 +472,32 @@ export async function POST(request: NextRequest) {
         } catch (error) {
           if (
             clientDisconnected
-            && error instanceof Error
-            && error.name === 'AbortError'
+            && isAbortError(error)
           ) {
             console.log('[BFF] Stream relay detached after client disconnect')
             return
           }
           console.error('[BFF] Error:', error)
+          const runtimeAuthError = (
+            error instanceof AgentCoreRuntimeError
+            && error.status === 401
+          )
+          const runtimeUnavailable = (
+            error instanceof AgentCoreRuntimeError
+            && error.status >= 500
+          )
           const errorEvent = `data: ${JSON.stringify({
             type: 'RUN_ERROR',
-            message: 'Agent stream failed'
+            code: runtimeAuthError
+              ? 'AUTH_TOKEN_STALE'
+              : runtimeUnavailable
+                ? 'RUNTIME_UNAVAILABLE'
+                : 'AGENT_STREAM_FAILED',
+            message: runtimeAuthError
+              ? 'Your authentication session needs to be refreshed. Please retry.'
+              : runtimeUnavailable
+                ? 'The agent service is temporarily unavailable. Please retry.'
+                : 'Agent request failed.'
           })}\n\n`
           try {
             if (!clientDisconnected) {
@@ -496,7 +526,7 @@ export async function POST(request: NextRequest) {
               }
             }
 
-            if (currentSession) {
+            if (currentSession && agentStarted) {
               const updates: any = {
                 lastMessageAt: new Date().toISOString(),
                 messageCount: (currentSession.messageCount || 0) + 1,

--- a/chatbot-app/frontend/src/hooks/useChatAPI.ts
+++ b/chatbot-app/frontend/src/hooks/useChatAPI.ts
@@ -3,13 +3,14 @@ import { Message, ToolExecution, WorkspaceAttachment } from '@/types/chat'
 import { AGUIStreamEvent, ChatUIState, AGUI_EVENT_TYPES } from '@/types/events'
 import { getApiUrl } from '@/config/environment'
 import logger from '@/utils/logger'
-import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth'
+import { getCurrentUser } from 'aws-amplify/auth'
 import { buildToolMaps, createToolExecution } from '@/utils/messageParser'
 import { isSessionTimedOut, getLastActivity, updateLastActivity, clearSessionData, triggerWarmup, generateSessionId } from '@/config/session'
 import { isA2ATool } from './usePolling'
 import { useSSEReconnect } from './useSSEReconnect'
 import { validateAGUIStreamEvent } from '@/utils/sseParser'
 import { arrayBufferToBase64 } from '@/lib/base64'
+import { getRuntimeAuthHeaders } from '@/lib/runtime-auth'
 
 /**
  * Process swarm message content blocks in order to preserve text/tool interleaving.
@@ -315,14 +316,9 @@ export const useChatAPI = ({
    */
   const getAuthHeaders = async (): Promise<Record<string, string>> => {
     try {
-      const session = await fetchAuthSession()
-      const token = session.tokens?.accessToken?.toString()
-
-      if (token) {
-        return { 'Authorization': `Bearer ${token}` }
-      }
+      return await getRuntimeAuthHeaders()
     } catch (error) {
-      logger.debug('No auth session available (local dev or not authenticated)')
+      logger.error('Failed to prepare AgentCore Runtime authentication:', error)
     }
     return {}
   }
@@ -592,12 +588,32 @@ export const useChatAPI = ({
           headers['X-Session-ID'] = currentSessionId
         }
 
-        let response = await fetch(getApiUrl('stream/chat'), {
-          method: 'POST',
-          headers,
-          body: aguiBody,
-          signal: localAbortController.signal
-        })
+        const sendRequest = (requestHeaders: Record<string, string>) => fetch(
+          getApiUrl('stream/chat'),
+          {
+            method: 'POST',
+            headers: requestHeaders,
+            body: aguiBody,
+            signal: localAbortController.signal
+          },
+        )
+
+        let response = await sendRequest(headers)
+
+        // The BFF uses the server clock to enforce AgentCore's minimum JWT
+        // lifetime. Refresh and retry exactly once only for that explicit case.
+        if (response.status === 401) {
+          const payload = await response.clone().json().catch(() => null)
+          if (payload?.code === 'AUTH_TOKEN_STALE') {
+            const refreshedAuthHeaders = await getRuntimeAuthHeaders({ forceRefresh: true })
+            if (!refreshedAuthHeaders.Authorization) {
+              throw new Error('Authentication session expired. Please sign in again.')
+            }
+            Object.assign(authHeaders, refreshedAuthHeaders)
+            Object.assign(headers, refreshedAuthHeaders)
+            response = await sendRequest(headers)
+          }
+        }
 
         // Retry on transient errors (502, 503, 504) with exponential backoff
         if (!response.ok) {

--- a/chatbot-app/frontend/src/hooks/useVoiceChat.ts
+++ b/chatbot-app/frontend/src/hooks/useVoiceChat.ts
@@ -20,6 +20,7 @@ import {
 } from '@/lib/audioUtils'
 import { fetchAuthSession } from 'aws-amplify/auth'
 import { AgentStatus } from '@/types/events'
+import { getRuntimeAccessToken } from '@/lib/runtime-auth'
 
 function toBase64Url(value: string): string {
   return btoa(value)
@@ -428,8 +429,7 @@ export function useVoiceChat({
       // Get auth token once (reused for BFF and WebSocket)
       let authToken: string | null = null
       try {
-        const session = await fetchAuthSession()
-        authToken = session.tokens?.accessToken?.toString() || null
+        authToken = await getRuntimeAccessToken()
       } catch {
         // Continue without auth for local development
       }

--- a/chatbot-app/frontend/src/lib/agentcore-runtime-client.ts
+++ b/chatbot-app/frontend/src/lib/agentcore-runtime-client.ts
@@ -16,6 +16,26 @@ let GetParameterCommand: any
 let ssmClient: any
 let cachedRuntimeUrl: string | null = null
 
+export class AgentCoreRuntimeError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly responseBody: string,
+  ) {
+    super(message)
+    this.name = 'AgentCoreRuntimeError'
+  }
+}
+
+export function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'name' in error
+    && error.name === 'AbortError'
+  )
+}
+
 async function initializeSsmClient() {
   if (!SSMClient) {
     const ssmModule = await import('@aws-sdk/client-ssm')
@@ -131,7 +151,11 @@ async function invokeAwsAgentCore(
 
   if (!response.ok) {
     const errorText = await response.text()
-    throw new Error(`AgentCore Runtime returned ${response.status}: ${errorText}`)
+    throw new AgentCoreRuntimeError(
+      `AgentCore Runtime returned ${response.status}: ${errorText}`,
+      response.status,
+      errorText,
+    )
   }
 
   console.log('[AgentCore] AWS Runtime invoked successfully')
@@ -163,7 +187,11 @@ export async function invokeAgentCoreRuntime(
       return await invokeAwsAgentCore(aguiBody, userId, sessionId, authToken, abortSignal)
     }
   } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
     console.error('[AgentCore] Failed to invoke Runtime:', error)
+    if (error instanceof AgentCoreRuntimeError) throw error
     throw new Error(
       `Failed to invoke AgentCore Runtime: ${error instanceof Error ? error.message : 'Unknown error'}`
     )

--- a/chatbot-app/frontend/src/lib/auth-utils.ts
+++ b/chatbot-app/frontend/src/lib/auth-utils.ts
@@ -7,6 +7,7 @@ interface CognitoUser {
   userId: string
   email?: string
   username?: string
+  tokenExpiresAt?: number
 }
 
 let verifier: ReturnType<typeof CognitoJwtVerifier.create> | null = null
@@ -53,13 +54,15 @@ export async function extractUserFromRequest(request: Request): Promise<CognitoU
     const email = typeof payload.email === 'string' ? payload.email : undefined
     const usernameClaim = payload['cognito:username'] || payload.username
     const username = typeof usernameClaim === 'string' ? usernameClaim : undefined
+    const tokenExpiresAt = typeof payload.exp === 'number' ? payload.exp : undefined
 
     console.log(`[Auth] Authenticated user: ${userId} (${email || username || 'no email'})`)
 
     return {
       userId,
       email,
-      username
+      username,
+      tokenExpiresAt,
     }
   } catch (error) {
     console.warn('[Auth] JWT verification failed:', error instanceof Error ? error.message : error)

--- a/chatbot-app/frontend/src/lib/runtime-auth-policy.ts
+++ b/chatbot-app/frontend/src/lib/runtime-auth-policy.ts
@@ -1,0 +1,12 @@
+export const RUNTIME_TOKEN_MIN_VALIDITY_MS = 2 * 60 * 1000
+
+export function isRuntimeTokenFresh(
+  expiresAtSeconds: number | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  return (
+    typeof expiresAtSeconds === 'number'
+    && Number.isFinite(expiresAtSeconds)
+    && expiresAtSeconds * 1000 - nowMs >= RUNTIME_TOKEN_MIN_VALIDITY_MS
+  )
+}

--- a/chatbot-app/frontend/src/lib/runtime-auth.ts
+++ b/chatbot-app/frontend/src/lib/runtime-auth.ts
@@ -1,0 +1,52 @@
+import { fetchAuthSession } from 'aws-amplify/auth'
+import { isRuntimeTokenFresh } from '@/lib/runtime-auth-policy'
+
+type AuthSession = Awaited<ReturnType<typeof fetchAuthSession>>
+
+let refreshInFlight: Promise<AuthSession> | null = null
+
+async function refreshAuthSession(): Promise<AuthSession> {
+  if (!refreshInFlight) {
+    refreshInFlight = fetchAuthSession({ forceRefresh: true }).finally(() => {
+      refreshInFlight = null
+    })
+  }
+  return refreshInFlight
+}
+
+function accessTokenFrom(session: AuthSession) {
+  return session.tokens?.accessToken
+}
+
+export async function getRuntimeAccessToken(
+  options: { forceRefresh?: boolean } = {},
+): Promise<string | null> {
+  let session = options.forceRefresh
+    ? await refreshAuthSession()
+    : await fetchAuthSession()
+  let accessToken = accessTokenFrom(session)
+
+  if (!accessToken) return null
+
+  if (
+    !options.forceRefresh
+    && !isRuntimeTokenFresh(accessToken.payload.exp)
+  ) {
+    session = await refreshAuthSession()
+    accessToken = accessTokenFrom(session)
+  }
+
+  if (!accessToken) return null
+  if (!isRuntimeTokenFresh(accessToken.payload.exp)) {
+    throw new Error('Refreshed authentication token is not valid long enough for AgentCore Runtime')
+  }
+
+  return accessToken.toString()
+}
+
+export async function getRuntimeAuthHeaders(
+  options: { forceRefresh?: boolean } = {},
+): Promise<Record<string, string>> {
+  const token = await getRuntimeAccessToken(options)
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}


### PR DESCRIPTION
## Summary
- refresh Cognito access tokens before AgentCore calls when less than two minutes remain
- coalesce concurrent refreshes and retry the BFF request once only for the explicit stale-token response
- preserve AgentCore HTTP status/body, classify streamed failures, and suppress expected disconnect abort noise
- avoid incrementing session message counts when Runtime invocation never started

## Root cause
AgentCore rejects tokens that expire within the next minute, while the client previously reused Amplify tokens until much closer to their expiration. The BFF then collapsed the Runtime 401 into the generic `Agent stream failed` response.

## Validation
- frontend tests: 62 files, 741 tests passed
- TypeScript type-check passed
- production frontend build passed
- development Terraform apply succeeded; post-deploy plan reports no changes
- ECS frontend task definition :82 reached COMPLETED (1/1 running)
- CloudFront /health passed
- Cognito → Gateway MCP → AgentCore warmup smoke passed
- Cognito → CloudFront → BFF → AgentCore streaming smoke passed
- no post-deploy frontend 401 or Runtime invocation errors observed