### PR TITLE
fix(gateway): repair Google Maps place details

### DIFF
--- a/agentcore/gateway-tools/lambda-functions/google-maps/README.md
+++ b/agentcore/gateway-tools/lambda-functions/google-maps/README.md
@@ -160,10 +160,6 @@ Or for local testing:
       "language": {
         "type": "string",
         "description": "Optional: Language code (default: 'en')"
-      },
-      "reviews_sort": {
-        "type": "string",
-        "description": "Optional: 'most_relevant' (default) or 'newest'"
       }
     },
     "required": ["place_id"]

--- a/agentcore/gateway-tools/lambda-functions/google-maps/lambda_function.py
+++ b/agentcore/gateway-tools/lambda-functions/google-maps/lambda_function.py
@@ -275,7 +275,6 @@ def get_place_details(params: Dict[str, Any]) -> Dict[str, Any]:
     # Extract parameters
     place_id = params.get('place_id')
     language = params.get('language', 'en')
-    reviews_sort = params.get('reviews_sort', 'most_relevant')  # "most_relevant" or "newest"
 
     if not place_id:
         return error_response("place_id parameter required")
@@ -284,21 +283,20 @@ def get_place_details(params: Dict[str, Any]) -> Dict[str, Any]:
 
     try:
         # Request specific fields to optimize cost
-        # Note: 'photos' and 'types' are not valid as fields parameter,
-        # but are automatically included in basic response
+        # googlemaps uses the legacy Places field identifiers here: the request
+        # names are singular even though the response keys are plural.
         fields = [
             "name", "formatted_address", "formatted_phone_number",
             "geometry", "rating", "user_ratings_total",
-            "reviews", "website", "opening_hours", "price_level",
-            "url"
+            "review", "photo", "type", "website", "opening_hours",
+            "price_level", "url"
         ]
 
         # Call Places API Place Details
         result = gmaps.place(
             place_id=place_id,
             fields=fields,
-            language=language,
-            reviews_sort=reviews_sort
+            language=language
         )
 
         place = result.get('result', {})

--- a/agentcore/gateway-tools/requirements-dev.txt
+++ b/agentcore/gateway-tools/requirements-dev.txt
@@ -4,6 +4,8 @@ pytest-asyncio>=0.21.0
 
 # Lambda function dependencies (for testing)
 arxiv>=2.0.0
+boto3>=1.34.0
+googlemaps>=4.2.0,<5.0.0
 
 # Linting
 ruff>=0.9.0

--- a/agentcore/gateway-tools/tests/test_google_maps_lambda.py
+++ b/agentcore/gateway-tools/tests/test_google_maps_lambda.py
@@ -1,0 +1,56 @@
+"""Tests for the Google Maps Lambda function."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from conftest import load_lambda
+
+
+lf = load_lambda("google-maps")
+get_place_details = lf.get_place_details
+
+
+class TestGetPlaceDetails:
+    """Regression tests for Google Places detail requests."""
+
+    @patch.object(lf, "get_google_maps_client")
+    def test_calls_supported_googlemaps_place_signature(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.place.return_value = {
+            "result": {
+                "name": "Test Place",
+                "formatted_address": "123 Test Street",
+                "reviews": [],
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_place_details({
+            "place_id": "test-place-id",
+            "language": "ko",
+            # Older callers may still send this until the Gateway schema update
+            # propagates. The Lambda must ignore it instead of forwarding it to
+            # googlemaps.Client.place(), which does not support the argument.
+            "reviews_sort": "newest",
+        })
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        content = json.loads(body["content"][0]["text"])
+        assert content["name"] == "Test Place"
+
+        call_kwargs = mock_client.place.call_args.kwargs
+        assert call_kwargs["place_id"] == "test-place-id"
+        assert call_kwargs["language"] == "ko"
+        assert "reviews_sort" not in call_kwargs
+        assert "review" in call_kwargs["fields"]
+        assert "reviews" not in call_kwargs["fields"]
+        assert set(call_kwargs["fields"]) <= lf.googlemaps.places.PLACES_DETAIL_FIELDS
+
+    @patch.object(lf, "get_google_maps_client", return_value=MagicMock())
+    def test_requires_place_id(self, _mock_get_client):
+        result = get_place_details({})
+
+        assert result["statusCode"] == 400
+        body = json.loads(result["body"])
+        assert "place_id" in body["error"]

--- a/chatbot-app/agentcore/skills/google-maps/SKILL.md
+++ b/chatbot-app/agentcore/skills/google-maps/SKILL.md
@@ -24,10 +24,9 @@ description: Place search, directions, geocoding, and interactive maps
   - `open_now` (boolean, optional, default: false): Only open places
   - `language` (string, optional, default: "en"): Language code
 
-- **get_place_details(place_id, language?, reviews_sort?)**: Get detailed place info including reviews and hours.
+- **get_place_details(place_id, language?)**: Get detailed place info including reviews and hours.
   - `place_id` (string, required): Place ID from search results
   - `language` (string, optional, default: "en"): Language code
-  - `reviews_sort` (string, optional, default: "most_relevant"): "most_relevant" or "newest"
 
 - **get_directions(origin, destination, mode?, alternatives?, avoid?, language?)**: Get directions between two locations.
   - `origin` (string, required): Starting point (address or "lat,lng")

--- a/infra/registry/definitions/mcp/google-maps.yaml
+++ b/infra/registry/definitions/mcp/google-maps.yaml
@@ -30,7 +30,6 @@ tools:
     properties:
       - { name: place_id, type: string, description: Place ID from search results, required: true }
       - { name: language, type: string, description: "Optional: Language code (default: 'en')" }
-      - { name: reviews_sort, type: string, description: "Optional: 'most_relevant' (default) or 'newest'" }
   - name: get_directions
     description: "Get turn-by-turn directions between two locations. Supports 4 modes: driving, walking, bicycling, transit. Returns distance, duration, and step-by-step instructions. Can avoid tolls/highways/ferries and provide alternative routes."
     input_type: object


### PR DESCRIPTION
## Summary
- remove the unsupported `reviews_sort` argument from Google Maps place detail requests and schemas
- use the `googlemaps` client's supported singular detail field identifiers (`review`, `photo`, `type`)
- add regression coverage for legacy callers and the supported field set

## Verification
- `pytest -q tests/` — 39 passed
- `ruff check lambda-functions/ tests/` — passed
- deployed to the dev environment
- direct Lambda `get_place_details` call — HTTP 200, reviews and photos returned
- Gateway MCP `tools/list` and `tools/call` — HTTP 200, `isError=false`
- post-deploy Google Maps error logs — 0