### PR TITLE
Migrate GPT models to Bedrock Runtime Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ tool execution, memory, browser automation, and agent-to-agent collaboration.
 It is intended as a realistic, extensible sample for teams exploring advanced agent architectures on AWS.
 
 > [!NOTE]
-> **New: Bedrock Mantle models.** The model picker now includes the OpenAI **GPT-5.6 family (Sol, Terra, and Luna)**, **xAI Grok 4.3**, and **Google Gemma 4** via Amazon Bedrock's OpenAI-compatible Mantle endpoints — alongside the native Bedrock models (Claude, DeepSeek, Qwen, and more).
+> **Expanded Bedrock Runtime models.** The model picker includes the OpenAI **GPT-5.6 family (Sol, Terra, and Luna)** through the Bedrock Runtime Responses API and **xAI Grok 4.6** through Bedrock Runtime Converse. **Google Gemma 4** remains available through Bedrock Mantle.
 
 ---
 
@@ -61,7 +61,7 @@ This sample combines **Strands Agent orchestration** with **Amazon Bedrock Agent
 - Built-in Code Interpreter for charts and documents
 - Multimodal input and output (vision, charts, documents, screenshots)
 - Real-time voice interaction with Amazon Nova Sonic 2
-- Wide model selection — native Bedrock models (Claude, DeepSeek, Qwen, GLM, ...) plus OpenAI GPT-5.x, Grok, and Gemma 4 via Bedrock Mantle
+- Wide model selection — Bedrock Runtime Converse models, GPT-5.6 via Bedrock Runtime Responses, and Gemma 4 via Bedrock Mantle
 
 ---
 

--- a/agentcore/a2a-agents/code-agent/tests/test_a2a_contract.py
+++ b/agentcore/a2a-agents/code-agent/tests/test_a2a_contract.py
@@ -212,9 +212,9 @@ class TestExtractMetadata:
         ctx = MagicMock()
         ctx.metadata = {
             "session_id": "s1",
-            "orchestrator_model_id": "openai.gpt-5.6-terra",
+            "orchestrator_model_id": "us.openai.gpt-5.6-terra",
         }
-        assert _extract_metadata(ctx)["orchestrator_model_id"] == "openai.gpt-5.6-terra"
+        assert _extract_metadata(ctx)["orchestrator_model_id"] == "us.openai.gpt-5.6-terra"
         assert "model_id" not in _extract_metadata(ctx)
 
 

