### PR TITLE
fix(skills): validate structured tool inputs

### DIFF
--- a/chatbot-app/agentcore/src/skill/skill_tools.py
+++ b/chatbot-app/agentcore/src/skill/skill_tools.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 from datetime import timedelta
+from typing import Any
 
 from strands import tool
 from strands.types.tools import ToolContext
@@ -23,6 +24,31 @@ logger = logging.getLogger(__name__)
 # Module-level registry reference, set by SkillChatAgent during init
 _registry = None
 _DEFAULT_SKILL_RESULT_MAX_CHARS = 100_000
+
+
+def _normalize_executor_input(
+    value: dict[str, Any] | str | None,
+    parameter_name: str,
+) -> dict[str, Any]:
+    """Return a structured executor input without repairing malformed payloads."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{parameter_name} must be a JSON object")
+
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{parameter_name} must be valid JSON object syntax "
+            f"(invalid JSON at character {exc.pos})"
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{parameter_name} must decode to a JSON object")
+    return parsed
 
 
 def _skill_result_max_chars() -> int:
@@ -413,9 +439,9 @@ def skill_executor(
     tool_context: ToolContext,
     skill_name: str,
     tool_name: str = None,
-    tool_input = None,
+    tool_input: dict[str, Any] | None = None,
     script_name: str = None,
-    script_input = None,
+    script_input: dict[str, Any] | None = None,
 ) -> str:
     """Execute a tool or script from an activated skill.
 
@@ -449,24 +475,20 @@ def skill_executor(
             "status": "error",
         })
 
-    # Normalize tool_input / script_input: LLM sometimes passes a JSON string instead of a dict
-    def _coerce_to_dict(value):
-        if value is None or isinstance(value, dict):
-            return value
-        if isinstance(value, str):
-            # Strip trailing XML artifacts the LLM may append (e.g. "\n</invoke>")
-            cleaned = value.strip()
-            if '</invoke>' in cleaned:
-                cleaned = cleaned[:cleaned.rfind('</invoke>')].rstrip()
-            try:
-                parsed = json.loads(cleaned)
-                return parsed if isinstance(parsed, dict) else {}
-            except Exception:
-                return {}
-        return {}
-
-    tool_input = _coerce_to_dict(tool_input)
-    script_input = _coerce_to_dict(script_input)
+    try:
+        # Direct Python callers from older sessions can still pass a serialized
+        # object. The public tool schema remains object-only so models do not
+        # need to construct nested, escaped JSON.
+        tool_input = _normalize_executor_input(tool_input, "tool_input")
+        script_input = _normalize_executor_input(script_input, "script_input")
+    except ValueError as exc:
+        return json.dumps({
+            "error": str(exc),
+            "code": "INVALID_SKILL_INPUT",
+            "skill": skill_name,
+            "tool": tool_name or script_name,
+            "status": "error",
+        })
 
     # Validation: must specify either tool_name or script_name, not both
     if tool_name and script_name:
