### PR TITLE
Fix conversation history loss after cutting a session

### DIFF
--- a/chatbot-app/agentcore/src/agent/mailbox.py
+++ b/chatbot-app/agentcore/src/agent/mailbox.py
@@ -68,12 +68,80 @@ def _is_condition_failure(error: Exception) -> bool:
     return any(reason.get("Code") == "ConditionalCheckFailed" for reason in reasons)
 
 
+def _clamp_conversation_cutoffs(
+    existing: Dict[int, str],
+    previous_epoch: int,
+    cutoff: datetime,
+) -> Dict[str, str]:
+    cutoff_utc = (
+        cutoff.replace(tzinfo=timezone.utc)
+        if cutoff.tzinfo is None
+        else cutoff.astimezone(timezone.utc)
+    )
+    result: Dict[str, str] = {}
+    for epoch, value in existing.items():
+        parsed = ConversationFence._parse_time(value)
+        result[str(epoch)] = (
+            value
+            if parsed is not None and parsed < cutoff_utc
+            else _iso(cutoff_utc)
+        )
+    result[str(previous_epoch)] = _iso(cutoff_utc)
+    return result
+
+
 @dataclass(frozen=True)
 class MailboxLease:
     owner: str
     epoch: int
     expires_at: int
     conversation_epoch: int = 0
+
+
+@dataclass(frozen=True)
+class ConversationFence:
+    current_epoch: int = 0
+    cutoff_by_epoch: Dict[int, str] = field(default_factory=dict)
+    truncated_at: Optional[str] = None
+
+    @staticmethod
+    def _parse_time(value: Any) -> Optional[datetime]:
+        if isinstance(value, datetime):
+            return (
+                value.replace(tzinfo=timezone.utc)
+                if value.tzinfo is None
+                else value.astimezone(timezone.utc)
+            )
+        if not isinstance(value, str):
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return (
+                parsed.replace(tzinfo=timezone.utc)
+                if parsed.tzinfo is None
+                else parsed.astimezone(timezone.utc)
+            )
+        except ValueError:
+            return None
+
+    def allows(self, event_epoch: Optional[int], event_time: Any) -> bool:
+        if event_epoch is None:
+            return True
+        if event_epoch == self.current_epoch:
+            return True
+        if event_epoch > self.current_epoch or event_epoch < 0:
+            return False
+
+        cutoff = self.cutoff_by_epoch.get(event_epoch)
+        if cutoff is None and event_epoch == self.current_epoch - 1:
+            cutoff = self.truncated_at
+        cutoff_time = self._parse_time(cutoff)
+        message_time = self._parse_time(event_time)
+        return bool(
+            cutoff_time is not None
+            and message_time is not None
+            and message_time < cutoff_time
+        )
 
 
 class SessionDeletedError(RuntimeError):
@@ -298,11 +366,20 @@ class MailboxRepository(ABC):
         """Return the fencing epoch for the current visible conversation."""
 
     @abstractmethod
+    def get_conversation_fence(
+        self,
+        user_id: str,
+        session_id: str,
+    ) -> ConversationFence:
+        """Return the current epoch and retained-prefix cutoff for each old epoch."""
+
+    @abstractmethod
     def advance_conversation_epoch(
         self,
         user_id: str,
         session_id: str,
         *,
+        cutoff: Optional[datetime] = None,
         now: Optional[datetime] = None,
     ) -> int:
         """Fence work created before a truncate and return the new epoch."""
@@ -551,45 +628,96 @@ class DynamoDBMailboxRepository(MailboxRepository):
         return bool(response.get("Item"))
 
     def get_conversation_epoch(self, user_id: str, session_id: str) -> int:
+        return self.get_conversation_fence(user_id, session_id).current_epoch
+
+    def get_conversation_fence(
+        self,
+        user_id: str,
+        session_id: str,
+    ) -> ConversationFence:
         response = self.client.get_item(
             TableName=self.table_name,
             Key=self._key(user_id, session_id, "STATE"),
             ConsistentRead=True,
-            ProjectionExpression="conversationEpoch",
+            ProjectionExpression=(
+                "conversationEpoch, conversationEpochCutoffs, truncatedAt"
+            ),
         )
         item = response.get("Item")
         if not item:
-            return 0
-        return int(self._deserialize(item).get("conversationEpoch", 0))
+            return ConversationFence()
+        state = self._deserialize(item)
+        raw_cutoffs = state.get("conversationEpochCutoffs") or {}
+        cutoffs = {
+            int(epoch): value
+            for epoch, value in raw_cutoffs.items()
+            if str(epoch).isdigit() and isinstance(value, str)
+        }
+        return ConversationFence(
+            current_epoch=int(state.get("conversationEpoch", 0)),
+            cutoff_by_epoch=cutoffs,
+            truncated_at=state.get("truncatedAt"),
+        )
 
     def advance_conversation_epoch(
         self,
         user_id: str,
         session_id: str,
         *,
+        cutoff: Optional[datetime] = None,
         now: Optional[datetime] = None,
     ) -> int:
         current = now or utc_now()
-        response = self.client.update_item(
-            TableName=self.table_name,
-            Key=self._key(user_id, session_id, "STATE"),
-            UpdateExpression=(
-                "SET conversationEpoch = if_not_exists(conversationEpoch, :zero) + :one, "
-                "leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, "
-                "truncatedAt = :updated, updatedAt = :updated "
-                "REMOVE leaseOwner, leaseUntil, latestAttentionCursor, "
-                "latestAttentionAt, lastSeenAttentionCursor, lastSeenAttentionAt"
-            ),
-            ConditionExpression="attribute_not_exists(deletedAt)",
-            ExpressionAttributeValues=self._serialize({
-                ":zero": 0,
-                ":one": 1,
-                ":updated": _iso(current),
-            }),
-            ReturnValues="ALL_NEW",
-        )
-        attributes = self._deserialize(response["Attributes"])
-        next_epoch = int(attributes["conversationEpoch"])
+        next_epoch = 0
+        for attempt in range(5):
+            fence = self.get_conversation_fence(user_id, session_id)
+            previous_epoch = fence.current_epoch
+            cutoffs = _clamp_conversation_cutoffs(
+                fence.cutoff_by_epoch,
+                previous_epoch,
+                cutoff or current,
+            )
+            condition = "conversationEpoch = :previous"
+            if previous_epoch == 0:
+                condition = (
+                    "(attribute_not_exists(conversationEpoch) "
+                    "OR conversationEpoch = :previous)"
+                )
+            try:
+                response = self.client.update_item(
+                    TableName=self.table_name,
+                    Key=self._key(user_id, session_id, "STATE"),
+                    UpdateExpression=(
+                        "SET conversationEpoch = :next, "
+                        "conversationEpochCutoffs = :cutoffs, "
+                        "leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, "
+                        "truncatedAt = :updated, updatedAt = :updated "
+                        "REMOVE leaseOwner, leaseUntil, latestAttentionCursor, "
+                        "latestAttentionAt, lastSeenAttentionCursor, "
+                        "lastSeenAttentionAt"
+                    ),
+                    ConditionExpression=(
+                        "attribute_not_exists(deletedAt) AND "
+                        f"{condition}"
+                    ),
+                    ExpressionAttributeValues=self._serialize({
+                        ":previous": previous_epoch,
+                        ":next": previous_epoch + 1,
+                        ":cutoffs": cutoffs,
+                        ":zero": 0,
+                        ":one": 1,
+                        ":updated": _iso(current),
+                    }),
+                    ReturnValues="ALL_NEW",
+                )
+                attributes = self._deserialize(response["Attributes"])
+                next_epoch = int(attributes["conversationEpoch"])
+                break
+            except Exception as error:
+                if not _is_condition_failure(error) or attempt == 4:
+                    raise
+        if not next_epoch:
+            raise RuntimeError("Failed to advance conversation epoch")
         terminal_ttl = int(
             (current + timedelta(days=TERMINAL_TTL_DAYS)).timestamp()
         )
@@ -1233,15 +1361,33 @@ class FileMailboxRepository(MailboxRepository):
             )
 
     def get_conversation_epoch(self, user_id: str, session_id: str) -> int:
+        return self.get_conversation_fence(user_id, session_id).current_epoch
+
+    def get_conversation_fence(
+        self,
+        user_id: str,
+        session_id: str,
+    ) -> ConversationFence:
         with self._lock:
             state = self._load(user_id, session_id)["state"]
-            return int(state.get("conversationEpoch", 0))
+            raw_cutoffs = state.get("conversationEpochCutoffs") or {}
+            cutoffs = {
+                int(epoch): value
+                for epoch, value in raw_cutoffs.items()
+                if str(epoch).isdigit() and isinstance(value, str)
+            }
+            return ConversationFence(
+                current_epoch=int(state.get("conversationEpoch", 0)),
+                cutoff_by_epoch=cutoffs,
+                truncated_at=state.get("truncatedAt"),
+            )
 
     def advance_conversation_epoch(
         self,
         user_id: str,
         session_id: str,
         *,
+        cutoff: Optional[datetime] = None,
         now: Optional[datetime] = None,
     ) -> int:
         current = now or utc_now()