--- a/agentcore/a2a-agents/research-agent/src/model_factory.py
+++ b/agentcore/a2a-agents/research-agent/src/model_factory.py
@@ -9,13 +9,17 @@ from strands.models import BedrockModel
 
 
 MANTLE_MODEL_REGIONS: dict[str, str] = {
-    "openai.gpt-5.6-sol": "us-east-1",
-    "openai.gpt-5.6-terra": "us-east-1",
-    "openai.gpt-5.6-luna": "us-east-1",
-    "xai.grok-4.3": "us-west-2",
     "google.gemma-4-31b": "us-east-2",
     "google.gemma-4-26b-a4b": "us-east-2",
     "google.gemma-4-e2b": "us-east-2",
+}
+
+MODEL_ID_ALIASES: dict[str, str] = {
+    "openai.gpt-5.6-sol": "us.openai.gpt-5.6-sol",
+    "openai.gpt-5.6-terra": "us.openai.gpt-5.6-terra",
+    "openai.gpt-5.6-luna": "us.openai.gpt-5.6-luna",
+    "xai.grok-4.3": "us.xai.grok-4.6",
+    "xai.grok-4.6": "us.xai.grok-4.6",
 }
 
 NATIVE_MODEL_REGION_OVERRIDES: dict[str, str] = {
@@ -53,7 +57,8 @@ def build_model(
     app_region: str,
     max_tokens: int = 32000,
 ):
-    """Build a Mantle Responses model or a native Bedrock model."""
+    """Build a Mantle Responses model or a Bedrock Runtime model."""
+    model_id = MODEL_ID_ALIASES.get(model_id, model_id)
     mantle_region = MANTLE_MODEL_REGIONS.get(model_id)
     if mantle_region:
         from strands.models.openai_responses import OpenAIResponsesModel

--- a/agentcore/a2a-agents/research-agent/tests/test_model_factory.py
+++ b/agentcore/a2a-agents/research-agent/tests/test_model_factory.py
@@ -27,13 +27,19 @@ def test_native_model_uses_bedrock():
     assert bedrock_model.call_args.kwargs["region_name"] == "us-west-2"
 
 
-@patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
-def test_gpt_56_uses_mantle_responses_in_us_east_1():
-    model = mf.build_model("openai.gpt-5.6-terra", app_region="us-west-2")
+def test_gpt_56_legacy_id_uses_bedrock_runtime_profile():
+    with patch.object(mf, "BedrockModel") as bedrock_model:
+        mf.build_model("openai.gpt-5.6-terra", app_region="us-west-2")
 
-    assert model.config["model_id"] == "openai.gpt-5.6-terra"
-    assert model.client_args["api_key"] == "test-key"
-    assert "bedrock-mantle.us-east-1.api.aws/openai/v1" in model.client_args["base_url"]
+    assert bedrock_model.call_args.kwargs["model_id"] == "us.openai.gpt-5.6-terra"
+    assert bedrock_model.call_args.kwargs["region_name"] == "us-west-2"
+
+
+def test_grok_46_uses_bedrock_runtime_profile():
+    with patch.object(mf, "BedrockModel") as bedrock_model:
+        mf.build_model("us.xai.grok-4.6", app_region="us-west-2")
+
+    assert bedrock_model.call_args.kwargs["model_id"] == "us.xai.grok-4.6"
 
 
 def test_mantle_secret_is_loaded_from_runtime_region():
@@ -59,4 +65,4 @@ def test_mantle_secret_is_loaded_from_runtime_region():
 def test_missing_mantle_credentials_fails_clearly():
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(RuntimeError, match="no Bedrock API key"):
-            mf.build_model("openai.gpt-5.6-terra", app_region="us-west-2")
+            mf.build_model("google.gemma-4-31b", app_region="us-west-2")

--- a/chatbot-app/agentcore/config/model-catalog.json
+++ b/chatbot-app/agentcore/config/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "revision": "2026-08-11.1",
+  "revision": "2026-08-26.2",
   "providerMatchers": {
     "anthropic": [
       "anthropic.",
@@ -45,30 +45,27 @@
       "rejectsTemperature": false
     },
     "gpt.sol.latest": {
-      "id": "openai.gpt-5.6-sol",
+      "id": "us.openai.gpt-5.6-sol",
       "provider": "openai",
       "family": "gpt",
-      "transport": "mantle_responses",
-      "region": "us-east-1",
-      "maxInputTokens": 1050000,
+      "transport": "bedrock_responses",
+      "maxInputTokens": 1000000,
       "rejectsTemperature": true
     },
     "gpt.terra.latest": {
-      "id": "openai.gpt-5.6-terra",
+      "id": "us.openai.gpt-5.6-terra",
       "provider": "openai",
       "family": "gpt",
-      "transport": "mantle_responses",
-      "region": "us-east-1",
-      "maxInputTokens": 1050000,
+      "transport": "bedrock_responses",
+      "maxInputTokens": 1000000,
       "rejectsTemperature": true
     },
     "gpt.luna.latest": {
-      "id": "openai.gpt-5.6-luna",
+      "id": "us.openai.gpt-5.6-luna",
       "provider": "openai",
       "family": "gpt",
-      "transport": "mantle_responses",
-      "region": "us-east-1",
-      "maxInputTokens": 1050000,
+      "transport": "bedrock_responses",
+      "maxInputTokens": 1000000,
       "rejectsTemperature": true
     },
     "gpt.oss.120b": {
@@ -80,13 +77,12 @@
       "rejectsTemperature": false
     },
     "grok.latest": {
-      "id": "xai.grok-4.3",
+      "id": "us.xai.grok-4.6",
       "provider": "xai",
       "family": "grok",
-      "transport": "mantle_responses",
-      "region": "us-west-2",
-      "maxInputTokens": 1048576,
-      "rejectsTemperature": false
+      "transport": "bedrock",
+      "maxInputTokens": 500000,
+      "rejectsTemperature": true
     },
     "gemma.31b.latest": {
       "id": "google.gemma-4-31b",

--- a/chatbot-app/agentcore/requirements.txt
+++ b/chatbot-app/agentcore/requirements.txt
@@ -10,7 +10,7 @@ strands-agents[a2a,otel]==1.53.0
 strands-agents-tools[a2a_client]>=0.8.6
 mcp>=1.28.1,<2.0.0
 
-# OpenAI SDK - required for Bedrock Mantle OpenAI-compatible models (gpt-5.x, grok, gemma-4)
+# OpenAI SDK - required for Bedrock Runtime/Mantle Responses models
 openai>=2.49.0
 
 # Voice Chat (BidiAgent)

--- a/chatbot-app/agentcore/src/agent/config/constants.py
+++ b/chatbot-app/agentcore/src/agent/config/constants.py
@@ -38,7 +38,7 @@ A2A_PREFIX = "agentcore_"
 # =============================================================================
 
 # Default text model ID
-DEFAULT_MODEL_ID = "openai.gpt-5.6-terra"
+DEFAULT_MODEL_ID = "us.openai.gpt-5.6-terra"
 
 # Default temperature for model inference
 DEFAULT_TEMPERATURE = 0.7
@@ -67,7 +67,7 @@ DEFAULT_PROJECT_NAME = "strands-agent-chatbot"
 
 # Fraction of the model's context window that may be filled before compaction
 # starts. Sized off the model rather than a fixed token count because the picker
-# spans an 8x range of context windows (131k to 1.05M) — see
+# spans nearly an 8x range of context windows (131k to 1M) — see
 # MODEL_MAX_INPUT_TOKENS in agents/model_factory.py.
 COMPACTION_CONTEXT_RATIO = 0.7
 

--- a/chatbot-app/agentcore/src/agent/config/model_catalog.py
+++ b/chatbot-app/agentcore/src/agent/config/model_catalog.py
@@ -11,7 +11,23 @@ from typing import Any, Optional
 
 TASK_COMPLEXITIES = frozenset({"low", "medium", "high"})
 DEFAULT_MAX_INPUT_TOKENS = 131_072
-_ALLOWED_TRANSPORTS = frozenset({"bedrock", "mantle_responses"})
+_ALLOWED_TRANSPORTS = frozenset({
+    "bedrock",
+    "bedrock_responses",
+    "mantle_responses",
+})
+MODEL_ID_ALIASES = {
+    "openai.gpt-5.6-sol": "us.openai.gpt-5.6-sol",
+    "openai.gpt-5.6-terra": "us.openai.gpt-5.6-terra",
+    "openai.gpt-5.6-luna": "us.openai.gpt-5.6-luna",
+    "xai.grok-4.3": "us.xai.grok-4.6",
+    "xai.grok-4.6": "us.xai.grok-4.6",
+}
+
+
+def normalize_model_id(model_id: str) -> str:
+    """Map persisted legacy IDs to the canonical Bedrock Runtime profile ID."""
+    return MODEL_ID_ALIASES.get(model_id, model_id)
 
 
 @dataclass(frozen=True)
@@ -139,6 +155,7 @@ class ModelCatalog:
                         )
 
     def provider_for(self, model_id: str) -> Optional[str]:
+        model_id = normalize_model_id(model_id)
         spec = self.models_by_id.get(model_id)
         if spec is not None:
             return spec.provider
@@ -150,6 +167,7 @@ class ModelCatalog:
         return None
 
     def family_for(self, model_id: str) -> Optional[str]:
+        model_id = normalize_model_id(model_id)
         spec = self.models_by_id.get(model_id)
         if spec is not None:
             return spec.family
@@ -210,9 +228,10 @@ def resolve_general_subagent_model(
     task_complexity: Optional[str],
 ) -> ModelSelection:
     catalog = get_model_catalog()
+    canonical_parent_model_id = normalize_model_id(parent_model_id)
     complexity = normalize_task_complexity(task_complexity)
-    provider = catalog.provider_for(parent_model_id)
-    family = catalog.family_for(parent_model_id)
+    provider = catalog.provider_for(canonical_parent_model_id)
+    family = catalog.family_for(canonical_parent_model_id)
     if complexity is None or family is None:
         return ModelSelection(
             policy="general_subagent",
@@ -220,13 +239,15 @@ def resolve_general_subagent_model(
             provider=provider,
             family=family,
             source_model_id=parent_model_id,
-            effective_model_id=parent_model_id,
+            effective_model_id=canonical_parent_model_id,
             catalog_revision=catalog.revision,
             applied=False,
         )
 
     spec = catalog.resolve("general_subagent", family, complexity)
-    effective_model_id = spec.model_id if spec is not None else parent_model_id
+    effective_model_id = (
+        spec.model_id if spec is not None else canonical_parent_model_id
+    )
     return ModelSelection(
         policy="general_subagent",
         task_complexity=complexity,

--- a/chatbot-app/agentcore/src/agent/config/model_context_windows.py
+++ b/chatbot-app/agentcore/src/agent/config/model_context_windows.py
@@ -12,6 +12,7 @@ from typing import Optional
 from agent.config.model_catalog import (
     DEFAULT_MAX_INPUT_TOKENS,
     get_model_catalog,
+    normalize_model_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,12 +23,12 @@ logger = logging.getLogger(__name__)
 #
 # Catalog values were measured against the deployed endpoints by sending an
 # oversized prompt and reading the limit back out of the rejection, e.g.
-#   prompt tokens (1600007) exceed model maximum (1050000) for openai.gpt-5.6-luna
+# GPT-5.6 Bedrock Runtime profiles publish a 1,000,000-token input limit.
 #   prompt is too long: 1600056 tokens > 1000000 maximum   (claude-opus-5)
 # Published docs agree where they exist, but the probe is what these are from:
 # the limit that matters is the one our account and region actually enforce.
 #
-# Note the spread — 131k to 1.05M, an 8x range. Sizing compaction off one
+# Note the spread — 131k to 1M, nearly an 8x range. Sizing compaction off one
 # constant either wastes most of a 1M window or overflows a 131k one.
 #
 # Re-measure when adding a model to the catalog; do not guess. A value that is
@@ -43,6 +44,7 @@ def get_max_input_tokens(model_id: Optional[str]) -> int:
     """Return the model's measured input-token limit, or a conservative default."""
     if not model_id:
         return DEFAULT_MAX_INPUT_TOKENS
+    model_id = normalize_model_id(model_id)
     limit = MODEL_MAX_INPUT_TOKENS.get(model_id)
     if limit is None:
         logger.warning(

--- a/chatbot-app/agentcore/src/agent/factory/session_manager_factory.py
+++ b/chatbot-app/agentcore/src/agent/factory/session_manager_factory.py
@@ -112,7 +112,7 @@ class CompactionConfig:
 
         The threshold is derived from the model's measured context window unless
         COMPACTION_TOKEN_THRESHOLD pins it explicitly. Sizing it per model matters
-        because the picker spans 131k to 1.05M tokens: one fixed number either
+        because the picker spans 131k to 1M tokens: one fixed number either
         wastes most of a 1M window or overflows the smallest one.
         """
         return cls(

--- a/chatbot-app/agentcore/src/agents/chat_agent.py
+++ b/chatbot-app/agentcore/src/agents/chat_agent.py
@@ -116,8 +116,8 @@ class ChatAgent(BaseAgent):
         try:
             config = self.get_model_config()
 
-            # Routes to BedrockModel (caching) or a Mantle OpenAI provider based
-            # on model_id. Mantle models ignore caching/temperature internally.
+            # Routes to Bedrock Runtime or a Mantle-only provider based on
+            # model_id. Mantle models ignore caching/temperature internally.
             model = build_model(
                 config["model_id"],
                 temperature=config.get("temperature"),

--- a/chatbot-app/agentcore/src/agents/model_factory.py
+++ b/chatbot-app/agentcore/src/agents/model_factory.py
@@ -1,16 +1,16 @@
 """Model factory - builds the right Strands model provider for a given model_id.
 
-Two execution paths coexist:
-- Native Bedrock (`BedrockModel`): supports prompt caching. Default for any
-  model_id not registered as Mantle-only.
-- Bedrock Mantle OpenAI-compatible (`OpenAIResponsesModel`): for frontier/extra
-  models not available on native Bedrock Converse (gpt-5.x, grok, gemma-4).
-  No prompt caching. Authenticated with a Bedrock API key from Secrets Manager.
+Three execution paths coexist:
+- Bedrock Runtime Converse (`BedrockModel`): default for native and
+  cross-Region inference-profile IDs.
+- Bedrock Runtime OpenAI-compatible Responses (`OpenAIResponsesModel`):
+  GPT-5.6 models, including file inputs that Converse rejects.
+- Bedrock Mantle OpenAI-compatible Responses (`OpenAIResponsesModel`):
+  models not yet available through Bedrock Runtime, currently Gemma 4.
 
-Mantle models differ by region and by API path, so each is registered with its
-own spec. A Mantle stream can intermittently end with a `response.failed` event
-that the Strands SDK silently swallows (producing an empty turn);
-BedrockMantleResponsesModel retries those before any output is streamed downstream.
+Responses models differ by endpoint and region, but share request formatting.
+An empty Responses turn can otherwise be swallowed by the Strands SDK, so the
+adapter retries before any output is streamed downstream.
 """
 
 import logging
@@ -22,7 +22,7 @@ import boto3
 from strands.models import BedrockModel, CacheConfig
 from strands.types.exceptions import ContextWindowOverflowException
 
-from agent.config.model_catalog import get_model_catalog
+from agent.config.model_catalog import get_model_catalog, normalize_model_id
 # Re-exported for callers that already reach for model_factory. The registry
 # itself lives in its own module so the session manager can size compaction
 # without importing the agent stack.
@@ -41,6 +41,21 @@ _CONTEXT_OVERFLOW_MARKERS = (
     "context length exceeded",
     "context window exceeded",
 )
+_DOCUMENT_MIME_TYPES = {
+    "csv": "text/csv",
+    "doc": "application/msword",
+    "docx": (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ),
+    "html": "text/html",
+    "md": "text/markdown",
+    "pdf": "application/pdf",
+    "txt": "text/plain",
+    "xls": "application/vnd.ms-excel",
+    "xlsx": (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    ),
+}
 
 
 def _is_context_overflow_error(error: BaseException) -> bool:
@@ -65,23 +80,25 @@ class MantleSpec:
     """How to reach a Mantle-only model.
 
     api: "responses" -> /openai/v1 (OpenAIResponsesModel)
-    region: Mantle region serving this model (independent of the app's region;
-            e.g. grok-4.3 is us-west-2 only, gpt-5.6 is served in us-east-1).
+    region: Mantle region serving this model, independent of the app's region.
     """
     api: str
     region: str
 
 
-# Mantle-only models (not callable via native Bedrock Converse). Anything not
-# registered there falls back to BedrockModel. The region is pinned per model: a
-# Mantle model is only served in some regions (grok-4.3 in us-west-2, gpt-5.6
-# in us-east-1), so the base_url region is forced independent of where the
-# app is deployed.
+# Mantle-only models (not callable through Bedrock Runtime). Anything not
+# registered here falls back to BedrockModel. The region is pinned per model.
 MANTLE_MODELS: dict[str, MantleSpec] = {
     spec.model_id: MantleSpec(api="responses", region=str(spec.region))
     for spec in _MODEL_CATALOG.models.values()
     if spec.transport == "mantle_responses"
 }
+
+BEDROCK_RESPONSES_MODELS = frozenset(
+    spec.model_id
+    for spec in _MODEL_CATALOG.models.values()
+    if spec.transport == "bedrock_responses"
+)
 
 
 # Native Bedrock models that are NOT available in every region. Selecting one of
@@ -95,7 +112,7 @@ NATIVE_MODEL_REGION_OVERRIDES: dict[str, str] = {
 
 
 def model_rejects_temperature(model_id: str) -> bool:
-    return model_id in NO_TEMPERATURE_MODELS
+    return normalize_model_id(model_id) in NO_TEMPERATURE_MODELS
 
 
 _bedrock_api_key: Optional[str] = None
@@ -118,7 +135,7 @@ def _get_bedrock_api_key() -> str:
     secret_name = os.environ.get("BEDROCK_API_KEY_SECRET_NAME")
     if not secret_name:
         raise RuntimeError(
-            "Mantle model requested but no Bedrock API key available "
+            "Responses model requested but no Bedrock API key available "
             "(set BEDROCK_API_KEY_SECRET_NAME or AWS_BEARER_TOKEN_BEDROCK)"
         )
     region = os.environ.get("AWS_REGION", "us-west-2")
@@ -127,20 +144,25 @@ def _get_bedrock_api_key() -> str:
     return _bedrock_api_key
 
 
-def _make_bedrock_mantle_responses_model(model_id: str, spec: MantleSpec, max_tokens: int):
-    """Build the OpenAI Responses model configured for Bedrock Mantle."""
+def _make_bedrock_responses_model(
+    model_id: str,
+    *,
+    base_url: str,
+    max_tokens: int,
+    endpoint_label: str,
+):
+    """Build an OpenAI Responses model for a Bedrock-compatible endpoint."""
     import asyncio
     import base64
     import mimetypes
 
     from strands.models.openai_responses import OpenAIResponsesModel
 
-    class BedrockMantleResponsesModel(OpenAIResponsesModel):
+    class BedrockOpenAIResponsesModel(OpenAIResponsesModel):
         """Live streaming preserved. Buffers only the content-less leading events
         (messageStart). On the first content/tool block, flushes the buffer and
-        streams live. If a turn produces no content block at all -- the Mantle
-        `response.failed` event that the SDK swallows into an empty turn -- the
-        buffer is discarded and the call retried. Safe because nothing was yielded
+        streams live. If a turn produces no content block at all, the buffer is
+        discarded and the call retried. This is safe because nothing was yielded
         downstream before the first content block.
         """
 
@@ -178,25 +200,36 @@ def _make_bedrock_mantle_responses_model(model_id: str, spec: MantleSpec, max_to
                 if attempt < self.MAX_RETRIES:
                     attempt += 1
                     logger.warning(
-                        "Mantle empty turn (response.failed) for %s; retry %d/%d",
-                        model_id, attempt, self.MAX_RETRIES,
+                        "%s empty turn for %s; retry %d/%d",
+                        endpoint_label,
+                        model_id,
+                        attempt,
+                        self.MAX_RETRIES,
                     )
                     await asyncio.sleep(self.RETRY_BASE_S * attempt)
                     continue
-                logger.error("Mantle model %s exhausted retries on empty turn", model_id)
+                logger.error(
+                    "%s model %s exhausted retries on empty turn",
+                    endpoint_label,
+                    model_id,
+                )
                 for held in lead_buffer:
                     yield held
                 return
 
         @classmethod
         def _format_request_message_content(cls, content, *, role="user"):
-            # The SDK emits documents as {"type": "input_file", "file_url": <data-url>},
-            # which Mantle rejects with "Unsupported file type: 'unknown'". Mantle
-            # requires the OpenAI-standard shape with an explicit filename + file_data.
+            # Bedrock's OpenAI-compatible Responses endpoints accept the standard
+            # inline file shape with an explicit filename and base64 file_data.
+            # Keep this conversion common to Runtime and Mantle so Strands
+            # document ContentBlocks do not reach Converse.
             if "document" in content:
                 doc = content["document"]
                 fmt = doc["format"]
-                mime = mimetypes.types_map.get(f".{fmt}", "application/octet-stream")
+                mime = _DOCUMENT_MIME_TYPES.get(
+                    fmt,
+                    mimetypes.types_map.get(f".{fmt}", "application/octet-stream"),
+                )
                 data_url = f"data:{mime};base64,{base64.b64encode(doc['source']['bytes']).decode()}"
                 name = doc.get("name", "document")
                 return {
@@ -206,8 +239,7 @@ def _make_bedrock_mantle_responses_model(model_id: str, spec: MantleSpec, max_to
                 }
             return super()._format_request_message_content(content, role=role)
 
-    base_url = f"https://bedrock-mantle.{spec.region}.api.aws/openai/v1"
-    return BedrockMantleResponsesModel(
+    return BedrockOpenAIResponsesModel(
         model_id=model_id,
         params={"max_output_tokens": max_tokens},
         client_args={
@@ -226,13 +258,35 @@ def build_model(
 ):
     """Build the appropriate Strands model for `model_id`.
 
-    Mantle-only models -> BedrockMantleResponsesModel (no caching, no temperature).
-    Everything else -> BedrockModel (caching + boto retry).
+    GPT-5.6 -> Bedrock Runtime OpenAI-compatible Responses API.
+    Mantle-only models -> Bedrock Mantle Responses API.
+    Everything else -> BedrockModel Converse with IAM authentication.
     """
+    model_id = normalize_model_id(model_id)
+
+    if model_id in BEDROCK_RESPONSES_MODELS:
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        logger.info(
+            "Building Bedrock Runtime Responses model %s (region=%s)",
+            model_id,
+            region,
+        )
+        return _make_bedrock_responses_model(
+            model_id,
+            base_url=f"https://bedrock-runtime.{region}.amazonaws.com/openai/v1",
+            max_tokens=max_tokens,
+            endpoint_label="Bedrock Runtime Responses",
+        )
+
     spec = MANTLE_MODELS.get(model_id)
     if spec is not None:
         logger.info("Building Mantle model %s (region=%s)", model_id, spec.region)
-        return _make_bedrock_mantle_responses_model(model_id, spec, max_tokens)
+        return _make_bedrock_responses_model(
+            model_id,
+            base_url=f"https://bedrock-mantle.{spec.region}.api.aws/openai/v1",
+            max_tokens=max_tokens,
+            endpoint_label="Bedrock Mantle Responses",
+        )
 
     from botocore.config import Config
 

--- a/chatbot-app/agentcore/src/routers/chat.py
+++ b/chatbot-app/agentcore/src/routers/chat.py
@@ -941,6 +941,7 @@ async def _handle_agui_invocation(body: dict, http_request: Request) -> Streamin
             "selected_artifact_id": selected_artifact_id,
             "auth_token": auth_token,
             "workspace_paths": list(workspace_paths),
+            "user_message": message,
         }
 
         accept = http_request.headers.get("accept", "")

--- a/chatbot-app/agentcore/src/skill/skill_tools.py
+++ b/chatbot-app/agentcore/src/skill/skill_tools.py
@@ -475,6 +475,27 @@ def skill_executor(
             "status": "error",
         })
 
+    # Some reasoning models append an annotation to the Research Agent skill
+    # name and omit the sole tool name. Repair only this unambiguous case.
+    if (
+        isinstance(skill_name, str)
+        and skill_name.startswith("research-agent ")
+    ):
+        logger.warning(
+            "Normalizing annotated Research Agent skill name: %s",
+            skill_name,
+        )
+        skill_name = "research-agent"
+    if (
+        skill_name == "research-agent"
+        and not tool_name
+        and not script_name
+    ):
+        logger.warning(
+            "Research Agent tool name was omitted; inferring research_agent"
+        )
+        tool_name = "research_agent"
+
     try:
         # Direct Python callers from older sessions can still pass a serialized
         # object. The public tool schema remains object-only so models do not
@@ -590,6 +611,23 @@ def _execute_tool(
             # Local tool — direct function call
             metadata = target_tool._metadata
             input_model = getattr(metadata, "input_model", None)
+            target_name = canonical_tool_name(target_tool)
+            if target_name == "research_agent" and not str(
+                tool_input.get("plan", "")
+            ).strip():
+                fallback_plan = tool_context.invocation_state.get(
+                    "user_message",
+                    "",
+                )
+                if isinstance(fallback_plan, str) and fallback_plan.strip():
+                    tool_input = {
+                        **tool_input,
+                        "plan": fallback_plan.strip(),
+                    }
+                    logger.warning(
+                        "Research Agent plan was omitted; using the current "
+                        "user message as the research plan"
+                    )
             if isinstance(input_model, type) and hasattr(input_model, "model_validate"):
                 try:
                     validated_input = input_model.model_validate(tool_input)
@@ -632,7 +670,6 @@ def _execute_tool(
                 session_id = tool_context.invocation_state.get("session_id")
                 user_id = tool_context.invocation_state.get("user_id")
                 run_id = tool_context.invocation_state.get("run_id")
-                target_name = canonical_tool_name(target_tool)
                 result = _run_async(_consume_async_generator(
                     result,
                     session_id=session_id,

--- a/chatbot-app/agentcore/src/workflows/composer_workflow.py
+++ b/chatbot-app/agentcore/src/workflows/composer_workflow.py
@@ -1165,7 +1165,7 @@ Please address this feedback in the revised outline.
         logger.info(prompt)
         logger.info("=" * 80)
 
-        # Routes to BedrockModel or a Mantle OpenAI provider based on model_id.
+        # Routes to Bedrock Runtime or a Mantle-only provider based on model_id.
         model = build_model(
             self.model_id,
             temperature=self.temperature,

--- a/chatbot-app/agentcore/tests/integration/e2e/sse_client.py
+++ b/chatbot-app/agentcore/tests/integration/e2e/sse_client.py
@@ -208,7 +208,7 @@ def stream_chat(
     prompt: str,
     *,
     thread_id: str | None = None,
-    model_id: str = "openai.gpt-5.6-terra",
+    model_id: str = "us.openai.gpt-5.6-terra",
     state_overrides: dict[str, Any] | None = None,
     timeout: float = 180.0,
 ) -> StreamResult:

--- a/chatbot-app/agentcore/tests/unit/test_a2a_code_agent_model.py
+++ b/chatbot-app/agentcore/tests/unit/test_a2a_code_agent_model.py
@@ -51,7 +51,7 @@ def _context():
     context.invocation_state = {
         "session_id": "session-1",
         "user_id": "user-1",
-        "model_id": "openai.gpt-5.6-terra",
+        "model_id": "us.openai.gpt-5.6-terra",
         "auth_token": None,
         "workspace_paths": ["uploads/turn-context.md"],
     }
@@ -79,7 +79,7 @@ async def test_code_agent_high_uses_latest_opus(code_tool):
     metadata = sent[0]["metadata"]
     assert metadata["model_id"] == "us.anthropic.claude-opus-5"
     assert metadata["task_complexity"] == "high"
-    assert metadata["orchestrator_model_id"] == "openai.gpt-5.6-terra"
+    assert metadata["orchestrator_model_id"] == "us.openai.gpt-5.6-terra"
     assert metadata["workspace_paths"] == [
         "uploads/turn-context.md",
         "inputs/spec.md",

--- a/chatbot-app/agentcore/tests/unit/test_compaction_thresholds.py
+++ b/chatbot-app/agentcore/tests/unit/test_compaction_thresholds.py
@@ -3,7 +3,7 @@
 Two behaviours are pinned here:
 
 1. The compaction threshold is derived from the model's context window, not a
-   single constant. The picker spans 131k to 1.05M tokens, so one fixed number
+   single constant. The picker spans 131k to 1M tokens, so one fixed number
    either wastes most of a 1M window or fires too late on the smallest model.
 
 2. Load-time truncation of tool output only runs when the conversation is
@@ -85,11 +85,16 @@ class TestMeasuredModelWindows:
         ):
             assert get_max_input_tokens(model_id) == 1_000_000
         for model_id in (
-            "openai.gpt-5.6-sol",
-            "openai.gpt-5.6-terra",
-            "openai.gpt-5.6-luna",
+            "us.openai.gpt-5.6-sol",
+            "us.openai.gpt-5.6-terra",
+            "us.openai.gpt-5.6-luna",
         ):
-            assert get_max_input_tokens(model_id) == 1_050_000
+            assert get_max_input_tokens(model_id) == 1_000_000
+
+    def test_grok_46_window_matches_runtime_profile(self):
+        get_max_input_tokens = _model_factory().get_max_input_tokens
+        assert get_max_input_tokens("us.xai.grok-4.6") == 500_000
+        assert get_max_input_tokens("xai.grok-4.3") == 500_000
 
     def test_small_window_model_is_not_overstated(self):
         # gpt-oss is the smallest window in the picker; the old fixed 100k
@@ -119,12 +124,12 @@ class TestMeasuredModelWindows:
     def test_every_picker_model_is_measured(self):
         # A model in the picker but absent here silently gets the conservative
         # fallback, which quietly over-compacts a large-context model.
-        from agents.model_factory import MANTLE_MODELS
+        from agent.config.model_catalog import get_model_catalog
 
         MODEL_MAX_INPUT_TOKENS = _model_factory().MODEL_MAX_INPUT_TOKENS
 
-        missing = set(MANTLE_MODELS) - set(MODEL_MAX_INPUT_TOKENS)
-        assert not missing, f"Mantle models without a measured window: {missing}"
+        missing = set(get_model_catalog().models_by_id) - set(MODEL_MAX_INPUT_TOKENS)
+        assert not missing, f"Picker models without a measured window: {missing}"
 
 
 def _manager(**overrides):

--- a/chatbot-app/agentcore/tests/unit/test_composer_workflow.py
+++ b/chatbot-app/agentcore/tests/unit/test_composer_workflow.py
@@ -112,7 +112,7 @@ class TestComposerWorkflowInit:
         agent = ComposerWorkflow(session_id="sess-123")
         assert agent.session_id == "sess-123"
         assert agent.user_id == "sess-123"  # defaults to session_id
-        assert agent.model_id == "openai.gpt-5.6-terra"
+        assert agent.model_id == "us.openai.gpt-5.6-terra"
         assert agent.temperature == 0.7
 
     def test_init_with_custom_values(self):

--- a/chatbot-app/agentcore/tests/unit/test_delegation_jobs.py
+++ b/chatbot-app/agentcore/tests/unit/test_delegation_jobs.py
@@ -221,14 +221,14 @@ def test_start_job_resolves_and_persists_model_selection(monkeypatch):
         idempotency_key="s1:r1:t1",
         profile="analyst",
         request=request,
-        model_id="openai.gpt-5.6-terra",
+        model_id="us.openai.gpt-5.6-terra",
     )
 
     record = delegation_jobs.get_job("u1", "s1", receipt.job_id)
-    assert record["parentModelId"] == "openai.gpt-5.6-terra"
-    assert record["modelId"] == "openai.gpt-5.6-sol"
+    assert record["parentModelId"] == "us.openai.gpt-5.6-terra"
+    assert record["modelId"] == "us.openai.gpt-5.6-sol"
     assert record["modelSelection"]["taskComplexity"] == "high"
-    assert record["modelSelection"]["catalogRevision"] == "2026-08-11.1"
+    assert record["modelSelection"]["catalogRevision"] == "2026-08-26.2"
     assert record["modelSelection"]["applied"] is True
 
 

--- a/chatbot-app/agentcore/tests/unit/test_model_catalog.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_catalog.py
@@ -2,6 +2,7 @@ import pytest
 
 from agent.config.model_catalog import (
     get_model_catalog,
+    normalize_model_id,
     normalize_task_complexity,
     resolve_code_agent_model,
     resolve_general_subagent_model,
@@ -28,19 +29,19 @@ class TestGeneralSubagentSelection:
                 "us.anthropic.claude-opus-5",
             ),
             (
-                "openai.gpt-5.6-terra",
+                "us.openai.gpt-5.6-terra",
                 "low",
-                "openai.gpt-5.6-luna",
+                "us.openai.gpt-5.6-luna",
             ),
             (
-                "openai.gpt-5.6-terra",
+                "us.openai.gpt-5.6-terra",
                 "medium",
-                "openai.gpt-5.6-terra",
+                "us.openai.gpt-5.6-terra",
             ),
             (
-                "openai.gpt-5.6-terra",
+                "us.openai.gpt-5.6-terra",
                 "high",
-                "openai.gpt-5.6-sol",
+                "us.openai.gpt-5.6-sol",
             ),
         ],
     )
@@ -59,7 +60,7 @@ class TestGeneralSubagentSelection:
 
     def test_unknown_provider_keeps_parent_model(self):
         selection = resolve_general_subagent_model("xai.grok-4.3", "high")
-        assert selection.effective_model_id == "xai.grok-4.3"
+        assert selection.effective_model_id == "us.xai.grok-4.6"
         assert selection.applied is False
 
     def test_other_openai_family_keeps_parent_model(self):
@@ -111,6 +112,20 @@ class TestCodeAgentSelection:
 def test_catalog_has_unique_model_ids():
     catalog = get_model_catalog()
     assert len(catalog.models) == len(catalog.models_by_id)
+
+
+def test_gpt_56_models_use_bedrock_runtime_responses():
+    catalog = get_model_catalog()
+    for key in ("gpt.sol.latest", "gpt.terra.latest", "gpt.luna.latest"):
+        assert catalog.models[key].transport == "bedrock_responses"
+
+
+@pytest.mark.parametrize(("legacy_id", "canonical_id"), [
+    ("openai.gpt-5.6-terra", "us.openai.gpt-5.6-terra"),
+    ("xai.grok-4.3", "us.xai.grok-4.6"),
+])
+def test_legacy_model_ids_are_normalized(legacy_id, canonical_id):
+    assert normalize_model_id(legacy_id) == canonical_id
 
 
 def test_invalid_complexity_is_rejected():

--- a/chatbot-app/agentcore/tests/unit/test_model_factory.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_factory.py
@@ -2,9 +2,10 @@
 Tests for agents.model_factory
 
 Covers:
-- build_model routing: Bedrock vs Mantle by model_id
+- build_model routing: Bedrock Converse vs Runtime Responses vs Mantle
 - temperature guard (extended-thinking / reasoning models)
-- Mantle base_url / region selection
+- Bedrock Runtime profile and legacy alias routing
+- Mantle-only Gemma base_url / region selection
 - Bedrock API key resolution (env var and Secrets Manager)
 """
 import os
@@ -17,6 +18,7 @@ from strands.types.exceptions import ContextWindowOverflowException
 from agents.model_factory import (
     build_model,
     model_rejects_temperature,
+    BEDROCK_RESPONSES_MODELS,
     MANTLE_MODELS,
 )
 
@@ -32,16 +34,16 @@ class TestTemperatureGuard:
     @pytest.mark.parametrize("model_id", [
         "us.anthropic.claude-opus-5",
         "us.anthropic.claude-sonnet-5",
-        "openai.gpt-5.6-sol",
-        "openai.gpt-5.6-terra",
-        "openai.gpt-5.6-luna",
+        "us.openai.gpt-5.6-sol",
+        "us.openai.gpt-5.6-terra",
+        "us.openai.gpt-5.6-luna",
+        "us.xai.grok-4.6",
     ])
     def test_rejects(self, model_id):
         assert model_rejects_temperature(model_id) is True
 
     @pytest.mark.parametrize("model_id", [
         "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-        "xai.grok-4.3",
         "google.gemma-4-31b",
     ])
     def test_allows(self, model_id):
@@ -79,6 +81,11 @@ class TestBedrockRouting:
             build_model("us.anthropic.claude-opus-5", temperature=0.7)
             assert "temperature" not in MockBedrock.call_args.kwargs
 
+    def test_no_temperature_for_grok_46(self):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model("us.xai.grok-4.6", temperature=0.7)
+            assert "temperature" not in MockBedrock.call_args.kwargs
+
     def test_no_cache_when_disabled(self):
         with patch.object(mf, "BedrockModel") as MockBedrock:
             build_model("us.anthropic.claude-sonnet-5", caching_enabled=False)
@@ -94,26 +101,112 @@ class TestBedrockRouting:
             build_model("us.anthropic.claude-sonnet-5")
             assert "region_name" not in MockBedrock.call_args.kwargs
 
+    @pytest.mark.parametrize("model_id", ["us.xai.grok-4.6"])
+    def test_runtime_profile_models_use_bedrock(self, model_id):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model(model_id)
+            assert MockBedrock.call_args.kwargs["model_id"] == model_id
+
+    @pytest.mark.parametrize(("legacy_id", "canonical_id"), [
+        ("xai.grok-4.3", "us.xai.grok-4.6"),
+        ("xai.grok-4.6", "us.xai.grok-4.6"),
+    ])
+    def test_legacy_ids_are_normalized(self, legacy_id, canonical_id):
+        with patch.object(mf, "BedrockModel") as MockBedrock:
+            build_model(legacy_id)
+            assert MockBedrock.call_args.kwargs["model_id"] == canonical_id
+
+
+class TestBedrockRuntimeResponsesRouting:
+    GPT_MODELS = (
+        "us.openai.gpt-5.6-sol",
+        "us.openai.gpt-5.6-terra",
+        "us.openai.gpt-5.6-luna",
+    )
+
+    def test_only_gpt_56_uses_runtime_responses(self):
+        assert BEDROCK_RESPONSES_MODELS == frozenset(self.GPT_MODELS)
+
+    @pytest.mark.parametrize("model_id", GPT_MODELS)
+    @patch.dict(os.environ, {
+        "AWS_BEARER_TOKEN_BEDROCK": "test-key",
+        "AWS_REGION": "us-west-2",
+    })
+    def test_gpt_56_uses_runtime_responses_endpoint(self, model_id):
+        model = build_model(model_id)
+        assert isinstance(model, OpenAIResponsesModel)
+        assert (
+            model.client_args["base_url"]
+            == "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
+        )
+        assert model.client_args["api_key"] == "test-key"
+        assert model.config["model_id"] == model_id
+
+    @pytest.mark.parametrize(("legacy_id", "canonical_id"), [
+        ("openai.gpt-5.6-sol", "us.openai.gpt-5.6-sol"),
+        ("openai.gpt-5.6-terra", "us.openai.gpt-5.6-terra"),
+        ("openai.gpt-5.6-luna", "us.openai.gpt-5.6-luna"),
+    ])
+    @patch.dict(os.environ, {
+        "AWS_BEARER_TOKEN_BEDROCK": "test-key",
+        "AWS_REGION": "us-west-2",
+    })
+    def test_legacy_gpt_ids_use_runtime_responses(self, legacy_id, canonical_id):
+        model = build_model(legacy_id)
+        assert model.config["model_id"] == canonical_id
+        assert "bedrock-runtime.us-west-2.amazonaws.com" in (
+            model.client_args["base_url"]
+        )
+
+    @pytest.mark.parametrize(("file_format", "expected_mime"), [
+        ("txt", "text/plain"),
+        ("pdf", "application/pdf"),
+        (
+            "docx",
+            "application/vnd.openxmlformats-officedocument."
+            "wordprocessingml.document",
+        ),
+        (
+            "xlsx",
+            "application/vnd.openxmlformats-officedocument."
+            "spreadsheetml.sheet",
+        ),
+    ])
+    @patch.dict(os.environ, {
+        "AWS_BEARER_TOKEN_BEDROCK": "test-key",
+        "AWS_REGION": "us-west-2",
+    })
+    def test_document_uses_filename_and_file_data(
+        self,
+        file_format,
+        expected_mime,
+    ):
+        model = build_model("us.openai.gpt-5.6-sol")
+        block = {
+            "document": {
+                "format": file_format,
+                "name": "probe",
+                "source": {"bytes": b"BEDROCK_FILE_OK"},
+            }
+        }
+        out = type(model)._format_request_message_content(block)
+        assert out["type"] == "input_file"
+        assert out["filename"] == f"probe.{file_format}"
+        assert out["file_data"].startswith(f"data:{expected_mime};base64,")
+        assert "file_url" not in out
+
 
 class TestMantleRouting:
     @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
     def test_mantle_model_built_with_correct_base_url(self):
-        model = build_model("openai.gpt-5.6-sol")
-        assert "bedrock-mantle.us-east-1.api.aws/openai/v1" in model.client_args["base_url"]
+        model = build_model("google.gemma-4-31b")
+        assert "bedrock-mantle.us-east-2.api.aws/openai/v1" in model.client_args["base_url"]
         assert model.client_args["api_key"] == "test-key"
 
-    def test_gpt_56_family_is_pinned_to_us_east_1(self):
-        for model_id in (
-            "openai.gpt-5.6-sol",
-            "openai.gpt-5.6-terra",
-            "openai.gpt-5.6-luna",
-        ):
-            assert MANTLE_MODELS[model_id].region == "us-east-1"
-
-    @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
-    def test_grok_region_is_west(self):
-        model = build_model("xai.grok-4.3")
-        assert "us-west-2" in model.client_args["base_url"]
+    def test_only_gemma_models_remain_on_mantle(self):
+        assert MANTLE_MODELS
+        assert all(model_id.startswith("google.gemma-4") for model_id in MANTLE_MODELS)
+        assert all(spec.region == "us-east-2" for spec in MANTLE_MODELS.values())
 
     def test_all_mantle_models_have_responses_api(self):
         for spec in MANTLE_MODELS.values():
@@ -122,9 +215,8 @@ class TestMantleRouting:
 
     @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
     def test_pdf_document_uses_filename_and_file_data(self):
-        # Mantle rejects the SDK default {"type":"input_file","file_url":...} with
-        # "Unsupported file type: 'unknown'". The subclass must emit filename + file_data.
-        model = build_model("openai.gpt-5.6-sol")
+        # Bedrock Responses endpoints require explicit filename + file_data.
+        model = build_model("google.gemma-4-31b")
         block = {"document": {"format": "pdf", "name": "report", "source": {"bytes": b"%PDF-1.4 x"}}}
         out = type(model)._format_request_message_content(block)
         assert out["type"] == "input_file"
@@ -134,7 +226,7 @@ class TestMantleRouting:
 
     @patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "test-key"})
     def test_non_document_content_delegates_to_parent(self):
-        model = build_model("openai.gpt-5.6-sol")
+        model = build_model("google.gemma-4-31b")
         out = type(model)._format_request_message_content({"text": "hi"})
         assert out == {"type": "input_text", "text": "hi"}
 
@@ -148,7 +240,7 @@ class TestMantleRouting:
                 "prompt tokens (1209034) exceed model maximum (1050000)"
             )
 
-        model = build_model("openai.gpt-5.6-sol")
+        model = build_model("google.gemma-4-31b")
         with patch.object(OpenAIResponsesModel, "stream", failing_stream):
             with pytest.raises(ContextWindowOverflowException, match="1209034"):
                 async for _ in model.stream([]):
@@ -162,7 +254,7 @@ class TestMantleRouting:
                 yield None
             raise RuntimeError("upstream connection reset")
 
-        model = build_model("openai.gpt-5.6-sol")
+        model = build_model("google.gemma-4-31b")
         with patch.object(OpenAIResponsesModel, "stream", failing_stream):
             with pytest.raises(RuntimeError, match="connection reset"):
                 async for _ in model.stream([]):

--- a/chatbot-app/agentcore/tests/unit/test_model_factory.py
+++ b/chatbot-app/agentcore/tests/unit/test_model_factory.py
@@ -154,8 +154,9 @@ class TestBedrockRuntimeResponsesRouting:
     def test_legacy_gpt_ids_use_runtime_responses(self, legacy_id, canonical_id):
         model = build_model(legacy_id)
         assert model.config["model_id"] == canonical_id
-        assert "bedrock-runtime.us-west-2.amazonaws.com" in (
+        assert (
             model.client_args["base_url"]
+            == "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
         )
 
     @pytest.mark.parametrize(("file_format", "expected_mime"), [

--- a/chatbot-app/agentcore/tests/unit/test_skill_executor_input.py
+++ b/chatbot-app/agentcore/tests/unit/test_skill_executor_input.py
@@ -56,6 +56,26 @@ def test_skill_executor_does_not_dispatch_malformed_tool_input(monkeypatch):
     execute_tool.assert_not_called()
 
 
+def test_skill_executor_repairs_annotated_research_skill_call(monkeypatch):
+    skill_tools._registry = MagicMock()
+    execute_tool = MagicMock(return_value="started")
+    monkeypatch.setattr(skill_tools, "_execute_tool", execute_tool)
+    context = MagicMock()
+
+    result = skill_tools.skill_executor(
+        tool_context=context,
+        skill_name="research-agent persistence=yes?true",
+    )
+
+    assert result == "started"
+    execute_tool.assert_called_once_with(
+        tool_context=context,
+        skill_name="research-agent",
+        tool_name="research_agent",
+        tool_input={},
+    )
+
+
 def test_execute_tool_validates_required_arguments_before_calling(monkeypatch):
     class ResearchInput:
         @classmethod
@@ -150,3 +170,55 @@ def test_execute_tool_dispatches_validated_input(monkeypatch):
     call_kwargs = tool_func.call_args.kwargs
     assert call_kwargs["plan"] == "research this"
     assert call_kwargs["tool_context"].tool_use == context.tool_use
+
+
+def test_execute_tool_repairs_missing_research_plan_from_user_message(monkeypatch):
+    class ResearchInput:
+        def __init__(self, plan):
+            self.plan = plan
+
+        @classmethod
+        def model_validate(cls, value):
+            if "plan" not in value:
+                raise ValueError("plan: Field required")
+            return cls(plan=value["plan"])
+
+        def model_dump(self):
+            return {"plan": self.plan}
+
+    tool_func = MagicMock(return_value="started")
+    target_tool = SimpleNamespace(
+        _metadata=SimpleNamespace(
+            input_model=ResearchInput,
+            _context_param="tool_context",
+        ),
+        _tool_func=tool_func,
+    )
+
+    registry = MagicMock()
+    registry.get_tools.return_value = [target_tool]
+    monkeypatch.setattr(skill_tools, "_registry", registry)
+    monkeypatch.setattr(
+        skill_tools,
+        "canonical_tool_name",
+        lambda _tool: "research_agent",
+    )
+
+    context = MagicMock(
+        tool_use={"toolUseId": "tool-1"},
+        agent=MagicMock(),
+        invocation_state={
+            "user_message": "Compare HTTP/2 and HTTP/3 using three sources.",
+        },
+    )
+    result = skill_tools._execute_tool(
+        tool_context=context,
+        skill_name="research-agent",
+        tool_name="research_agent",
+        tool_input={},
+    )
+
+    assert result == "started"
+    assert tool_func.call_args.kwargs["plan"] == (
+        "Compare HTTP/2 and HTTP/3 using three sources."
+    )

--- a/chatbot-app/frontend/__tests__/lib/model-ids.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/model-ids.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_MODEL_ID, normalizeModelId } from '@/lib/model-ids'
+
+describe('model ID normalization', () => {
+  it('uses the Bedrock Runtime inference profile as the default', () => {
+    expect(DEFAULT_MODEL_ID).toBe('us.openai.gpt-5.6-terra')
+  })
+
+  it.each([
+    ['openai.gpt-5.6-sol', 'us.openai.gpt-5.6-sol'],
+    ['openai.gpt-5.6-terra', 'us.openai.gpt-5.6-terra'],
+    ['openai.gpt-5.6-luna', 'us.openai.gpt-5.6-luna'],
+    ['xai.grok-4.3', 'us.xai.grok-4.6'],
+    ['xai.grok-4.6', 'us.xai.grok-4.6'],
+  ])('maps %s to %s', (legacyId, canonicalId) => {
+    expect(normalizeModelId(legacyId)).toBe(canonicalId)
+  })
+
+  it('preserves already canonical and unrelated IDs', () => {
+    expect(normalizeModelId('us.xai.grok-4.6')).toBe('us.xai.grok-4.6')
+    expect(normalizeModelId('us.anthropic.claude-sonnet-5'))
+      .toBe('us.anthropic.claude-sonnet-5')
+  })
+})

--- a/chatbot-app/frontend/package-lock.json
+++ b/chatbot-app/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-amplify/ui-react": "^6.15.5",
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/client-bedrock-agentcore": "^3.1116.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1119.0",
         "@aws-sdk/client-dynamodb": "^3.1116.0",
         "@aws-sdk/client-s3": "^3.1116.0",
         "@aws-sdk/client-s3files": "^3.1116.0",
@@ -569,6 +570,46 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1119.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1119.0.tgz",
+      "integrity": "sha512-NmmWFYYj+thIRMoWFL4rS2qSe2nzHiS1eF23bHu99iN3F8+TAAzWTl60wqwpnkR41eV0DMO0Y2COqHrFTfV4bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.81",
+        "@aws-sdk/eventstream-handler-node": "^3.972.34",
+        "@aws-sdk/middleware-eventstream": "^3.972.29",
+        "@aws-sdk/middleware-websocket": "^3.972.52",
+        "@aws-sdk/token-providers": "3.1119.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1119.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1119.0.tgz",
+      "integrity": "sha512-yykRe5L/yHukeHJteTsYFFu4NpxTE4+zirs7mf1GjH8In2iohYv/wbe/n1jQyx6WzVg2TpXx4KNno2O0DsU6gA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1116.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1116.0.tgz",
@@ -945,6 +986,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.972.30",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.30.tgz",
@@ -952,6 +1008,21 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -976,6 +1047,24 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {

--- a/chatbot-app/frontend/package.json
+++ b/chatbot-app/frontend/package.json
@@ -19,6 +19,7 @@
     "@aws-amplify/ui-react": "^6.15.5",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-bedrock-agentcore": "^3.1116.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1119.0",
     "@aws-sdk/client-dynamodb": "^3.1116.0",
     "@aws-sdk/client-s3": "^3.1116.0",
     "@aws-sdk/client-s3files": "^3.1116.0",

--- a/chatbot-app/frontend/src/app/api/model/available-models/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/available-models/route.ts
@@ -1,10 +1,10 @@
 /**
  * Available Models endpoint - returns list of supported AI models
  *
- * Two backend execution paths (decided server-side by model_id):
- * - Native Bedrock (BedrockModel): prompt caching supported.
- * - Bedrock Mantle (OpenAIResponsesModel): frontier/extra models not on native
- *   Bedrock Converse (gpt-5.x, grok, gemma-4). No prompt caching.
+ * Three backend execution paths (decided server-side by model_id):
+ * - Bedrock Runtime Converse (BedrockModel): native/cross-Region profiles.
+ * - Bedrock Runtime Responses (OpenAIResponsesModel): GPT-5.6.
+ * - Bedrock Mantle Responses (OpenAIResponsesModel): Gemma 4.
  */
 import { NextResponse } from 'next/server'
 
@@ -33,26 +33,26 @@ const AVAILABLE_MODELS = [
     description: 'Fast and efficient, cost-effective'
   },
 
-  // GPT (OpenAI) - gpt-5.x via Mantle, gpt-oss via native Bedrock
+  // GPT (OpenAI) - Bedrock Runtime Responses with cross-Region profiles
   {
-    id: 'openai.gpt-5.6-sol',
+    id: 'us.openai.gpt-5.6-sol',
     name: 'GPT-5.6 Sol',
     provider: 'OpenAI',
-    description: 'Flagship frontier model (via Bedrock Mantle)',
+    description: 'Flagship frontier model via Bedrock Runtime',
     noTemperature: true
   },
   {
-    id: 'openai.gpt-5.6-terra',
+    id: 'us.openai.gpt-5.6-terra',
     name: 'GPT-5.6 Terra',
     provider: 'OpenAI',
-    description: 'Balanced frontier model (via Bedrock Mantle)',
+    description: 'Balanced frontier model via Bedrock Runtime',
     noTemperature: true
   },
   {
-    id: 'openai.gpt-5.6-luna',
+    id: 'us.openai.gpt-5.6-luna',
     name: 'GPT-5.6 Luna',
     provider: 'OpenAI',
-    description: 'Fast and cost-efficient model (via Bedrock Mantle)',
+    description: 'Fast and cost-efficient model via Bedrock Runtime',
     noTemperature: true
   },
   {
@@ -62,12 +62,12 @@ const AVAILABLE_MODELS = [
     description: 'Open-source GPT model with 120B parameters'
   },
 
-  // Grok (xAI) - via Mantle
+  // Grok (xAI) - Bedrock Runtime cross-Region inference profile
   {
-    id: 'xai.grok-4.3',
-    name: 'Grok 4.3',
+    id: 'us.xai.grok-4.6',
+    name: 'Grok 4.6',
     provider: 'xAI',
-    description: 'Advanced reasoning model (via Bedrock Mantle)'
+    description: 'Advanced reasoning model via Bedrock Runtime'
   },
 
   // DeepSeek - native Bedrock

--- a/chatbot-app/frontend/src/app/api/model/config/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/config/route.ts
@@ -5,6 +5,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { extractUserFromRequest } from '@/lib/auth-utils'
 import { getUserProfile } from '@/lib/dynamodb-client'
+import { DEFAULT_MODEL_ID, normalizeModelId } from '@/lib/model-ids'
 
 // Check if running in local development mode
 const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
 
     // Default configuration
     let config = {
-      model_id: 'openai.gpt-5.6-terra',
+      model_id: DEFAULT_MODEL_ID,
       temperature: 0.5,
     }
 
@@ -31,7 +32,7 @@ export async function GET(request: NextRequest) {
 
       if (savedConfig) {
         if (savedConfig.model_id) {
-          config.model_id = savedConfig.model_id
+          config.model_id = normalizeModelId(savedConfig.model_id)
         }
         if (savedConfig.temperature !== undefined) {
           config.temperature = savedConfig.temperature
@@ -47,7 +48,7 @@ export async function GET(request: NextRequest) {
         if (profile?.preferences) {
           // Override with user preferences
           if (profile.preferences.defaultModel) {
-            config.model_id = profile.preferences.defaultModel
+            config.model_id = normalizeModelId(profile.preferences.defaultModel)
           }
           if (profile.preferences.defaultTemperature !== undefined) {
             config.temperature = profile.preferences.defaultTemperature

--- a/chatbot-app/frontend/src/app/api/model/config/update/route.ts
+++ b/chatbot-app/frontend/src/app/api/model/config/update/route.ts
@@ -4,6 +4,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { extractUserFromRequest } from '@/lib/auth-utils'
 import { getUserProfile, upsertUserProfile } from '@/lib/dynamodb-client'
+import { normalizeModelId } from '@/lib/model-ids'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -19,15 +20,16 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json()
     const { model_id, temperature } = body
+    const normalizedModelId = normalizeModelId(model_id)
 
     if (userId === 'anonymous') {
       // Anonymous user - save to local file storage (works for both local and AWS)
       const { updateUserModelConfig } = await import('@/lib/local-tool-store')
       updateUserModelConfig(userId, {
-        model_id,
+        model_id: normalizedModelId,
         temperature
       })
-      console.log(`[API] Updated model config for anonymous user via local file: ${model_id}, temp: ${temperature}`)
+      console.log(`[API] Updated model config for anonymous user via local file: ${normalizedModelId}, temp: ${temperature}`)
 
       return NextResponse.json({
         success: true,
@@ -40,21 +42,21 @@ export async function POST(request: NextRequest) {
       // Local: Save to file
       const { updateUserModelConfig } = await import('@/lib/local-tool-store')
       updateUserModelConfig(userId, {
-        model_id,
+        model_id: normalizedModelId,
         temperature
       })
-      console.log(`[API] Updated model config for user ${userId} via local file: ${model_id}, temp: ${temperature}`)
+      console.log(`[API] Updated model config for user ${userId} via local file: ${normalizedModelId}, temp: ${temperature}`)
     } else {
       // AWS: Save to DynamoDB
       const profile = await getUserProfile(userId)
 
       await upsertUserProfile(userId, user.email || '', user.username, {
         ...(profile?.preferences || {}),
-        defaultModel: model_id,
+        defaultModel: normalizedModelId,
         defaultTemperature: temperature
       })
 
-      console.log(`[API] Updated model config for user ${userId} via DynamoDB: ${model_id}, temp: ${temperature}`)
+      console.log(`[API] Updated model config for user ${userId} via DynamoDB: ${normalizedModelId}, temp: ${temperature}`)
     }
 
     return NextResponse.json({

--- a/chatbot-app/frontend/src/app/api/session/compact/summarize/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/compact/summarize/route.ts
@@ -3,12 +3,15 @@
  *
  * Receives the current messages directly from the frontend (no need to
  * re-load from AgentCore Memory, which avoids actorId / payload format issues).
- * Generates a summary with GPT-5.6 Luna via Bedrock Mantle.
+ * Generates a summary with GPT-5.6 Luna via Bedrock Runtime Converse.
  */
+import { BedrockRuntimeClient, ConverseCommand } from '@aws-sdk/client-bedrock-runtime'
 import { NextRequest, NextResponse } from 'next/server'
 
-const COMPACTION_MODEL_ID = 'openai.gpt-5.6-luna'
-const MANTLE_RESPONSES_URL = 'https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses'
+const COMPACTION_MODEL_ID = 'us.openai.gpt-5.6-luna'
+const bedrockRuntime = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION || 'us-west-2',
+})
 
 export const runtime = 'nodejs'
 
@@ -99,54 +102,24 @@ ${transcript}
 Now produce the summary following the instructions above.`
 }
 
-type MantleContent = {
-  type?: string
-  text?: string
-}
-
-type MantleOutput = {
-  type?: string
-  content?: MantleContent[]
-}
-
-type MantleResponse = {
-  output?: MantleOutput[]
-  error?: { message?: string }
-}
-
 async function generateSummary(prompt: string): Promise<string> {
-  const apiKey = process.env.AWS_BEARER_TOKEN_BEDROCK
-  if (!apiKey) {
-    throw new Error('AWS_BEARER_TOKEN_BEDROCK is not configured')
-  }
-
-  const response = await fetch(MANTLE_RESPONSES_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
+  const response = await bedrockRuntime.send(new ConverseCommand({
+    modelId: COMPACTION_MODEL_ID,
+    messages: [{
+      role: 'user',
+      content: [{ text: prompt }],
+    }],
+    inferenceConfig: {
+      maxTokens: 4096,
     },
-    body: JSON.stringify({
-      model: COMPACTION_MODEL_ID,
-      input: prompt,
-      max_output_tokens: 4096,
-    }),
-  })
+  }))
 
-  const payload = await response.json() as MantleResponse
-  if (!response.ok) {
-    throw new Error(payload.error?.message || `Mantle Responses API returned ${response.status}`)
-  }
-
-  const text = payload.output
-    ?.filter(item => item.type === 'message')
-    .flatMap(item => item.content ?? [])
-    .filter(item => item.type === 'output_text' && item.text)
-    .map(item => item.text)
+  const text = response.output?.message?.content
+    ?.map(block => block.text ?? '')
     .join('') ?? ''
 
   if (!text) {
-    throw new Error('Mantle Responses API returned no summary text')
+    throw new Error('Bedrock Runtime returned no summary text')
   }
   return text
 }

--- a/chatbot-app/frontend/src/app/api/stream/chat/route.ts
+++ b/chatbot-app/frontend/src/app/api/stream/chat/route.ts
@@ -3,6 +3,7 @@
  * Invokes AgentCore Runtime and streams responses
  */
 import { NextRequest } from 'next/server'
+import { DEFAULT_MODEL_ID, normalizeModelId } from '@/lib/model-ids'
 import {
   AgentCoreRuntimeError,
   invokeAgentCoreRuntime,
@@ -259,7 +260,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Load model configuration from storage (only if not provided in request)
-    const defaultModelId = model_id || 'openai.gpt-5.6-terra'
+    const defaultModelId = normalizeModelId(model_id || DEFAULT_MODEL_ID)
 
     let modelConfig = {
       model_id: defaultModelId,
@@ -279,8 +280,8 @@ export async function POST(request: NextRequest) {
           if (config) {
             // Update model and temperature
             if (config.model_id) {
-              modelConfig.model_id = config.model_id
-              modelConfig.caching_enabled = config.model_id.toLowerCase().includes('claude')
+              modelConfig.model_id = normalizeModelId(config.model_id)
+              modelConfig.caching_enabled = modelConfig.model_id.toLowerCase().includes('claude')
               console.log(`[BFF] Applied model_id: ${config.model_id}, caching: ${modelConfig.caching_enabled}`)
             }
             if (config.temperature !== undefined) {
@@ -300,8 +301,8 @@ export async function POST(request: NextRequest) {
           const profile = await getUserProfile(userId)
           if (profile?.preferences) {
             if (profile.preferences.defaultModel) {
-              modelConfig.model_id = profile.preferences.defaultModel
-              modelConfig.caching_enabled = profile.preferences.defaultModel.toLowerCase().includes('claude')
+              modelConfig.model_id = normalizeModelId(profile.preferences.defaultModel)
+              modelConfig.caching_enabled = modelConfig.model_id.toLowerCase().includes('claude')
             }
             if (profile.preferences.defaultTemperature !== undefined) {
               modelConfig.temperature = profile.preferences.defaultTemperature

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -13,6 +13,7 @@ import { useMessageQueue, QueuedMessage, QueueHoldReason } from './useMessageQue
 import { getApiUrl } from '@/config/environment'
 import { generateSessionId } from '@/config/session'
 import { apiGet, apiPost } from '@/lib/api-client'
+import { DEFAULT_MODEL_ID, normalizeModelId } from '@/lib/model-ids'
 import { groupChatMessages, type GroupedChatMessage } from '@/lib/chat-message-groups'
 import { deriveTurnControl, type TurnControlState } from '@/lib/turn-control'
 
@@ -130,7 +131,7 @@ const CONCISE_MODE_KEY = 'chat-concise-mode'
 
 // Default preferences when session has no saved preferences
 const DEFAULT_PREFERENCES: SessionPreferences = {
-  lastModel: 'openai.gpt-5.6-terra',
+  lastModel: DEFAULT_MODEL_ID,
   selectedPromptId: 'general',
 }
 
@@ -441,7 +442,7 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     console.log(`[useChat] ${preferences ? 'Restoring session' : 'Using default'} preferences:`, effectivePreferences)
 
     // Restore model configuration with validation against available models
-    let restoredModel = effectivePreferences.lastModel!
+    let restoredModel = normalizeModelId(effectivePreferences.lastModel!)
     try {
       const modelsResponse = await apiGet<{ models: { id: string }[] }>('model/available-models')
       const validModelIds = modelsResponse.models?.map(m => m.id) || []
@@ -1069,13 +1070,14 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
 
   // Update per-session model config (React state + global default via API)
   const updateModelConfig = useCallback((modelId: string, temperature?: number) => {
-    setCurrentModelId(modelId)
+    const normalizedModelId = normalizeModelId(modelId)
+    setCurrentModelId(normalizedModelId)
     if (temperature !== undefined) {
       setCurrentTemperature(temperature)
     }
     // Also persist as global default for new chats
     apiPost('model/config/update', {
-      model_id: modelId,
+      model_id: normalizedModelId,
       ...(temperature !== undefined && { temperature }),
     }, {
       headers: sessionId ? { 'X-Session-ID': sessionId } : {},

--- a/chatbot-app/frontend/src/lib/dynamodb-schema.ts
+++ b/chatbot-app/frontend/src/lib/dynamodb-schema.ts
@@ -86,7 +86,7 @@ export interface UserApiKeys {
 
 export interface UserPreferences {
   // Model Configuration
-  defaultModel?: string // e.g., "openai.gpt-5.6-terra"
+  defaultModel?: string // e.g., "us.openai.gpt-5.6-terra"
   defaultTemperature?: number // 0.0 - 1.0
   systemPrompt?: string // Custom system prompt
   customPromptName?: string // Name of custom prompt
@@ -261,7 +261,7 @@ export const EXAMPLE_USER_RECORD: UserProfileRecord = {
   createdAt: '2025-01-14T10:00:00Z',
   lastAccessAt: '2025-01-14T15:30:00Z',
   preferences: {
-    defaultModel: 'openai.gpt-5.6-terra',
+    defaultModel: 'us.openai.gpt-5.6-terra',
     defaultTemperature: 0.5,
     systemPrompt: 'You are a helpful AI assistant.',
     enabledTools: ['calculator', 'web_search', 'code_interpreter'],
@@ -282,7 +282,7 @@ export const EXAMPLE_SESSION_RECORD: SessionRecord = {
   tags: ['aws', 'lambda', 'deployment'],
   starred: true,
   metadata: {
-    lastModel: 'openai.gpt-5.6-terra',
+    lastModel: 'us.openai.gpt-5.6-terra',
     lastTemperature: 0.5,
     totalTokens: 8500,
     agentCoreTraceId: 'trace-abc123',

--- a/chatbot-app/frontend/src/lib/model-ids.ts
+++ b/chatbot-app/frontend/src/lib/model-ids.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_MODEL_ID = 'us.openai.gpt-5.6-terra'
+
+const MODEL_ID_ALIASES: Record<string, string> = {
+  'openai.gpt-5.6-sol': 'us.openai.gpt-5.6-sol',
+  'openai.gpt-5.6-terra': 'us.openai.gpt-5.6-terra',
+  'openai.gpt-5.6-luna': 'us.openai.gpt-5.6-luna',
+  'xai.grok-4.3': 'us.xai.grok-4.6',
+  'xai.grok-4.6': 'us.xai.grok-4.6',
+}
+
+export function normalizeModelId(modelId: string): string {
+  return MODEL_ID_ALIASES[modelId] ?? modelId
+}

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -649,12 +649,6 @@ module "chat" {
 
   orchestrator_runtime_arn = module.runtime_orchestrator.runtime_arn
   orchestrator_runtime_url = module.runtime_orchestrator.runtime_invocation_url
-  bedrock_api_key_secret_arn = (
-    var.enable_mantle_models
-    ? data.aws_secretsmanager_secret.bedrock_api_key[0].arn
-    : ""
-  )
-
   frontend_build_args = {
     NEXT_PUBLIC_GOOGLE_MAPS_EMBED_API_KEY = local.google_maps_embed_api_key
   }

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -32,7 +32,7 @@ variable "enable_google_maps" {
 }
 
 variable "enable_mantle_models" {
-  description = "Wire the Bedrock API key secret into model-calling runtimes so Mantle OpenAI-compatible models (gpt-5.x, grok, gemma-4) can be selected. Requires a Secrets Manager secret at <project_name>/bedrock/api-key."
+  description = "Wire the Bedrock API key secret into model-calling runtimes. Required for GPT-5.6 through Bedrock Runtime Responses and for Mantle-only Gemma 4. Grok 4.6 continues to use Bedrock Runtime IAM authentication. Requires a Secrets Manager secret at <project_name>/bedrock/api-key."
   type        = bool
   default     = false
 }

--- a/infra/modules/chat/main.tf
+++ b/infra/modules/chat/main.tf
@@ -258,21 +258,6 @@ resource "aws_iam_role_policy_attachment" "ecs_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-resource "aws_iam_role_policy" "ecs_execution_secrets" {
-  count = var.bedrock_api_key_secret_arn != "" ? 1 : 0
-
-  name = "${local.prefix}-ecs-exec-secrets"
-  role = aws_iam_role.ecs_execution.id
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = ["secretsmanager:GetSecretValue"]
-      Resource = var.bedrock_api_key_secret_arn
-    }]
-  })
-}
-
 resource "aws_iam_role" "ecs_task" {
   name = "${local.prefix}-ecs-task"
   assume_role_policy = jsonencode({
@@ -310,10 +295,12 @@ resource "aws_iam_role_policy" "ecs_task" {
         },
         {
           Effect = "Allow"
-          Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream", "bedrock:Converse", "bedrock:ConverseStream"]
+          Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"]
           Resource = [
             "arn:aws:bedrock:*::foundation-model/*",
-            "arn:aws:bedrock:${var.aws_region}:${var.account_id}:*",
+            "arn:aws:bedrock:*:${var.account_id}:inference-profile/*",
+            "arn:aws:bedrock:*:*:inference-profile/*",
+            "arn:aws:bedrock:*:${var.account_id}:project/*",
           ]
         },
         {
@@ -409,10 +396,6 @@ resource "aws_ecs_task_definition" "frontend" {
       { name = "AGENTCORE_RUNTIME_URL", value = var.orchestrator_runtime_url },
       { name = "SOURCE_HASH", value = local.source_hash },
     ]
-    secrets = var.bedrock_api_key_secret_arn != "" ? [{
-      name      = "AWS_BEARER_TOKEN_BEDROCK"
-      valueFrom = var.bedrock_api_key_secret_arn
-    }] : []
     logConfiguration = {
       logDriver = "awslogs"
       options = {
@@ -426,7 +409,6 @@ resource "aws_ecs_task_definition" "frontend" {
   depends_on = [
     null_resource.codebuild_trigger,
     aws_iam_role_policy_attachment.ecs_execution,
-    aws_iam_role_policy.ecs_execution_secrets,
   ]
 }
 

--- a/infra/modules/chat/variables.tf
+++ b/infra/modules/chat/variables.tf
@@ -103,12 +103,6 @@ variable "orchestrator_runtime_url" {
   type = string
 }
 
-variable "bedrock_api_key_secret_arn" {
-  description = "Secrets Manager ARN for the Bedrock Mantle API key."
-  type        = string
-  default     = ""
-}
-
 # Build-time secrets passed as build args (e.g., Google Maps embed key, default keys)
 variable "frontend_build_args" {
   description = "Extra NEXT_PUBLIC_* build args (key → value)"

--- a/infra/modules/runtime/main.tf
+++ b/infra/modules/runtime/main.tf
@@ -306,11 +306,12 @@ resource "aws_iam_role_policy" "execution_base" {
       },
       {
         Effect = "Allow"
-        Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream", "bedrock:Converse", "bedrock:ConverseStream"]
+        Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"]
         Resource = [
           "arn:aws:bedrock:*::foundation-model/*",
           "arn:aws:bedrock:*:${var.account_id}:inference-profile/*",
           "arn:aws:bedrock:*:*:inference-profile/*",
+          "arn:aws:bedrock:*:${var.account_id}:project/*",
         ]
       },
       {

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -202,22 +202,22 @@ prompt_api_keys() {
     fi
   fi
 
-  # Bedrock API key (for Mantle OpenAI-compatible models: gpt-5.x, grok, gemma-4)
+  # Bedrock API key (GPT-5.6 Runtime Responses and Mantle-only Gemma 4)
   if _secret_exists "$mantle_secret"; then
     ENABLE_MANTLE_MODELS=true
     echo ""
-    echo "Bedrock Mantle  : already configured (gpt-5.x, grok, gemma-4 enabled)"
+    echo "Bedrock API Key : already configured (GPT-5.6 Responses + Gemma 4 enabled)"
   else
     echo ""
-    echo "Bedrock API Key (enables Mantle models: GPT-5.6, Grok-4.3, Gemma-4)"
+    echo "Bedrock API Key (enables GPT-5.6 Runtime Responses and Gemma 4)"
     echo "  Generate at: https://console.aws.amazon.com/bedrock/home#/api-keys"
     read -rp "  Bedrock API Key (Enter to skip): " key
     if [ -n "${key:-}" ]; then
-      _ensure_secret "$mantle_secret" "Bedrock API key for Mantle OpenAI-compatible models" "$key"
+      _ensure_secret "$mantle_secret" "Bedrock API key for OpenAI-compatible Responses models" "$key"
       ENABLE_MANTLE_MODELS=true
       echo "  -> stored"
     else
-      echo "  (skipped — GPT-5.6, Grok, Gemma-4 will not be available)"
+      echo "  (skipped — GPT-5.6 and Gemma 4 will not be available; Grok 4.6 still uses Bedrock Runtime IAM)"
     fi
   fi
 

--- a/infra/scripts/model-smoke.py
+++ b/infra/scripts/model-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import sys
@@ -10,30 +11,43 @@ import urllib.error
 import urllib.request
 import uuid
 
-
 ORCHESTRATOR_URL = os.environ["ORCH_URL"]
 ACCESS_TOKEN = os.environ["ACCESS_TOKEN"]
-MODEL_ID = os.environ.get("MODEL_SMOKE_MODEL_ID", "openai.gpt-5.6-terra")
+USER_ID = os.environ["USER_ID"]
+MODEL_ID = os.environ.get("MODEL_SMOKE_MODEL_ID", "us.openai.gpt-5.6-terra")
 
 
 def _thread_id(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex}_{uuid.uuid4().hex}"[:64]
 
 
-def _invoke(prompt: str, thread_id: str) -> list[dict]:
+def _invoke(
+    prompt: str,
+    thread_id: str,
+    *,
+    files=None,
+) -> list[dict]:
+    content = [{"type": "text", "text": prompt}]
+    for file in files or []:
+        content.append({
+            "type": "binary",
+            "mime_type": file["mime_type"],
+            "data": base64.b64encode(file["data"].encode()).decode(),
+            "filename": file["filename"],
+        })
     payload = {
         "thread_id": thread_id,
         "run_id": f"run_{uuid.uuid4().hex}",
         "messages": [{
             "id": f"msg_{uuid.uuid4().hex}",
             "role": "user",
-            "content": [{"type": "text", "text": prompt}],
+            "content": content,
         }],
         "tools": [],
         "context": [],
         "state": {
             "model_id": MODEL_ID,
-            "user_id": "model-smoke-test",
+            "user_id": USER_ID,
         },
     }
     request = urllib.request.Request(
@@ -87,6 +101,14 @@ def _tool_names(events: list[dict]) -> set[str]:
     }
 
 
+def _response_text(events: list[dict]) -> str:
+    return "".join(
+        str(event.get("delta") or "")
+        for event in events
+        if event.get("type") == "TEXT_MESSAGE_CONTENT"
+    )
+
+
 def _tool_receipt(events: list[dict], tool_name: str) -> dict:
     tool_call_ids = {
         event.get("toolCallId")
@@ -116,6 +138,24 @@ def _tool_receipt(events: list[dict], tool_name: str) -> dict:
 
 
 def main() -> int:
+    file_events = _invoke(
+        "Read the attached text file and return only its verification code.",
+        _thread_id("file_smoke"),
+        files=[{
+            "filename": "responses-smoke.txt",
+            "mime_type": "text/plain",
+            "data": "The verification code is BEDROCK_RUNTIME_RESPONSES_FILE_OK.",
+        }],
+    )
+    _assert_finished(file_events, "GPT file streaming")
+    file_response = _response_text(file_events)
+    if "BEDROCK_RUNTIME_RESPONSES_FILE_OK" not in file_response:
+        raise RuntimeError(
+            "GPT file streaming did not read the attachment: "
+            f"{file_response[-500:]}"
+        )
+    print(f"  GPT file streaming -> completed with {MODEL_ID}")
+
     code_events = _invoke(
         "Delegate to the coding agent: create model-smoke.txt containing exactly "
         "MODEL_SMOKE_OK, verify it, and report completion.",
@@ -151,6 +191,6 @@ def main() -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
-    except Exception as error:
+    except Exception as error:  # noqa: BLE001 - CLI must render any smoke failure
         print(f"  model smoke failed: {error}", file=sys.stderr)
         raise SystemExit(1)

--- a/infra/scripts/test-api.sh
+++ b/infra/scripts/test-api.sh
@@ -155,6 +155,6 @@ echo ""
 if [ "${RUN_MODEL_SMOKE:-0}" = "1" ]; then
   echo ""
   echo ">>> Model routing: Code + Research"
-  export ORCH_URL ACCESS_TOKEN
+  export ORCH_URL ACCESS_TOKEN USER_ID
   python3 "$INFRA_DIR/scripts/model-smoke.py"
 fi

--- a/mobile-app/src/components/chat/ChatScreen.tsx
+++ b/mobile-app/src/components/chat/ChatScreen.tsx
@@ -6,7 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { ImagePickerAsset } from 'expo-image-picker'
 import { useChat } from '../../hooks/useChat'
 import { useTheme } from '../../context/ThemeContext'
-import { AVAILABLE_MODELS, DEFAULT_MODEL_ID, MODEL_STORAGE_KEY } from '../../lib/constants'
+import { AVAILABLE_MODELS, DEFAULT_MODEL_ID, MODEL_STORAGE_KEY, normalizeModelId } from '../../lib/constants'
 import MessageList from './MessageList'
 import ChatInputBar from './ChatInputBar'
 import GreetingScreen from './GreetingScreen'
@@ -40,8 +40,12 @@ export default function ChatScreen({
   // Load persisted model selection
   useEffect(() => {
     AsyncStorage.getItem(MODEL_STORAGE_KEY).then(saved => {
-      if (saved && AVAILABLE_MODELS.some(model => model.id === saved)) {
-        setSelectedModelId(saved)
+      const normalized = saved ? normalizeModelId(saved) : null
+      if (normalized && AVAILABLE_MODELS.some(model => model.id === normalized)) {
+        setSelectedModelId(normalized)
+        if (normalized !== saved) {
+          AsyncStorage.setItem(MODEL_STORAGE_KEY, normalized)
+        }
       } else if (saved) {
         AsyncStorage.setItem(MODEL_STORAGE_KEY, DEFAULT_MODEL_ID)
       }

--- a/mobile-app/src/lib/constants.ts
+++ b/mobile-app/src/lib/constants.ts
@@ -2,7 +2,7 @@ export const API_BASE_URL = (
   (process.env.EXPO_PUBLIC_API_URL as string | undefined) ?? 'http://localhost:3000'
 ).replace(/\/$/, '')
 
-export const DEFAULT_MODEL_ID = 'openai.gpt-5.6-terra'
+export const DEFAULT_MODEL_ID = 'us.openai.gpt-5.6-terra'
 export const DEFAULT_TEMPERATURE = 0.7
 export const TEXT_BUFFER_FLUSH_MS = 120
 
@@ -33,10 +33,10 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
   { id: 'us.anthropic.claude-opus-5', name: 'Claude Opus 5', provider: 'Anthropic', description: 'Most intelligent model' },
   { id: 'us.anthropic.claude-sonnet-5', name: 'Claude Sonnet 5', provider: 'Anthropic', description: 'Balanced performance' },
   { id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0', name: 'Claude Haiku 4.5', provider: 'Anthropic', description: 'Fast and efficient' },
-  { id: 'openai.gpt-5.6-sol', name: 'GPT-5.6 Sol', provider: 'OpenAI', description: 'Flagship frontier model' },
-  { id: 'openai.gpt-5.6-terra', name: 'GPT-5.6 Terra', provider: 'OpenAI', description: 'Balanced frontier model' },
-  { id: 'openai.gpt-5.6-luna', name: 'GPT-5.6 Luna', provider: 'OpenAI', description: 'Fast and cost-efficient model' },
-  { id: 'xai.grok-4.3', name: 'Grok 4.3', provider: 'xAI', description: 'Advanced reasoning model' },
+  { id: 'us.openai.gpt-5.6-sol', name: 'GPT-5.6 Sol', provider: 'OpenAI', description: 'Flagship frontier model' },
+  { id: 'us.openai.gpt-5.6-terra', name: 'GPT-5.6 Terra', provider: 'OpenAI', description: 'Balanced frontier model' },
+  { id: 'us.openai.gpt-5.6-luna', name: 'GPT-5.6 Luna', provider: 'OpenAI', description: 'Fast and cost-efficient model' },
+  { id: 'us.xai.grok-4.6', name: 'Grok 4.6', provider: 'xAI', description: 'Advanced reasoning model' },
   { id: 'google.gemma-4-31b', name: 'Gemma 4 31B', provider: 'Google', description: 'Latest multimodal model' },
   { id: 'deepseek.v3.2', name: 'DeepSeek V3.2', provider: 'DeepSeek', description: 'Strong reasoning capabilities' },
   { id: 'zai.glm-5', name: 'GLM-5', provider: 'Z.AI', description: 'Flagship reasoning model' },
@@ -44,3 +44,15 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
 ]
 
 export const MODEL_STORAGE_KEY = 'selected_model_id'
+
+const MODEL_ID_ALIASES: Record<string, string> = {
+  'openai.gpt-5.6-sol': 'us.openai.gpt-5.6-sol',
+  'openai.gpt-5.6-terra': 'us.openai.gpt-5.6-terra',
+  'openai.gpt-5.6-luna': 'us.openai.gpt-5.6-luna',
+  'xai.grok-4.3': 'us.xai.grok-4.6',
+  'xai.grok-4.6': 'us.xai.grok-4.6',
+}
+
+export function normalizeModelId(modelId: string): string {
+  return MODEL_ID_ALIASES[modelId] ?? modelId
+}

--- a/telegram-app/src/agentcore-client.ts
+++ b/telegram-app/src/agentcore-client.ts
@@ -78,7 +78,7 @@ async function getAccessToken(): Promise<string> {
 
 const sessionEpochs = new Map<number, number>();
 const selectedModels = new Map<number, string>();
-export const DEFAULT_MODEL_ID = "openai.gpt-5.6-terra";
+export const DEFAULT_MODEL_ID = "us.openai.gpt-5.6-terra";
 
 export function resetSession(chatId: number): void {
   sessionEpochs.set(chatId, Date.now());

--- a/telegram-app/src/message-handler.ts
+++ b/telegram-app/src/message-handler.ts
@@ -19,9 +19,10 @@ const MODELS = [
   { id: "us.anthropic.claude-sonnet-5", label: "Sonnet 5" },
   { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Haiku 4.5" },
   { id: "us.anthropic.claude-opus-5", label: "Opus 5" },
-  { id: "openai.gpt-5.6-sol", label: "GPT-5.6 Sol" },
-  { id: "openai.gpt-5.6-terra", label: "GPT-5.6 Terra" },
-  { id: "openai.gpt-5.6-luna", label: "GPT-5.6 Luna" },
+  { id: "us.openai.gpt-5.6-sol", label: "GPT-5.6 Sol" },
+  { id: "us.openai.gpt-5.6-terra", label: "GPT-5.6 Terra" },
+  { id: "us.openai.gpt-5.6-luna", label: "GPT-5.6 Luna" },
+  { id: "us.xai.grok-4.6", label: "Grok 4.6" },
 ] as const;
 
 export function setupMessageHandlers(bot: Bot): void {


### PR DESCRIPTION
## Summary
- route GPT-5.6 Sol, Terra, and Luna through the Bedrock Runtime Responses endpoint
- move Grok to the Bedrock Runtime 4.6 inference profile and preserve legacy model ID compatibility
- convert document blocks to Responses input_file payloads and add deployed attachment streaming smoke coverage
- update frontend, mobile, Telegram, A2A, IAM, and documentation model configuration

## Validation
- backend unit: 690 passed
- backend integration: 140 passed, 15 deselected
- frontend: 748 passed; type-check and production build passed
- A2A: research 62 passed; code 45 passed; lint passed
- mobile type-check and Telegram build passed
- Terraform fmt/validate and targeted post-deploy plan passed
- development deployment smoke passed for GPT attachment streaming, Code Agent, and Research Agent
- post-deploy logs contained no Stream error, document support error, RUN_ERROR, or response.failed events