@@ -566,8 +588,30 @@ def _execute_tool(
 
         else:
             # Local tool — direct function call
-            call_kwargs = dict(tool_input)
-            context_param = target_tool._metadata._context_param
+            metadata = target_tool._metadata
+            input_model = getattr(metadata, "input_model", None)
+            if isinstance(input_model, type) and hasattr(input_model, "model_validate"):
+                try:
+                    validated_input = input_model.model_validate(tool_input)
+                    call_kwargs = validated_input.model_dump()
+                except Exception as exc:
+                    logger.warning(
+                        "Rejected invalid input for %s/%s: %s",
+                        skill_name,
+                        tool_name,
+                        exc,
+                    )
+                    return json.dumps({
+                        "error": f"Invalid input for tool '{tool_name}': {exc}",
+                        "code": "INVALID_TOOL_INPUT",
+                        "skill": skill_name,
+                        "tool": tool_name,
+                        "status": "error",
+                    })
+            else:
+                call_kwargs = dict(tool_input)
+
+            context_param = metadata._context_param
             if context_param:
                 target_context = ToolContext(
                     tool_use=tool_context.tool_use,

--- a/chatbot-app/agentcore/tests/unit/test_skill_executor_input.py
+++ b/chatbot-app/agentcore/tests/unit/test_skill_executor_input.py
@@ -1,0 +1,152 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from skill import skill_tools
+
+
+def test_skill_executor_schema_exposes_structured_tool_input():
+    schema = skill_tools.skill_executor._metadata.input_model.model_json_schema()
+    tool_input_schema = schema["properties"]["tool_input"]
+    variants = tool_input_schema.get("anyOf", [tool_input_schema])
+
+    assert any(variant.get("type") == "object" for variant in variants)
+    assert not any(variant.get("type") == "string" for variant in variants)
+
+
+def test_normalize_executor_input_accepts_legacy_json_object_string():
+    assert skill_tools._normalize_executor_input(
+        '{"plan": "research this"}',
+        "tool_input",
+    ) == {"plan": "research this"}
+
+
+def test_normalize_executor_input_rejects_malformed_json():
+    with pytest.raises(ValueError, match="invalid JSON"):
+        skill_tools._normalize_executor_input(
+            '{"plan": "research this"',
+            "tool_input",
+        )
+
+
+def test_normalize_executor_input_rejects_non_object_json():
+    with pytest.raises(ValueError, match="decode to a JSON object"):
+        skill_tools._normalize_executor_input(
+            '["research this"]',
+            "tool_input",
+        )
+
+
+def test_skill_executor_does_not_dispatch_malformed_tool_input(monkeypatch):
+    skill_tools._registry = MagicMock()
+    execute_tool = MagicMock()
+    monkeypatch.setattr(skill_tools, "_execute_tool", execute_tool)
+
+    result = json.loads(skill_tools.skill_executor(
+        tool_context=MagicMock(),
+        skill_name="research-agent",
+        tool_name="research_agent",
+        tool_input='{"plan": "research this"',
+    ))
+
+    assert result["code"] == "INVALID_SKILL_INPUT"
+    assert result["status"] == "error"
+    execute_tool.assert_not_called()
+
+
+def test_execute_tool_validates_required_arguments_before_calling(monkeypatch):
+    class ResearchInput:
+        @classmethod
+        def model_validate(cls, value):
+            if "plan" not in value:
+                raise ValueError("plan: Field required")
+            return cls()
+
+        def model_dump(self):
+            return {"plan": "research this"}
+
+    tool_func = MagicMock(return_value="started")
+    target_tool = SimpleNamespace(
+        _metadata=SimpleNamespace(
+            input_model=ResearchInput,
+            _context_param="tool_context",
+        ),
+        _tool_func=tool_func,
+    )
+
+    registry = MagicMock()
+    registry.get_tools.return_value = [target_tool]
+    monkeypatch.setattr(skill_tools, "_registry", registry)
+    monkeypatch.setattr(
+        skill_tools,
+        "canonical_tool_name",
+        lambda _tool: "research_agent",
+    )
+
+    result = json.loads(skill_tools._execute_tool(
+        tool_context=MagicMock(
+            tool_use={"toolUseId": "tool-1"},
+            agent=MagicMock(),
+            invocation_state={},
+        ),
+        skill_name="research-agent",
+        tool_name="research_agent",
+        tool_input={},
+    ))
+
+    assert result["code"] == "INVALID_TOOL_INPUT"
+    assert "plan" in result["error"]
+    tool_func.assert_not_called()
+
+
+def test_execute_tool_dispatches_validated_input(monkeypatch):
+    class ResearchInput:
+        def __init__(self, plan):
+            self.plan = plan
+
+        @classmethod
+        def model_validate(cls, value):
+            if "plan" not in value:
+                raise ValueError("plan: Field required")
+            return cls(plan=value["plan"])
+
+        def model_dump(self):
+            return {"plan": self.plan}
+
+    tool_func = MagicMock(return_value="started")
+    target_tool = SimpleNamespace(
+        _metadata=SimpleNamespace(
+            input_model=ResearchInput,
+            _context_param="tool_context",
+        ),
+        _tool_func=tool_func,
+    )
+
+    registry = MagicMock()
+    registry.get_tools.return_value = [target_tool]
+    monkeypatch.setattr(skill_tools, "_registry", registry)
+    monkeypatch.setattr(
+        skill_tools,
+        "canonical_tool_name",
+        lambda _tool: "research_agent",
+    )
+
+    context = MagicMock(
+        tool_use={"toolUseId": "tool-1"},
+        agent=MagicMock(),
+        invocation_state={},
+    )
+    result = skill_tools._execute_tool(
+        tool_context=context,
+        skill_name="research-agent",
+        tool_name="research_agent",
+        tool_input={"plan": "research this"},
+    )
+
+    assert result == "started"
+    tool_func.assert_called_once()
+    call_kwargs = tool_func.call_args.kwargs
+    assert call_kwargs["plan"] == "research this"
+    assert call_kwargs["tool_context"].tool_use == context.tool_use


### PR DESCRIPTION
## Summary
- expose `skill_executor.tool_input` and `script_input` as structured JSON objects instead of untyped/string-shaped payloads
- reject malformed serialized inputs explicitly instead of silently coercing them to `{}`
- validate local tool arguments against each Strands input model before dispatch
- add regression coverage for schema shape, malformed payloads, required arguments, and successful context-aware dispatch

## Root cause
The model produced `tool_input` as a nested JSON string. One production payload was truncated by its final closing brace; the old coercion code swallowed the JSON parse error and replaced it with `{}`, so `research_agent` was invoked without its required `plan` argument.

## Validation
- `ruff check` passed
- AgentCore tests: `810 passed, 15 deselected`
- deployed orchestrator runtime v67, source hash `459ba59568ea8d8188c155fbd1a6367898b0e31e`
- deployed BFF smoke: `research_agent` received object input with a non-empty `plan` and returned a durable job receipt
- CloudWatch confirmed `Executing research-agent/research_agent with input: {'plan': ...}` with no missing-plan error
- full Terraform plan: `No changes`