@@ -1252,9 +1398,18 @@ class FileMailboxRepository(MailboxRepository):
                 raise SessionDeletedError(
                     f"Session {session_id} has been deleted"
                 )
-            state["conversationEpoch"] = int(
-                state.get("conversationEpoch", 0)
-            ) + 1
+            previous_epoch = int(state.get("conversationEpoch", 0))
+            state["conversationEpoch"] = previous_epoch + 1
+            raw_cutoffs = state.get("conversationEpochCutoffs") or {}
+            state["conversationEpochCutoffs"] = _clamp_conversation_cutoffs(
+                {
+                    int(epoch): value
+                    for epoch, value in raw_cutoffs.items()
+                    if str(epoch).isdigit() and isinstance(value, str)
+                },
+                previous_epoch,
+                cutoff or current,
+            )
             state["leaseEpoch"] = int(state.get("leaseEpoch", 0)) + 1
             state["truncatedAt"] = _iso(current)
             state["updatedAt"] = _iso(current)

--- a/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
+++ b/chatbot-app/agentcore/src/agent/session/compacting_session_manager.py
@@ -316,7 +316,7 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
 
         from agent.mailbox import get_mailbox_repository
 
-        current_epoch = get_mailbox_repository().get_conversation_epoch(
+        conversation_fence = get_mailbox_repository().get_conversation_fence(
             self.user_id or self.config.actor_id,
             session_id,
         )
@@ -330,9 +330,13 @@ class CompactingSessionManager(AgentCoreMemorySessionManager):
         events = [
             event
             for event in events
-            if (
-                (event_epoch := self._event_conversation_epoch(event)) is None
-                or event_epoch >= current_epoch
+            if conversation_fence.allows(
+                self._event_conversation_epoch(event),
+                (
+                    event.get("eventTimestamp")
+                    or event.get("eventTime")
+                    or event.get("event_time")
+                ),
             )
         ]
         messages = self.converter.events_to_messages(events)

--- a/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
+++ b/chatbot-app/agentcore/tests/unit/test_compacting_session_manager.py
@@ -174,19 +174,35 @@ class TestMailboxPersistenceScope:
         assert metadata["visibility"]["stringValue"] == "conversation"
 
     def test_list_messages_filters_stale_mailbox_epochs(self, manager):
+        from agent.mailbox import ConversationFence
+
         repository = MagicMock()
-        repository.get_conversation_epoch.return_value = 3
+        repository.get_conversation_fence.return_value = ConversationFence(
+            current_epoch=3,
+            cutoff_by_epoch={
+                2: "2026-08-31T12:00:00+00:00",
+            },
+        )
         manager.config.filter_restored_tool_context = False
         manager.memory_client.list_events.return_value = [
             {"eventId": "foreground"},
             {
+                "eventId": "retained-prefix",
+                "eventTimestamp": "2026-08-31T11:59:59+00:00",
+                "metadata": {
+                    "conversationEpoch": {"stringValue": "2"},
+                },
+            },
+            {
                 "eventId": "stale",
+                "eventTime": "2026-08-31T12:00:01+00:00",
                 "metadata": {
                     "conversationEpoch": {"stringValue": "2"},
                 },
             },
             {
                 "eventId": "current",
+                "eventTime": "2026-08-31T12:00:02+00:00",
                 "metadata": {
                     "conversationEpoch": {"stringValue": "3"},
                 },
@@ -203,8 +219,8 @@ class TestMailboxPersistenceScope:
         ):
             messages = manager.list_messages("session-1", "default")
 
-        assert messages == ["foreground", "current"]
-        repository.get_conversation_epoch.assert_called_once_with(
+        assert messages == ["foreground", "retained-prefix", "current"]
+        repository.get_conversation_fence.assert_called_once_with(
             "user-1",
             "session-1",
         )

--- a/chatbot-app/agentcore/tests/unit/test_mailbox.py
+++ b/chatbot-app/agentcore/tests/unit/test_mailbox.py
@@ -65,18 +65,49 @@ def test_deleted_session_rejects_new_events_and_leases(tmp_path):
 def test_truncate_epoch_rejects_stale_events_and_accepts_current_work(tmp_path):
     repository = FileMailboxRepository(tmp_path)
     stale = event("stale")
+    cutoff = NOW - timedelta(minutes=5)
 
     assert repository.advance_conversation_epoch(
         "user-1",
         "session-1",
+        cutoff=cutoff,
         now=NOW,
     ) == 1
+    fence = repository.get_conversation_fence("user-1", "session-1")
+    assert fence.current_epoch == 1
+    assert fence.cutoff_by_epoch == {0: cutoff.isoformat()}
     with pytest.raises(SessionSupersededError):
         repository.enqueue(stale)
 
     current = event("current")
     current.conversation_epoch = 1
     assert repository.enqueue(current) is True
+
+
+def test_repeated_truncate_clamps_all_older_epoch_cutoffs(tmp_path):
+    repository = FileMailboxRepository(tmp_path)
+    first_cutoff = NOW - timedelta(minutes=5)
+    earlier_cutoff = NOW - timedelta(minutes=10)
+
+    repository.advance_conversation_epoch(
+        "user-1",
+        "session-1",
+        cutoff=first_cutoff,
+        now=NOW,
+    )
+    repository.advance_conversation_epoch(
+        "user-1",
+        "session-1",
+        cutoff=earlier_cutoff,
+        now=NOW + timedelta(seconds=1),
+    )
+
+    fence = repository.get_conversation_fence("user-1", "session-1")
+    assert fence.current_epoch == 2
+    assert fence.cutoff_by_epoch == {
+        0: earlier_cutoff.isoformat(),
+        1: earlier_cutoff.isoformat(),
+    }
 
 
 def test_truncate_epoch_fences_claimed_event_and_cancels_it(tmp_path):

--- a/chatbot-app/frontend/__tests__/lib/conversation-fence.test.ts
+++ b/chatbot-app/frontend/__tests__/lib/conversation-fence.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isConversationEventVisible,
+  type ConversationFence,
+} from '@/lib/session-events'
+
+function event(
+  epoch: number | undefined,
+  eventTime: string,
+  timestampKey: 'eventTimestamp' | 'eventTime' = 'eventTimestamp',
+) {
+  return {
+    [timestampKey]: eventTime,
+    ...(epoch !== undefined && {
+      metadata: {
+        conversationEpoch: { stringValue: String(epoch) },
+      },
+    }),
+  }
+}
+
+describe('conversation epoch fences', () => {
+  it('preserves the old-epoch prefix and rejects stale suffix writes', () => {
+    const fence: ConversationFence = {
+      conversationEpoch: 1,
+      cutoffByEpoch: {
+        0: '2026-08-31T12:00:00.000Z',
+      },
+    }
+
+    expect(isConversationEventVisible(
+      event(0, '2026-08-31T11:59:59.000Z', 'eventTime'),
+      fence,
+    )).toBe(true)
+    expect(isConversationEventVisible(
+      event(0, '2026-08-31T12:00:00.000Z'),
+      fence,
+    )).toBe(false)
+    expect(isConversationEventVisible(
+      event(0, '2026-08-31T12:00:01.000Z'),
+      fence,
+    )).toBe(false)
+    expect(isConversationEventVisible(
+      event(1, '2026-08-31T12:00:02.000Z'),
+      fence,
+    )).toBe(true)
+  })
+
+  it('uses each epoch cutoff across repeated truncations', () => {
+    const fence: ConversationFence = {
+      conversationEpoch: 2,
+      cutoffByEpoch: {
+        0: '2026-08-31T12:00:00.000Z',
+        1: '2026-08-31T13:00:00.000Z',
+      },
+    }
+
+    expect(isConversationEventVisible(
+      event(0, '2026-08-31T11:00:00.000Z'),
+      fence,
+    )).toBe(true)
+    expect(isConversationEventVisible(
+      event(0, '2026-08-31T12:30:00.000Z'),
+      fence,
+    )).toBe(false)
+    expect(isConversationEventVisible(
+      event(1, '2026-08-31T12:30:00.000Z'),
+      fence,
+    )).toBe(true)
+    expect(isConversationEventVisible(
+      event(1, '2026-08-31T13:30:00.000Z'),
+      fence,
+    )).toBe(false)
+  })
+
+  it('keeps legacy metadata-less events and migrates the latest old epoch', () => {
+    const fence: ConversationFence = {
+      conversationEpoch: 1,
+      cutoffByEpoch: {},
+      truncatedAt: '2026-08-31T12:00:00.000Z',
+    }
+
+    expect(isConversationEventVisible(
+      event(undefined, '2026-08-31T13:00:00.000Z'),
+      fence,
+    )).toBe(true)
+    expect(isConversationEventVisible(
+      event(0, '2026-08-31T11:59:59.000Z'),
+      fence,
+    )).toBe(true)
+    expect(isConversationEventVisible(
+      event(0, '2026-08-31T12:00:01.000Z'),
+      fence,
+    )).toBe(false)
+  })
+})

--- a/chatbot-app/frontend/src/app/api/conversation/history/route.ts
+++ b/chatbot-app/frontend/src/app/api/conversation/history/route.ts
@@ -29,6 +29,13 @@ function eventMetadataString(event: any, key: string): string | undefined {
   return undefined
 }
 
+function eventTimestampString(event: any): string {
+  const value = event?.eventTimestamp ?? event?.eventTime
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string') return value
+  return new Date().toISOString()
+}
+
 async function getMemoryId(): Promise<string | null> {
   // Use environment variable if available
   const envMemoryId = process.env.MEMORY_ID || process.env.NEXT_PUBLIC_MEMORY_ID
@@ -150,14 +157,14 @@ export async function GET(request: NextRequest) {
         console.log(`[API] Retrieved ${pageEvents.length} events (total: ${allEvents.length})${nextToken ? ', fetching more...' : ''}`)
       } while (nextToken)
 
-      const { getSessionConversationEpoch } = await import('@/lib/session-events')
-      const conversationEpoch = await getSessionConversationEpoch(userId, sessionId)
-      const events = allEvents.filter(event => {
-        const rawEpoch = eventMetadataString(event, 'conversationEpoch')
-        if (rawEpoch === undefined) return true
-        const eventEpoch = Number(rawEpoch)
-        return Number.isFinite(eventEpoch) && eventEpoch >= conversationEpoch
-      })
+      const {
+        getSessionConversationFence,
+        isConversationEventVisible,
+      } = await import('@/lib/session-events')
+      const conversationFence = await getSessionConversationFence(userId, sessionId)
+      const events = allEvents.filter(event =>
+        isConversationEventVisible(event, conversationFence)
+      )
       console.log(`[API] Retrieved ${events.length} total events from AgentCore Memory`)
 
       // Convert AgentCore Memory events to chat messages
@@ -248,7 +255,7 @@ export async function GET(request: NextRequest) {
             ...(logicalMessageId && { logicalMessageId }),
             ...(event.eventId && { eventId: event.eventId }),
             ...(originEventId && { originEventId }),
-            timestamp: event.eventTime || new Date().toISOString()
+            timestamp: eventTimestampString(event)
           }
           // Extract SDK-persisted metadata (usage + metrics) from message.metadata
           if (parsed.message.metadata?.usage) {
@@ -286,7 +293,7 @@ export async function GET(request: NextRequest) {
                   ...(logicalMessageId && { logicalMessageId }),
                   ...(event.eventId && { eventId: event.eventId }),
                   ...(originEventId && { originEventId }),
-                  timestamp: event.eventTime || new Date().toISOString()
+                  timestamp: eventTimestampString(event)
                 }
                 if (blobMessageData.message.metadata?.usage) {
                   message.tokenUsage = blobMessageData.message.metadata.usage

--- a/chatbot-app/frontend/src/app/api/session/truncate/route.ts
+++ b/chatbot-app/frontend/src/app/api/session/truncate/route.ts
@@ -13,6 +13,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { extractUserFromRequest } from '@/lib/auth-utils'
+import { conversationEventTimestamp } from '@/lib/session-events'
 
 const IS_LOCAL = process.env.NEXT_PUBLIC_AGENTCORE_LOCAL === 'true'
 const AWS_REGION = process.env.AWS_REGION || process.env.NEXT_PUBLIC_AWS_REGION || 'us-west-2'
@@ -125,11 +126,15 @@ export async function POST(request: NextRequest) {
       // Positional approach: find the event and delete it + everything after
       const fromIndex = chronologicalEvents.findIndex((e: any) => e.eventId === fromEventId)
       if (fromIndex >= 0) {
-        const cutoffEventTime = chronologicalEvents[fromIndex]?.eventTime
-        cutoffMs = cutoffEventTime ? new Date(cutoffEventTime).getTime() : NaN
+        const cutoffEventTime = conversationEventTimestamp(
+          chronologicalEvents[fromIndex],
+        )
+        cutoffMs = cutoffEventTime instanceof Date
+          ? cutoffEventTime.getTime()
+          : new Date(cutoffEventTime || '').getTime()
         if (!Number.isFinite(cutoffMs)) {
           return NextResponse.json(
-            { success: false, error: 'Target event has no usable eventTime' },
+            { success: false, error: 'Target event has no usable timestamp' },
             { status: 409 },
           )
         }
@@ -155,7 +160,10 @@ export async function POST(request: NextRequest) {
       // Timestamp fallback: delete events with eventTime >= fromTimestamp
       for (const event of chronologicalEvents) {
         if (!event.eventId) continue
-        const eventMs = (event as any).eventTime ? new Date((event as any).eventTime).getTime() : NaN
+        const eventTimestamp = conversationEventTimestamp(event)
+        const eventMs = eventTimestamp instanceof Date
+          ? eventTimestamp.getTime()
+          : new Date(eventTimestamp || '').getTime()
         if (!isNaN(eventMs) && eventMs >= fromTimestamp) {
           toDelete.push({ eventId: event.eventId, actorId: userId })
         }

--- a/chatbot-app/frontend/src/hooks/useChat.ts
+++ b/chatbot-app/frontend/src/hooks/useChat.ts
@@ -955,7 +955,10 @@ export const useChat = (props?: UseChatProps): UseChatReturn => {
     })
 
     try {
-      await apiTruncateSession(params)
+      const truncated = await apiTruncateSession(params)
+      if (!truncated) {
+        throw new Error('Backend truncation failed')
+      }
       setSessionEventRefreshVersion(version => version + 1)
       console.log('[truncate] Backend truncation complete')
     } catch (error) {

--- a/chatbot-app/frontend/src/lib/session-events.ts
+++ b/chatbot-app/frontend/src/lib/session-events.ts
@@ -49,8 +49,79 @@ export interface SessionAttentionState {
   lastSeenAttentionAt?: string
 }
 
+export interface ConversationFence {
+  conversationEpoch: number
+  cutoffByEpoch: Record<string, string>
+  truncatedAt?: string
+}
+
 function sessionKey(userId: string, sessionId: string): string {
   return `USER#${userId}#SESSION#${sessionId}`
+}
+
+function conversationFenceFromState(
+  state: Record<string, any> | undefined,
+): ConversationFence {
+  const rawCutoffs = state?.conversationEpochCutoffs
+  const cutoffByEpoch: Record<string, string> = {}
+  if (rawCutoffs && typeof rawCutoffs === 'object' && !Array.isArray(rawCutoffs)) {
+    for (const [epoch, cutoff] of Object.entries(rawCutoffs)) {
+      if (/^\d+$/.test(epoch) && typeof cutoff === 'string') {
+        cutoffByEpoch[epoch] = cutoff
+      }
+    }
+  }
+  return {
+    conversationEpoch: Number(state?.conversationEpoch || 0),
+    cutoffByEpoch,
+    ...(typeof state?.truncatedAt === 'string' && {
+      truncatedAt: state.truncatedAt,
+    }),
+  }
+}
+
+function eventMetadataString(event: any, key: string): string | undefined {
+  const value = event?.metadata?.[key]
+  if (typeof value === 'string') return value
+  if (typeof value?.stringValue === 'string') return value.stringValue
+  return undefined
+}
+
+export function conversationEventTimestamp(
+  event: any,
+): string | Date | undefined {
+  return event?.eventTimestamp ?? event?.eventTime
+}
+
+export function isConversationEventVisible(
+  event: any,
+  fence: ConversationFence,
+): boolean {
+  const rawEpoch = eventMetadataString(event, 'conversationEpoch')
+  if (rawEpoch === undefined) return true
+
+  const eventEpoch = Number(rawEpoch)
+  if (!Number.isInteger(eventEpoch) || eventEpoch < 0) return false
+  if (eventEpoch === fence.conversationEpoch) return true
+  if (eventEpoch > fence.conversationEpoch) return false
+
+  const cutoff =
+    fence.cutoffByEpoch[String(eventEpoch)] ||
+    (
+      eventEpoch === fence.conversationEpoch - 1
+        ? fence.truncatedAt
+        : undefined
+    )
+  if (!cutoff) return false
+
+  const timestamp = conversationEventTimestamp(event)
+  const eventMs = timestamp instanceof Date
+    ? timestamp.getTime()
+    : new Date(timestamp || '').getTime()
+  const cutoffMs = new Date(cutoff).getTime()
+  return Number.isFinite(eventMs) &&
+    Number.isFinite(cutoffMs) &&
+    eventMs < cutoffMs
 }
 
 function localMailboxPath(userId: string, sessionId: string): string {
@@ -149,18 +220,37 @@ export async function getSessionConversationEpoch(
   userId: string,
   sessionId: string,
 ): Promise<number> {
+  return (await getSessionConversationFence(userId, sessionId)).conversationEpoch
+}
+
+export async function getSessionConversationFence(
+  userId: string,
+  sessionId: string,
+): Promise<ConversationFence> {
   if (IS_LOCAL || userId === 'anonymous') {
     const targetPath = localMailboxPath(userId, sessionId)
-    if (!fs.existsSync(targetPath)) return 0
+    if (!fs.existsSync(targetPath)) {
+      return { conversationEpoch: 0, cutoffByEpoch: {} }
+    }
     const data = JSON.parse(fs.readFileSync(targetPath, 'utf-8'))
-    return Number(data.state?.conversationEpoch || 0)
+    return conversationFenceFromState(data.state)
   }
-  if (!TABLE_NAME) return 0
-  return readConversationEpoch(
-    new DynamoDBClient({ region: AWS_REGION }),
-    userId,
-    sessionId,
+  if (!TABLE_NAME) return { conversationEpoch: 0, cutoffByEpoch: {} }
+  const response = await new DynamoDBClient({ region: AWS_REGION }).send(
+    new GetItemCommand({
+      TableName: TABLE_NAME,
+      Key: {
+        sessionKey: { S: sessionKey(userId, sessionId) },
+        recordKey: { S: 'STATE' },
+      },
+      ConsistentRead: true,
+      ProjectionExpression:
+        'conversationEpoch, conversationEpochCutoffs, truncatedAt',
+    }),
   )
+  return response.Item
+    ? conversationFenceFromState(unmarshall(response.Item))
+    : { conversationEpoch: 0, cutoffByEpoch: {} }
 }
 
 async function queryPrefix(

--- a/chatbot-app/frontend/src/lib/session-lifecycle.ts
+++ b/chatbot-app/frontend/src/lib/session-lifecycle.ts
@@ -4,6 +4,7 @@ import { createHash, randomUUID } from 'crypto'
 import {
   BatchWriteItemCommand,
   DynamoDBClient,
+  GetItemCommand,
   QueryCommand,
   UpdateItemCommand,
   type WriteRequest,
@@ -63,6 +64,25 @@ function writeLocalMailbox(targetPath: string, data: Record<string, any>) {
   fs.renameSync(temporaryPath, targetPath)
 }
 
+function clampConversationEpochCutoffs(
+  rawCutoffs: Record<string, unknown> | undefined,
+  previousEpoch: number,
+  cutoff: string,
+): Record<string, string> {
+  const cutoffMs = Date.parse(cutoff)
+  const result: Record<string, string> = {}
+  for (const [epoch, existing] of Object.entries(rawCutoffs || {})) {
+    if (!/^\d+$/.test(epoch) || typeof existing !== 'string') continue
+    const existingMs = Date.parse(existing)
+    result[epoch] =
+      Number.isFinite(existingMs) && existingMs < cutoffMs
+        ? existing
+        : cutoff
+  }
+  result[String(previousEpoch)] = cutoff
+  return result
+}
+
 function advanceLocalConversationEpoch(
   userId: string,
   sessionId: string,
@@ -77,10 +97,17 @@ function advanceLocalConversationEpoch(
         sessionEvents: {},
       }
   const updatedAt = new Date().toISOString()
-  const nextEpoch = Number(data.state?.conversationEpoch || 0) + 1
+  const previousEpoch = Number(data.state?.conversationEpoch || 0)
+  const nextEpoch = previousEpoch + 1
+  const conversationEpochCutoffs = clampConversationEpochCutoffs(
+    data.state?.conversationEpochCutoffs,
+    previousEpoch,
+    cutoff,
+  )
   data.state = {
     ...(data.state || {}),
     conversationEpoch: nextEpoch,
+    conversationEpochCutoffs,
     leaseEpoch: Number(data.state?.leaseEpoch || 0) + 1,
     truncatedAt: updatedAt,
     updatedAt,
@@ -294,29 +321,63 @@ export async function advanceSessionConversationEpoch(
 
   const client = new DynamoDBClient({ region: AWS_REGION })
   const updatedAt = new Date().toISOString()
-  const state = await client.send(new UpdateItemCommand({
-    TableName: TABLE_NAME,
-    Key: marshall({
-      sessionKey: sessionKey(userId, sessionId),
-      recordKey: 'STATE',
-    }),
-    UpdateExpression:
-      'SET conversationEpoch = if_not_exists(conversationEpoch, :zero) + :one, ' +
-      'leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, ' +
-      'truncatedAt = :updated, updatedAt = :updated ' +
-      'REMOVE leaseOwner, leaseUntil, latestAttentionCursor, ' +
-      'latestAttentionAt, lastSeenAttentionCursor, lastSeenAttentionAt',
-    ConditionExpression: 'attribute_not_exists(deletedAt)',
-    ExpressionAttributeValues: marshall({
-      ':zero': 0,
-      ':one': 1,
-      ':updated': updatedAt,
-    }),
-    ReturnValues: 'ALL_NEW',
-  }))
-  const nextEpoch = Number(
-    state.Attributes ? unmarshall(state.Attributes).conversationEpoch : 0,
-  )
+  const stateKey = marshall({
+    sessionKey: sessionKey(userId, sessionId),
+    recordKey: 'STATE',
+  })
+  let nextEpoch = 0
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const existing = await client.send(new GetItemCommand({
+      TableName: TABLE_NAME,
+      Key: stateKey,
+      ConsistentRead: true,
+    }))
+    const current = existing.Item ? unmarshall(existing.Item) : {}
+    if (current.deletedAt) {
+      throw new Error('Session has been deleted')
+    }
+    const previousEpoch = Number(current.conversationEpoch || 0)
+    const conversationEpochCutoffs = clampConversationEpochCutoffs(
+      current.conversationEpochCutoffs,
+      previousEpoch,
+      cutoff,
+    )
+    try {
+      const state = await client.send(new UpdateItemCommand({
+        TableName: TABLE_NAME,
+        Key: stateKey,
+        UpdateExpression:
+          'SET conversationEpoch = :next, ' +
+          'conversationEpochCutoffs = :cutoffs, ' +
+          'leaseEpoch = if_not_exists(leaseEpoch, :zero) + :one, ' +
+          'truncatedAt = :updated, updatedAt = :updated ' +
+          'REMOVE leaseOwner, leaseUntil, latestAttentionCursor, ' +
+          'latestAttentionAt, lastSeenAttentionCursor, lastSeenAttentionAt',
+        ConditionExpression:
+          'attribute_not_exists(deletedAt) AND ' +
+          (
+            previousEpoch === 0
+              ? '(attribute_not_exists(conversationEpoch) OR conversationEpoch = :previous)'
+              : 'conversationEpoch = :previous'
+          ),
+        ExpressionAttributeValues: marshall({
+          ':previous': previousEpoch,
+          ':next': previousEpoch + 1,
+          ':cutoffs': conversationEpochCutoffs,
+          ':zero': 0,
+          ':one': 1,
+          ':updated': updatedAt,
+        }),
+        ReturnValues: 'ALL_NEW',
+      }))
+      nextEpoch = Number(
+        state.Attributes ? unmarshall(state.Attributes).conversationEpoch : 0,
+      )
+      break
+    } catch (error) {
+      if (!isConditionalFailure(error) || attempt === 4) throw error
+    }
+  }
   if (!nextEpoch) {
     throw new Error('Failed to advance conversation epoch')
   }

--- a/chatbot-app/frontend/src/utils/historyParser.ts
+++ b/chatbot-app/frontend/src/utils/historyParser.ts
@@ -13,6 +13,7 @@ export interface ParsedMessage {
 
 export interface AgentCoreEvent {
   eventId?: string
+  eventTimestamp?: string | Date
   eventTime?: string
   payload?: Array<{
     conversational?: {
@@ -28,6 +29,13 @@ export interface ParseResult {
   success: boolean
   message?: ParsedMessage
   error?: string
+}
+
+function eventTimestampString(event: AgentCoreEvent): string {
+  const value = event.eventTimestamp ?? event.eventTime
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string') return value
+  return new Date().toISOString()
 }
 
 /**
@@ -66,7 +74,7 @@ export function parseConversationalEvent(
   const message: ParsedMessage = {
     ...parsed.message,
     id: event.eventId || `msg-${sessionId}-${msgIndex}`,
-    timestamp: event.eventTime || new Date().toISOString()
+    timestamp: eventTimestampString(event)
   }
 
   return { success: true, message }
@@ -113,7 +121,7 @@ export function parseBlobEvent(
   const message: ParsedMessage = {
     ...blobMessageData.message,
     id: event.eventId || `msg-${sessionId}-${msgIndex}`,
-    timestamp: event.eventTime || new Date().toISOString()
+    timestamp: eventTimestampString(event)
   }
 
   return { success: true, message }


### PR DESCRIPTION
## Summary
- preserve the retained message prefix when advancing a conversation epoch after cut
- track per-epoch cutoff timestamps and reject only stale suffix writes
- support AgentCore `eventTimestamp` in history, truncation, and restored model context
- surface truncate API failures to the chat UI

## Validation
- frontend type check passed
- frontend test suite: 64 files / 751 tests passed
- frontend production build passed
- AgentCore mailbox/session manager tests: 121 passed
- deployed to dev and verified ECS + AgentCore health
- live regression: 3 messages -> cut from middle -> send on new branch -> switch session -> return; retained prefix and new message both remained
- Gateway MCP handshake and orchestrator warmup passed